### PR TITLE
Update install-pupnp18.sh

### DIFF
--- a/scripts/install-pupnp18.sh
+++ b/scripts/install-pupnp18.sh
@@ -10,7 +10,7 @@ else
    extraFlags="--prefix=/usr"
 fi
 
-wget https://github.com/mrjimenez/pupnp/archive/release-1.8.1.tar.gz -O pupnp-1.8.1.tgz
-tar -xzvf pupnp-1.8.1.tgz
-cd pupnp-release-1.8.1
+wget https://github.com/mrjimenez/pupnp/archive/release-1.8.2.tar.gz -O pupnp-1.8.2.tgz
+tar -xzvf pupnp-1.8.2.tgz
+cd pupnp-release-1.8.2
 ./bootstrap && ./configure $extraFlags --enable-ipv6 --enable-reuseaddr && make && sudo make install


### PR DESCRIPTION
Freebsd 11.1
If you compile with pupnp-1.8.1, gerbera does not start.
##error##
Exception raised in [src/server.cc:123] upnp_init(): upnp_init: UpnpInit failed
ERROR: main: upnp error -203
ERROR: Could not bind to socket.
INFO: Please check if another instance of Gerbera or
INFO: another application is running on port 49152.
ERROR: upnp_cleanup: UpnpUnRegisterRootDevice failed
Exception raised in [src/server.cc:248] shutdown(): upnp_cleanup: UpnpUnRegisterRootDevice failed
##error#

It is necessary in the script install-pupnp18.sh to change

release-1.8.1 to release-1.8.2

####install-pupnp18.sh####
#!/bin/sh
set -ex

unamestr=uname
if [ "$unamestr" == 'FreeBSD' ]; then
extraFlags=""
elif [ "$unamestr" == 'Darwin' ]; then
extraFlags="--prefix=/usr/local"
else
extraFlags="--prefix=/usr"
fi

wget https://github.com/mrjimenez/pupnp/archive/release-1.8.2.tar.gz -O pupnp-1.8.2.tgz
tar -xzvf pupnp-1.8.2.tgz
cd pupnp-release-1.8.2
./bootstrap && ./configure $extraFlags --enable-ipv6 --enable-reuseaddr && make && sudo make install
####end####

Then everything starts.