### PR TITLE
Fixes #201 - Remove row on click, instead of waiting for refresh

### DIFF
--- a/gerbera-web/test/client/jquery.gerbera.items.spec.js
+++ b/gerbera-web/test/client/jquery.gerbera.items.spec.js
@@ -23,16 +23,19 @@ describe('The jQuery Datagrid', function () {
     expect($('#datagrid').find('a').get(0).href).toBe(datagridData[0].url)
   })
 
-  it('binds the delete icon click to the method provided', function () {
+  it('binds the delete icon click to the method provided and removes the row on click', function () {
     var methodSpy = jasmine.createSpy('delete')
     $('#datagrid').dataitems({
       data: datagridData,
       onDelete: methodSpy,
       itemType: 'db'
     })
+    var beforeCount = $('#datagrid').find('.grb-item').length
 
     $('#datagrid').find('.grb-item span.grb-item-delete').first().click()
 
+    var afterCount = $('#datagrid').find('.grb-item').length
+    expect(afterCount).toEqual(beforeCount - 1)
     expect(methodSpy).toHaveBeenCalled()
   })
 

--- a/web/js/jquery.gerbera.items.js
+++ b/web/js/jquery.gerbera.items.js
@@ -103,7 +103,10 @@ $.widget('grb.dataitems', {
           deleteIcon.addClass('grb-item-delete fa fa-trash-o')
           deleteIcon.appendTo(buttons)
           if (onDelete) {
-            deleteIcon.click(item, onDelete)
+            deleteIcon.click(item, function (event) {
+              row.remove();
+              onDelete(event);
+            })
           }
           buttons.appendTo(content)
         } else if (itemType === 'fs') {


### PR DESCRIPTION
A simple change to manually remove the item table row `<tr>` on click...which removes possibility of double clicking, while waiting for items to refresh from server.