### PR TITLE
Fix wrong found messages from CMake files

### DIFF
--- a/cmake/FindINotify.cmake
+++ b/cmake/FindINotify.cmake
@@ -16,6 +16,6 @@ find_library(LIBINOTIFY_LIBRARY inotify)
 # all listed variables are TRUE
 # handle the QUIETLY and REQUIRED arguments and set INOTIFY_FOUND to TRUE if
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(INOTIFY DEFAULT_MSG INOTIFY_INCLUDE_DIR)
+find_package_handle_standard_args(INOTIFY DEFAULT_MSG LIBINOTIFY_LIBRARY)
 
 mark_as_advanced(INOTIFY_LIBRARY INOTIFY_INCLUDE_DIR)

--- a/cmake/FindLibMagic.cmake
+++ b/cmake/FindLibMagic.cmake
@@ -4,7 +4,7 @@ FIND_PATH(MAGIC_INCLUDE_DIR magic.h)
 FIND_LIBRARY(MAGIC_LIBRARIES NAMES magic)
 
 # handle the QUIETLY and REQUIRED arguments and set MAGIC_FOUND to TRUE
-find_package_handle_standard_args(MAGIC DEFAULT_MSG MAGIC_INCLUDE_DIR)
+find_package_handle_standard_args(MAGIC DEFAULT_MSG MAGIC_LIBRARIES)
 
 MARK_AS_ADVANCED(
     MAGIC_LIBRARIES


### PR DESCRIPTION
For libinotify and libmagic wrong lib file paths in found messsages are
echoed.

Situation before:

    -- Looking for BSD native UUID - found
    -- Found UPnP: /usr/local/gerbera/lib/libupnp-1.8.so (found version "1.8.2")
    -- Found EXPAT: /usr/local/lib/libexpat.so (found version "2.2.1")
    -- Found Sqlite3: /usr/local/lib/libsqlite3.so
    -- Found INOTIFY: /usr/local/gerbera/include
    -- Found CURL: /usr/local/lib/libcurl.so (found version "7.55.1")
    -- Found MAGIC: /usr/include
    -- Found ZLIB: /usr/lib/libz.so (found version "1.2.11")
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /home/mosipov/Projekte/gerbera/build

Situation after:

    -- Looking for BSD native UUID
    -- Looking for BSD native UUID - found
    -- Found UUID: TRUE
    -- Looking for native LFS support
    -- Looking for native LFS support - found
    -- Found LFS: TRUE
    -- Found UPnP: /usr/local/gerbera/lib/libupnp-1.8.so (found version "1.8.2")
    -- Found EXPAT: /usr/local/lib/libexpat.so (found version "2.2.1")
    -- Found Sqlite3: /usr/local/lib/libsqlite3.so
    -- Found INOTIFY: /usr/local/gerbera/lib/libinotify.so
    -- Found CURL: /usr/local/lib/libcurl.so (found version "7.55.1")
    -- Found MAGIC: /usr/lib/libmagic.so
    -- Found ZLIB: /usr/lib/libz.so (found version "1.2.11")
    -- Configuring done
    -- Generating done
    -- Build files have been written to: /home/mosipov/Projekte/gerbera/build
