### PR TITLE
#227 Pass rootpath to import.js on Inotify event

### DIFF
--- a/src/autoscan_inotify.cc
+++ b/src/autoscan_inotify.cc
@@ -240,7 +240,7 @@ void AutoscanInotify::threadProc()
                     if (mask & (IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE)) {
                         log_debug("adding %s\n", path.c_str());
                         // path, recursive, async, hidden, low priority, cancellable
-                        cm->addFile(fullPath, adir->getRecursive(), true, adir->getHidden(), true, false);
+                        cm->addFile(fullPath, adir->getLocation(), adir->getRecursive(), true, adir->getHidden(), true, false);
 
                         if (mask & IN_ISDIR)
                             monitorUnmonitorRecursive(path, false, adir, watchAs->getNormalizedAutoscanPath(), false);

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -1,29 +1,29 @@
 /*MT*
-    
+
     MediaTomb - http://www.mediatomb.cc/
-    
+
     content_manager.cc - this file is part of MediaTomb.
-    
+
     Copyright (C) 2005 Gena Batyan <bgeradz@mediatomb.cc>,
                        Sergey 'Jin' Bostandzhyan <jin@mediatomb.cc>
-    
+
     Copyright (C) 2006-2010 Gena Batyan <bgeradz@mediatomb.cc>,
                             Sergey 'Jin' Bostandzhyan <jin@mediatomb.cc>,
                             Leonhard Wimmer <leo@mediatomb.cc>
-    
+
     MediaTomb is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License version 2
     as published by the Free Software Foundation.
-    
+
     MediaTomb is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
     GNU General Public License for more details.
-    
+
     You should have received a copy of the GNU General Public License
     version 2 along with MediaTomb; if not, write to the Free Software
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
-    
+
     $Id$
 */
 
@@ -1147,7 +1147,7 @@ Ref<CdsObject> ContentManager::createObjectFromFile(String path, bool magic, boo
          * this exists only to inform the caller that
          * this is a container
          */
-        /* 
+        /*
         cont->setLocation(path);
         Ref<StringConverter> f2i = StringConverter::f2i();
         obj->setTitle(f2i->convert(filename));
@@ -1310,6 +1310,14 @@ int ContentManager::addFile(zmm::String path, bool recursive, bool async,
     bool hidden, bool lowPriority, bool cancellable)
 {
     String rootpath;
+    if (check_path(path, true))
+        rootpath = path;
+    return addFileInternal(path, rootpath, recursive, async, hidden, lowPriority, 0, cancellable);
+}
+
+int ContentManager::addFile(zmm::String path, zmm::String rootpath, bool recursive, bool async,
+    bool hidden, bool lowPriority, bool cancellable)
+{
     if (check_path(path, true))
         rootpath = path;
     return addFileInternal(path, rootpath, recursive, async, hidden, lowPriority, 0, cancellable);

--- a/src/content_manager.h
+++ b/src/content_manager.h
@@ -201,6 +201,18 @@ public:
                 bool hidden=false, bool lowPriority=false, 
                 bool cancellable=true);
 
+    /// \brief Adds a file or directory to the database.
+    /// \param path absolute path to the file
+    /// \param rootpath absolute path to the container root
+    /// \param recursive recursive add (process subdirecotories)
+    /// \param async queue task or perform a blocking call
+    /// \param hidden true allows to import hidden files, false ignores them
+    /// \param queue for immediate processing or in normal order
+    /// \return object ID of the added file - only in blockign mode, when used in async mode this function will return INVALID_OBJECT_ID
+    int addFile(zmm::String path, zmm::String rootpath, bool recursive=true, bool async=true,
+                bool hidden=false, bool lowPriority=false,
+                bool cancellable=true);
+
     int ensurePathExistence(zmm::String path);
     void removeObject(int objectID, bool async=true, bool all=false);
     void rescanDirectory(int objectID, int scanID, ScanMode scanMode,


### PR DESCRIPTION
Dear gerbera maintainers,

I added an overload to the ContentManager::addFile method, allowing for passing a container's root path as additional parameter. Using this method from within the event handling code in AutoscanInotify::threadProc should fix the problem of undefined object_script_path values in import.js as described in https://github.com/gerbera/gerbera/issues/227.

Cheers --

Torsten
