### PR TITLE
Allow the subquery LIMIT to be disabled by -DMAX_ART_CONTAINERS=0

### DIFF
--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -1214,7 +1214,9 @@ String SQLStorage::incrementUpdateIDs(shared_ptr<unordered_set<int>> ids)
 
 // id is the parent_id for cover media to find, and if set, trackArtBase is the case-folded
 // name of the track to try as artwork; we rely on LIKE being case-insensitive
+#ifndef MAX_ART_CONTAINERS
 #define MAX_ART_CONTAINERS 100
+#endif
 String SQLStorage::findFolderImage(int id, String trackArtBase)
 {
     Ref<StringBuffer> q(new StringBuffer());
@@ -1245,7 +1247,12 @@ String SQLStorage::findFolderImage(int id, String trackArtBase)
     *q << "SELECT " << TQ("ref_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
     *q << TQ("parent_id") << '=' << quote(String::from(id)) << " AND ";
     *q << TQ("object_type") << '=' << quote(OBJECT_TYPE_ITEM);
+    // some db's apparently don't support LIMIT in subqueries, so allow this to be disabled; beware performance
+#if (MAX_ART_CONTAINERS > 0)
     *q <<               " LIMIT " << MAX_ART_CONTAINERS << ")";
+#else
+    *q <<               ")";
+#endif
     *q <<       ")";
     *q << "     ) OR ";
 #endif


### PR DESCRIPTION
This should allow #238 to be addressed by appropriate cmake shenanigans