### PR TITLE
Fix static linking with ffmpeg

### DIFF
--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -150,8 +150,8 @@ IF (FFMPEG_INCLUDE_DIR)
                 SET(FFMPEG_FOUND TRUE)
                 SET(FFMPEG_INCLUDE_DIRS ${FFMPEG_INCLUDE_DIR})
                 SET(FFMPEG_BASIC_LIBRARIES
-                        ${FFMPEG_avcodec_LIBRARY}
                         ${FFMPEG_avformat_LIBRARY}
+                        ${FFMPEG_avcodec_LIBRARY}
                         ${FFMPEG_avutil_LIBRARY}
                         )
 


### PR DESCRIPTION
avformat depends on avcodec so it should be added first otherwise static
linking will fail

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>