### PR TITLE
Fix #205 - Add Gerbera UI tests to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
           packages:
             - nodejs
             - xvfb
+      before_install: skip
       install:
         - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web/ install $TRAVIS_BUILD_DIR/gerbera-web/
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,36 +12,49 @@ before_install:
   - ./scripts/install-pupnp18.sh
   - ./scripts/install-taglib111.sh
 
+install:
+  - if [[ "$RUN_UI_TESTS" == "true" ]]; then npm --prefix $TRAVIS_BUILD_DIR/gerbera-web/ install $TRAVIS_BUILD_DIR/gerbera-web/; fi
+
+before_script:
+  - if [[ "$RUN_UI_TESTS" == "true" ]]; then export DISPLAY=:99.0; fi
+  - if [[ "$RUN_UI_TESTS" == "true" ]]; then sh -e /etc/init.d/xvfb start; fi
+  - if [[ "$RUN_UI_TESTS" == "true" ]]; then sleep 3; fi # give xvfb some time to start
+
 # Build
 script:
   - mkdir build
   - cd build
   - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DWITH_SYSTEMD=0 .. && make
+  - if [[ "$RUN_UI_TESTS" == "true" ]]; then npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run test; fi
+  - if [[ "$RUN_UI_TESTS" == "true" ]]; then npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run test:e2e; fi
 
 matrix:
   include:
-    - env: CXX=g++-4.9 CC=gcc-4.9
+    - env: CXX=g++-4.9 CC=gcc-4.9 RUN_UI_TESTS=false
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-    - env: CXX=g++-5 CC=gcc-5
+    - env: CXX=g++-5 CC=gcc-5 RUN_UI_TESTS=false
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-    - env: CXX=g++-6 CC=gcc-6
+    - env: CXX=g++-6 CC=gcc-6 RUN_UI_TESTS=true
       addons:
+        chrome: stable
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-6
-    - env: CXX=clang++-4.0 CC=clang-4.0
+            - nodejs
+            - xvfb
+    - env: CXX=clang++-4.0 CC=clang-4.0 RUN_UI_TESTS=false
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Bash is a minimal toolchain
-language: bash
+language: none
 
 # Ubuntu 14.04 Trusty support
 sudo: required
@@ -60,7 +60,6 @@ matrix:
           packages:
             - nodejs
             - xvfb
-      before_install: skip
       install:
         - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web/ install $TRAVIS_BUILD_DIR/gerbera-web/
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
-# None as otherwise it clobbers our compiler choce
-language: none
+# Bash is a minimal toolchain
+language: bash
 
 # Ubuntu 14.04 Trusty support
 sudo: required
 dist: trusty
+
+# The default build
+env: CXX=g++-6 CC=gcc-6
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-6
 
 before_install:
   - sudo apt-get update -qq
@@ -12,49 +21,30 @@ before_install:
   - ./scripts/install-pupnp18.sh
   - ./scripts/install-taglib111.sh
 
-install:
-  - if [[ "$RUN_UI_TESTS" == "true" ]]; then npm --prefix $TRAVIS_BUILD_DIR/gerbera-web/ install $TRAVIS_BUILD_DIR/gerbera-web/; fi
-
-before_script:
-  - if [[ "$RUN_UI_TESTS" == "true" ]]; then export DISPLAY=:99.0; fi
-  - if [[ "$RUN_UI_TESTS" == "true" ]]; then sh -e /etc/init.d/xvfb start; fi
-  - if [[ "$RUN_UI_TESTS" == "true" ]]; then sleep 3; fi # give xvfb some time to start
-
 # Build
 script:
   - mkdir build
   - cd build
   - cmake -DCMAKE_VERBOSE_MAKEFILE=ON -DWITH_SYSTEMD=0 .. && make
-  - if [[ "$RUN_UI_TESTS" == "true" ]]; then npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run test; fi
-  - if [[ "$RUN_UI_TESTS" == "true" ]]; then npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run test:e2e; fi
 
 matrix:
   include:
-    - env: CXX=g++-4.9 CC=gcc-4.9 RUN_UI_TESTS=false
+    - stage: Build Gerbera
+    - env: CXX=g++-4.9 CC=gcc-4.9
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-    - env: CXX=g++-5 CC=gcc-5 RUN_UI_TESTS=false
+    - env: CXX=g++-5 CC=gcc-5
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-    - env: CXX=g++-6 CC=gcc-6 RUN_UI_TESTS=true
-      addons:
-        chrome: stable
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-            - nodejs
-            - xvfb
-    - env: CXX=clang++-4.0 CC=clang-4.0 RUN_UI_TESTS=false
+    - env: CXX=clang++-4.0 CC=clang-4.0
       addons:
         apt:
           sources:
@@ -63,3 +53,20 @@ matrix:
           packages:
             - libc++-dev
             - clang-4.0
+    - stage: Test Gerbera UI
+      addons:
+        chrome: stable
+        apt:
+          packages:
+            - nodejs
+            - xvfb
+      install:
+        - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web/ install $TRAVIS_BUILD_DIR/gerbera-web/
+      before_script:
+        - export DISPLAY=:99.0
+        - sh -e /etc/init.d/xvfb start
+        - sleep 3 # give xvfb some time to start
+      script:
+        - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run lint
+        - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run test
+        - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run test:e2e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Bash is a minimal toolchain
+# None as otherwise it clobbers our compiler choce
 language: none
 
 # Ubuntu 14.04 Trusty support

--- a/gerbera-web/test/e2e/toast.spec.js
+++ b/gerbera-web/test/e2e/toast.spec.js
@@ -47,7 +47,7 @@ test.describe('The gerbera toast', function () {
     homePage.clickTree('All Video')
     homePage.getToastElement().then(function (element) {
       element.getSize().then(function (size) {
-        expect(size.width).to.equal(1270)
+        expect(size.width).to.equal(1280)
       })
     })
   })


### PR DESCRIPTION
### Gerbera UI Tests in Travis CI
Add environment variable which decides whether to run Gerbera UI tests, including Karma client-side tests and Selenium e2e tests.

1. Install NodeJS and Google Chrome dependencies using `apt`
2. Run `npm install` to download all dependencies from default registry **(npmjs.com)**
3. Run `npm run test` for a single matrix'd build
4. Run `npm run test:e2e` for a single matrix'd build

### Karma Tests
The client-side unit tests run using the [PhantomJS](http://phantomjs.org/) webkit headless browser.  These tests are fully isolated from a gerbera runtime server.

### Selenium Tests
The end-to-end tests run using a **mock server** which mimics the API expected from a server runtime.  The mock server runs using [express-js](https://expressjs.com/) and does not rely on a gerbera server runtime.  

The selenium tests require **xvfb** and **google-chrome** to mimic opening a GUI browser, but in a headless way.

The e2e tests are inherently brittle, these tests have reached a consistent/stable state.

### Disable UI Tests

If instability occurs in the `gcc-6` matrix build, we can disable the UI tests by setting the boolean 

```yml
- env: CXX=g++-6 CC=gcc-6 RUN_UI_TESTS=false
```