### PR TITLE
Improve consistent toast size for error messages

### DIFF
--- a/gerbera-web/mock-api/items/oversize-error-msg.json
+++ b/gerbera-web/mock-api/items/oversize-error-msg.json
@@ -1,0 +1,6 @@
+{
+  "success": false,
+  "error": {
+    "text": "This text should take up more space than 500 px and then be wrapped and cut off by the CSS for toast error message when the error message is too big."
+  }
+}

--- a/gerbera-web/mock-api/items/tests/toast.spec.json
+++ b/gerbera-web/mock-api/items/tests/toast.spec.json
@@ -1,0 +1,14 @@
+{
+  "7443_0" : {
+    "count" : 0,
+    "responses" : {
+      "default" : "./items/parent_id-7443-start-0.json"
+    }
+  },
+  "7444_0" : {
+    "count" : 0,
+    "responses" : {
+      "default" : "./items/oversize-error-msg.json"
+    }
+  }
+}

--- a/gerbera-web/test/e2e/page/home.page.js
+++ b/gerbera-web/test/e2e/page/home.page.js
@@ -226,6 +226,12 @@ module.exports = function (driver) {
     })
   }
 
+  this.getToastElement = function () {
+    return driver.wait(until.elementIsVisible(driver.findElement(By.id('toast'))), 5000).then(function () {
+      return driver.findElement(By.id('toast'))
+    })
+  }
+
   this.waitForToastClose = function () {
     driver.wait(until.elementIsNotVisible(driver.findElement(By.id('toast'))), 6000)
     return driver.findElement(By.css('.grb-toast-msg')).isDisplayed()

--- a/gerbera-web/test/e2e/toast.spec.js
+++ b/gerbera-web/test/e2e/toast.spec.js
@@ -1,0 +1,54 @@
+var chai = require('chai')
+var expect = chai.expect
+var webdriver = require('selenium-webdriver')
+var test = require('selenium-webdriver/testing')
+var driver
+var mockWebServer = 'http://' + process.env.npm_package_config_webserver_host + ':' + process.env.npm_package_config_webserver_port
+
+require('chromedriver')
+
+var HomePage = require('./page/home.page')
+var LoginPage = require('./page/login.page')
+
+test.describe('The gerbera toast', function () {
+  var loginPage, homePage
+
+  this.slow(5000)
+  this.timeout(15000)
+
+  test.before(function () {
+    driver = new webdriver.Builder()
+      .forBrowser('chrome')
+      .build()
+
+    driver.manage().window().setSize(1280, 1024)
+    driver.get(mockWebServer + '/reset?testName=toast.spec.json')
+
+    loginPage = new LoginPage(driver)
+    homePage = new HomePage(driver)
+
+    driver.get(mockWebServer + '/disabled.html')
+    driver.manage().deleteAllCookies()
+
+    loginPage.get(mockWebServer + '/gerbera.html')
+
+    loginPage.password('pwd')
+    loginPage.username('user')
+    loginPage.submitLogin()
+  })
+
+  test.after(function () {
+    driver.quit()
+  })
+
+  test.it('shows with max-width when error message is too big', function () {
+    homePage.clickMenu('nav-db')
+    homePage.clickTree('Video')
+    homePage.clickTree('All Video')
+    homePage.getToastElement().then(function (element) {
+      element.getSize().then(function (size) {
+        expect(size.width).to.equal(500)
+      })
+    })
+  })
+})

--- a/web/assets/theme/gerbera.css
+++ b/web/assets/theme/gerbera.css
@@ -192,22 +192,32 @@ ul.pagination {
 }
 
 .grb-toast {
-    bottom: 30px;
-    min-width: 500px;
-    margin-left: -250px;
-    z-index: 1000;
-    left: 50%;
-    position: fixed;
+    bottom: 5vh;
     box-shadow: 0px 2px 5px #888888;
 }
 
 .grb-task {
     top: 15vh;
+}
+
+.grb-toast,
+.grb-task {
     min-width: 500px;
+    max-width: 500px;
     margin-left: -250px;
-    z-index: 1000;
     left: 50%;
+    z-index: 1000;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     position: fixed;
+}
+
+.grb-toast-msg {
+    width: 425px;
+    display: inline-block;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .autoscan {


### PR DESCRIPTION
When the system suffers a catastrophic error, the toast will show the entire message.  This causes elements to go off-screen and be unreadable.  This fix also applies to **tasks** which show at the top of the screen.

> There is presently no standard CSS way to easily do _multi-line_ wrapped ellipsis. (requires -webkit, etc)

### BEFORE
![gerbera-toast-big-error](https://user-images.githubusercontent.com/8599799/32760694-6aa2fc22-c8bd-11e7-9567-5f2231caad7b.png)

### AFTER
![gerbera-fixed-width-toast](https://user-images.githubusercontent.com/8599799/32760702-76981f30-c8bd-11e7-84c8-0b4e0c8b228a.png)

