### PR TITLE
Replace zmm::StringBuffer with std::ostringstream

### DIFF
--- a/cmake/FindTaglib.cmake
+++ b/cmake/FindTaglib.cmake
@@ -19,9 +19,9 @@ ELSE()
 	endif(NOT TAGLIB_MIN_VERSION)
 
 	if(NOT WIN32)
-		find_program(TAGLIBCONFIG_EXECUTABLE NAMES taglib-config PATHS
+            find_program(TAGLIBCONFIG_EXECUTABLE NAMES taglib-config PATHS
 		   ${BIN_INSTALL_DIR}
-		)
+            )
 	endif(NOT WIN32)
 
 	#reset vars

--- a/scripts/install-duktape.sh
+++ b/scripts/install-duktape.sh
@@ -7,9 +7,9 @@ if [ "$unamestr" == 'FreeBSD' ]; then
    makeCMD="gmake"
 fi
 
-wget http://duktape.org/duktape-2.1.0.tar.xz
-tar -xJvf duktape-2.1.0.tar.xz
-cd duktape-2.1.0
+wget http://duktape.org/duktape-2.2.0.tar.xz
+tar -xJvf duktape-2.2.0.tar.xz
+cd duktape-2.2.0
 
 if [ "$unamestr" == 'Darwin' ]; then
   # Patch Makefile to install on macOS

--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -113,6 +113,6 @@ void ActionRequest::update()
             UpnpActionRequest_set_ErrCode(upnp_request, UPNP_E_ACTION_FAILED);
         }
         
-        log_error("ActionRequest::update(): response is nullptr, code %d\n", errCode);
+        log_error("ActionRequest::update(): response is nullptr, code %d for %s\n", errCode, actionName.c_str());
     }
 }

--- a/src/atrailers_service.cc
+++ b/src/atrailers_service.cc
@@ -40,6 +40,8 @@
 #include "config_options.h"
 #include "server.h"
 
+#include <string>
+
 using namespace zmm;
 using namespace mxml;
 
@@ -88,7 +90,7 @@ Ref<Element> ATrailersService::getData()
     long retcode;
     Ref<StringConverter> sc = StringConverter::i2i();
 
-    Ref<StringBuffer> buffer;
+    std::string buffer;
     
     try 
     {
@@ -103,17 +105,17 @@ Ref<Element> ATrailersService::getData()
         return nullptr;
     }
 
-    if (buffer == nullptr)
+    if (buffer.empty())
         return nullptr;
 
     if (retcode != 200)
         return nullptr;
 
-    log_debug("GOT BUFFER\n%s\n", buffer->toString().c_str()); 
+    log_debug("GOT BUFFER\n%s\n", buffer.c_str());
     Ref<Parser> parser(new Parser());
     try
     {
-        return parser->parseString(sc->convert(buffer->toString()))->getRoot();
+        return parser->parseString(sc->convert(buffer))->getRoot();
     }
     catch (const ParseException & pe)
     {
@@ -182,11 +184,11 @@ bool ATrailersService::refreshServiceData(Ref<Layout> layout)
             log_debug("Updating existing Trailers object\n");
             obj->setID(old->getID());
             obj->setParentID(old->getParentID());
-            struct timespec oldt, newt;
-            oldt.tv_nsec = 0;
-            oldt.tv_sec = old->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
-            newt.tv_nsec = 0;
-            newt.tv_sec = obj->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
+//            struct timespec oldt, newt;
+//            oldt.tv_nsec = 0;
+//            oldt.tv_sec = old->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
+//            newt.tv_nsec = 0;
+//            newt.tv_sec = obj->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
             ContentManager::getInstance()->updateObject(obj);
         }
 

--- a/src/autoscan_inotify.cc
+++ b/src/autoscan_inotify.cc
@@ -763,8 +763,7 @@ void AutoscanInotify::removeDescendants(int wd)
         watch = wdWatches->get(i);
         if (watch->getType() == WatchType::Autoscan) {
             watchAs = RefCast(watch, WatchAutoscan);
-            auto descendants = watchAs->getDescendants();
-            for (int descWd : descendants) {
+            for (int descWd : watchAs->getDescendants()) {
                 inotify->removeWatch(descWd);
             }
         }

--- a/src/autoscan_inotify.cc
+++ b/src/autoscan_inotify.cc
@@ -96,8 +96,6 @@ void AutoscanInotify::threadProc()
 
     inotify_event* event;
 
-    Ref<StringBuffer> pathBuf(new StringBuffer());
-
     try {
         cm = ContentManager::getInstance();
         st = Storage::getInstance();
@@ -173,11 +171,11 @@ void AutoscanInotify::threadProc()
                     continue;
                 }
 
-                pathBuf->clear();
-                *pathBuf << wdObj->getPath();
+                std::ostringstream pathBuf;
+                pathBuf << wdObj->getPath();
                 if (!(mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT)))
-                    *pathBuf << name;
-                String path = pathBuf->toString();
+                    pathBuf << name;
+                String path(pathBuf.str());
 
                 Ref<AutoscanDirectory> adir;
                 Ref<WatchAutoscan> watchAs = getAppropriateAutoscan(wdObj, path);
@@ -282,15 +280,15 @@ void AutoscanInotify::unmonitor(zmm::Ref<AutoscanDirectory> dir)
 int AutoscanInotify::watchPathForMoves(String path, int wd)
 {
     Ref<Array<StringBase>> pathAr = split_string(path, DIR_SEPARATOR);
-    Ref<StringBuffer> buf(new StringBuffer());
+    std::ostringstream buf;
     int parentWd = INOTIFY_ROOT;
     for (int i = -1; i < pathAr->size() - 1; i++) {
         if (i != 0)
-            *buf << DIR_SEPARATOR;
+            buf << DIR_SEPARATOR;
         if (i >= 0)
-            *buf << pathAr->get(i);
-        log_debug("adding move watch: %s\n", buf->c_str());
-        parentWd = addMoveWatch(buf->toString(), wd, parentWd);
+            buf << pathAr->get(i);
+        log_debug("adding move watch: %s\n", buf.str().c_str());
+        parentWd = addMoveWatch(buf.str(), wd, parentWd);
     }
     return parentWd;
 }
@@ -340,25 +338,24 @@ void AutoscanInotify::monitorNonexisting(String path, Ref<AutoscanDirectory> adi
 
 void AutoscanInotify::recheckNonexistingMonitor(int curWd, Ref<Array<StringBase>> pathAr, Ref<AutoscanDirectory> adir, String normalizedAutoscanPath)
 {
-    Ref<StringBuffer> buf(new StringBuffer());
     bool first = true;
     for (int i = pathAr->size(); i >= 0; i--) {
-        buf->clear();
+        std::ostringstream buf;
         if (i == 0)
-            *buf << DIR_SEPARATOR;
+            buf << DIR_SEPARATOR;
         else {
             for (int j = 0; j < i; j++) {
-                *buf << DIR_SEPARATOR << pathAr->get(j);
+                buf << DIR_SEPARATOR << pathAr->get(j);
                 //                log_debug("adding: %s\n", pathAr->get(j)->data);
             }
         }
-        bool pathExists = check_path(buf->toString(), true);
+        bool pathExists = check_path(buf.str(), true);
         //        log_debug("checking %s: %d\n", buf->c_str(), pathExists);
         if (pathExists) {
             if (curWd != -1)
                 removeNonexistingMonitor(curWd, watches->at(curWd), pathAr);
 
-            String path = buf->toString() + DIR_SEPARATOR;
+            String path = buf.str() + DIR_SEPARATOR;
             if (first) {
                 monitorDirectory(path, adir, normalizedAutoscanPath, true);
                 ContentManager::getInstance()->handlePersistentAutoscanRecreate(adir->getScanID(), adir->getScanMode());

--- a/src/autoscan_inotify.h
+++ b/src/autoscan_inotify.h
@@ -108,12 +108,10 @@ private:
         bool isStartPoint() { return startPoint; }
         zmm::Ref<zmm::Array<zmm::StringBase>> getNonexistingPathArray() { return nonexistingPathArray; }
         void setNonexistingPathArray(zmm::Ref<zmm::Array<zmm::StringBase>> nonexistingPathArray) { this->nonexistingPathArray = nonexistingPathArray; }
-        void addDescendant(int wd)
-        {
+        void addDescendant(int wd) {
             descendants.push_back(wd);
         }
-        const std::vector<int>& getDescendants() { return descendants; }
-
+        const std::vector<int>& getDescendants() const { return descendants; }
     private:
         zmm::Ref<AutoscanDirectory> adir;
         bool startPoint;

--- a/src/cds_resource.cc
+++ b/src/cds_resource.cc
@@ -32,6 +32,8 @@
 #include "tools.h"
 #include "cds_resource.h"
 
+#include <sstream>
+
 #define RESOURCE_PART_SEP '~'
 
 using namespace zmm;
@@ -136,15 +138,15 @@ Ref<CdsResource> CdsResource::clone()
 String CdsResource::encode()
 {
     // encode resources
-    Ref<StringBuffer> buf(new StringBuffer());
-    *buf << handlerType;
-    *buf << RESOURCE_PART_SEP;
-    *buf << attributes->encode();
-    *buf << RESOURCE_PART_SEP;
-    *buf << parameters->encode();
-    *buf << RESOURCE_PART_SEP;
-    *buf << options->encode();
-    return buf->toString();
+    std::ostringstream buf;
+    buf << handlerType;
+    buf << RESOURCE_PART_SEP;
+    buf << attributes->encode();
+    buf << RESOURCE_PART_SEP;
+    buf << parameters->encode();
+    buf << RESOURCE_PART_SEP;
+    buf << options->encode();
+    return buf.str().c_str();
 }
 
 Ref<CdsResource> CdsResource::decode(String serial)

--- a/src/dictionary.cc
+++ b/src/dictionary.cc
@@ -32,6 +32,7 @@
 #include "dictionary.h"
 
 #include <cstring>
+#include <sstream>
 #include "tools.h"
 
 using namespace zmm;
@@ -117,17 +118,17 @@ void Dictionary::remove(String key)
 
 String Dictionary::_encode(char sep1, char sep2)
 {
-    Ref<StringBuffer> buf(new StringBuffer());
+    std::ostringstream buf;
     int len = elements->size();
     for (int i = 0; i < len; i++)
     {
         if(i > 0)
-            *buf << sep1;
+            buf << sep1;
         Ref<DictionaryElement> el = elements->get(i);
-        *buf << url_escape(el->getKey()) << sep2
+        buf << url_escape(el->getKey()) << sep2
              << url_escape(el->getValue());
     }
-    return buf->toString();
+    return buf.str();
 }
 
 String Dictionary::encode()

--- a/src/mxml/comment.cc
+++ b/src/mxml/comment.cc
@@ -42,7 +42,6 @@ Comment::Comment(String text, bool indentWithLFbefore) : Node()
     this->indentWithLFbefore = indentWithLFbefore;
 }
 
-void Comment::print_internal(Ref<StringBuffer> buf, int indent)
-{
-    *buf << "<!--" << text << "-->";
+void Comment::print_internal(std::ostringstream &buf, int indent) {
+    buf << "<!--" << text << "-->";
 }

--- a/src/mxml/comment.h
+++ b/src/mxml/comment.h
@@ -57,7 +57,7 @@ public:
     inline void setIndentWithLFbefore(bool indentWithLFbefore) { this->indentWithLFbefore = indentWithLFbefore; }
 
 protected:
-    virtual void print_internal(zmm::Ref<zmm::StringBuffer> buf, int indent);
+    virtual void print_internal(std::ostringstream &buf, int indent);
 };
 
 } // namespace

--- a/src/mxml/document.cc
+++ b/src/mxml/document.cc
@@ -59,12 +59,9 @@ void Document::appendChild(Ref<Node> child)
     children->append(child);
 }
 
-void Document::print_internal(Ref<StringBuffer> buf, int indent)
-{
-    if (children != nullptr && children->size())
-    {
-        for(int i = 0; i < children->size(); i++)
-        {
+void Document::print_internal(std::ostringstream &buf, int indent) {
+    if (children != nullptr && children->size()) {
+        for(int i = 0; i < children->size(); i++) {
             children->get(i)->print_internal(buf, indent + 1);
         }
     }

--- a/src/mxml/document.h
+++ b/src/mxml/document.h
@@ -54,7 +54,7 @@ public:
     void appendChild(zmm::Ref<Node> child);
     
 protected:
-    virtual void print_internal(zmm::Ref<zmm::StringBuffer> buf, int indent);
+    void print_internal(std::ostringstream &buf, int indent) override;
 };
 
 } // namespace

--- a/src/mxml/element.cc
+++ b/src/mxml/element.cc
@@ -34,6 +34,8 @@
 #include "element.h"
 #include "tools.h"
 
+#include <sstream>
+
 using namespace zmm;
 using namespace mxml;
 
@@ -280,17 +282,17 @@ void Element::indent(int level)
 
 String Element::getText()
 {
-    Ref<StringBuffer> buf(new StringBuffer());
+    std::ostringstream buf;
     Ref<Text> text;
     int i = 0;
     bool someText = false;
     while ((text = RefCast(getChild(i++, mxml_node_text), Text)) != nullptr)
     {
         someText = true;
-        *buf << text->getText();
+        buf << text->getText();
     }
     if (someText)
-        return buf->toString();
+        return buf.str();
     else
         return nullptr;
 }
@@ -410,41 +412,25 @@ String Element::getChildText(String name)
     return el->getText();
 }
 
-void Element::print_internal(Ref<StringBuffer> buf, int indent)
-{
-    /*
-    static char *ind_str = "                                                               ";
-    static char *ind = ind_str + strlen(ind_str);
-    char *ptr = ind - indent * 2;
-    *buf << ptr;
-    */
-    
-    int i;
-    
-    *buf << "<" << name;
-    if (attributes != nullptr)
-    {
-        for(i = 0; i < attributes->size(); i++)
-        {
-            *buf << ' ';
+void Element::print_internal(std::ostringstream &buf, int indent) {
+    buf << "<" << name;
+    if (attributes != nullptr) {
+        for(int i = 0; i < attributes->size(); i++) {
+            buf << ' ';
             Ref<Attribute> attr = attributes->get(i);
-            *buf << attr->name << "=\"" << escape(attr->value) << '"';
+            buf << attr->name << "=\"" << escape(attr->value) << '"';
         }
     }
     
-    if (children != nullptr && children->size())
-    {
-        *buf << ">";
+    if (children != nullptr && children->size()) {
+        buf << ">";
         
-        for(i = 0; i < children->size(); i++)
-        {
+        for(int i = 0; i < children->size(); i++) {
             children->get(i)->print_internal(buf, indent + 1);
         }
         
-        *buf << "</" << name << ">";
-    }
-    else
-    {
-        *buf << "/>";
+        buf << "</" << name << ">";
+    } else {
+        buf << "/>";
     }
 }

--- a/src/mxml/element.h
+++ b/src/mxml/element.h
@@ -102,7 +102,7 @@ public:
     void setTextKey(zmm::String textKey) { this->textKey = textKey; }
     
 protected:
-    virtual void print_internal(zmm::Ref<zmm::StringBuffer> buf, int indent);
+    void print_internal(std::ostringstream &buf, int indent) override;
     
     friend class Parser;
 };

--- a/src/mxml/node.cc
+++ b/src/mxml/node.cc
@@ -38,38 +38,38 @@ using namespace mxml;
 
 String Node::print()
 {
-    Ref<StringBuffer> buf(new StringBuffer());
+    std::ostringstream buf;
     print_internal(buf, 0);
-    return buf->toString();
+    return buf.str();
 }
 
 String Node::escape(String str)
 {
-    Ref<StringBuffer> buf(new StringBuffer(str.length()));
+    std::ostringstream buf;
     auto *ptr = (signed char *)str.c_str();
     while (ptr && *ptr)
     {
         switch (*ptr)
         {
-            case '<' : *buf << "&lt;"; break;
-            case '>' : *buf << "&gt;"; break;
-            case '&' : *buf << "&amp;"; break;
-            case '"' : *buf << "&quot;"; break;
-            case '\'' : *buf << "&apos;"; break;
+            case '<' : buf << "&lt;"; break;
+            case '>' : buf << "&gt;"; break;
+            case '&' : buf << "&amp;"; break;
+            case '"' : buf << "&quot;"; break;
+            case '\'' : buf << "&apos;"; break;
                        // handle control codes
             default  : if (((*ptr >= 0x00) && (*ptr <= 0x1f) && 
                             (*ptr != 0x09) && (*ptr != 0x0d) && 
                             (*ptr != 0x0a)) || (*ptr == 0x7f))
                        {
-                           *buf << '.';
+                           buf << '.';
                        }
                        else
-                           *buf << *ptr;
+                           buf << *ptr;
                        break;
         }
         ptr++;
     }
-    return buf->toString();
+    return buf.str();
 }
 
 /*

--- a/src/mxml/node.h
+++ b/src/mxml/node.h
@@ -60,7 +60,7 @@ public:
     enum mxml_node_types getType() { return type; }
     virtual zmm::String print();
 
-    virtual void print_internal(zmm::Ref<zmm::StringBuffer> buf, int indent) = 0;
+    virtual void print_internal(std::ostringstream &buf, int indent) = 0;
 protected:
     static zmm::String escape(zmm::String str);
 };

--- a/src/mxml/xml_text.cc
+++ b/src/mxml/xml_text.cc
@@ -49,7 +49,6 @@ Text::Text(String text, enum mxml_value_type vtype) : Node()
     this->vtype = vtype;
 }
 
-void Text::print_internal(Ref<StringBuffer> buf, int indent)
-{
-    *buf << escape(text);
+void Text::print_internal(std::ostringstream &buf, int indent) {
+    buf << escape(text);
 }

--- a/src/mxml/xml_text.h
+++ b/src/mxml/xml_text.h
@@ -56,7 +56,7 @@ public:
     inline void setVType(enum mxml_value_type vtype) { this->vtype = vtype; }
 
 protected:
-    virtual void print_internal(zmm::Ref<zmm::StringBuffer> buf, int indent);
+    void print_internal(std::ostringstream &buf, int indent) override;
 };
 
 } // namespace

--- a/src/mxml/xml_to_json.cc
+++ b/src/mxml/xml_to_json.cc
@@ -39,15 +39,15 @@ using namespace mxml;
 
 String XML2JSON::getJSON(Ref<Element> root)
 {
-    Ref<StringBuffer> buf(new StringBuffer());
-    *buf << '{';
+    std::ostringstream buf;
+    buf << '{';
     handleElement(buf, root);
-    *buf << '}';
-    return buf->toString();
+    buf << '}';
+    return buf.str();
 }
 
 
-void XML2JSON::handleElement(Ref<StringBuffer> buf, Ref<Element> el)
+void XML2JSON::handleElement(std::ostringstream &buf, Ref<Element> el)
 {
     bool firstChild = true;
     int attributeCount = el->attributeCount();
@@ -57,10 +57,10 @@ void XML2JSON::handleElement(Ref<StringBuffer> buf, Ref<Element> el)
         {
             Ref<Attribute> at = el->getAttribute(i);
             if (! firstChild)
-                *buf << ',';
+                buf << ',';
             else
                 firstChild = false;
-            *buf << '"' << escape(at->name, '\\', '"') << "\":" << getValue(at->value, at->getVType());
+            buf << '"' << escape(at->name, '\\', '"') << "\":" << getValue(at->value, at->getVType());
         }
     }
     
@@ -74,9 +74,9 @@ void XML2JSON::handleElement(Ref<StringBuffer> buf, Ref<Element> el)
             throw _Exception(_("XML2JSON: Element ") + el->getName() + " was of arrayType, but had no arrayName set");
         
         if (! firstChild)
-            *buf << ',';
-        *buf << '"' << escape(nodeName, '\\', '"') << "\":";
-        *buf << '[';
+            buf << ',';
+        buf << '"' << escape(nodeName, '\\', '"') << "\":";
+        buf << '[';
         firstChild = true;
     }
     
@@ -91,7 +91,7 @@ void XML2JSON::handleElement(Ref<StringBuffer> buf, Ref<Element> el)
             if (childCount == 1 && type == mxml_node_text)
             {
                 if (! firstChild)
-                    *buf << ',';
+                    buf << ',';
                 else
                     firstChild = false;
                 String key = el->getTextKey();
@@ -99,7 +99,7 @@ void XML2JSON::handleElement(Ref<StringBuffer> buf, Ref<Element> el)
                     throw _Exception(_("XML2JSON: Element ") + el->getName() + " had a text child, but had no textKey set");
                     //key = _("value");
                 
-                *buf << '"' << key << "\":" << getValue(el->getText(), el->getVTypeText());
+                buf << '"' << key << "\":" << getValue(el->getText(), el->getVTypeText());
             }
             else
                 throw _Exception(_("XML2JSON cannot handle an element which consists of text AND element children - element: ") + el->getName() + "; has type: " + type);
@@ -107,7 +107,7 @@ void XML2JSON::handleElement(Ref<StringBuffer> buf, Ref<Element> el)
         else
         {
             if (! firstChild)
-                *buf << ',';
+                buf << ',';
             else
                 firstChild = false;
             
@@ -149,23 +149,23 @@ void XML2JSON::handleElement(Ref<StringBuffer> buf, Ref<Element> el)
                     throw _Exception(_("XML2JSON: if an element is of arrayType, all children have to have the same name"));
             }
             else
-                *buf << '"' << escape(childEl->getName(), '\\', '"') << "\":";
+                buf << '"' << escape(childEl->getName(), '\\', '"') << "\":";
             
             if (childAttributeCount > 0 || childElementCount > 0 || childEl->isArrayType())
             {
-                *buf << '{';
+                buf << '{';
                 handleElement(buf, childEl);
-                *buf << '}';
+                buf << '}';
             }
             else
             {
-                *buf << getValue(childEl->getText(), childEl->getVTypeText());
+                buf << getValue(childEl->getText(), childEl->getVTypeText());
             }
         }
     }
     
     if (array)
-        *buf << ']';
+        buf << ']';
     
 }
 

--- a/src/mxml/xml_to_json.h
+++ b/src/mxml/xml_to_json.h
@@ -42,7 +42,7 @@ namespace mxml
 class XML2JSON : public zmm::Object
 {
 protected:
-    static void handleElement(zmm::Ref<zmm::StringBuffer> buf, zmm::Ref<Element> el);
+    static void handleElement(std::ostringstream &buf, zmm::Ref<Element> el);
     static zmm::String getValue(zmm::String text, enum mxml_value_type type);
 public:
     static zmm::String getJSON(zmm::Ref<Element> root);

--- a/src/process.cc
+++ b/src/process.cc
@@ -110,7 +110,7 @@ String run_simple_process(String prog, String param, String input)
         throw _Exception(_("Failed to open output file ")+output_file +_(" ") + 
                 strerror(errno));
     }
-    Ref<StringBuffer> output(new StringBuffer());
+    std::ostringstream output;
 
     int bytesRead;
     char buf[BUF_SIZE];
@@ -118,7 +118,7 @@ String run_simple_process(String prog, String param, String input)
     {
         bytesRead = fread(buf, 1, BUF_SIZE, file);
         if(bytesRead > 0)
-            *output << String(buf, bytesRead);
+            output << std::string(buf, bytesRead);
         else
             break;
     }
@@ -128,7 +128,7 @@ String run_simple_process(String prog, String param, String input)
     unlink(input_file.c_str());
     unlink(output_file.c_str());
 
-    return output->toString();
+    return output.str();
 }
 
 

--- a/src/sopcast_service.cc
+++ b/src/sopcast_service.cc
@@ -79,7 +79,7 @@ Ref<Element> SopCastService::getData()
     long retcode;
     Ref<StringConverter> sc = StringConverter::i2i();
 
-    Ref<StringBuffer> buffer;
+    std::string buffer;
     
     try 
     {
@@ -95,17 +95,17 @@ Ref<Element> SopCastService::getData()
         return nullptr;
     }
 
-    if (buffer == nullptr)
+    if (buffer.empty())
         return nullptr;
 
     if (retcode != 200)
         return nullptr;
 
-    log_debug("GOT BUFFER\n%s\n", buffer->toString().c_str()); 
+    log_debug("GOT BUFFER\n%s\n", buffer.c_str());
     Ref<Parser> parser(new Parser());
     try
     {
-        return parser->parseString(sc->convert(buffer->toString()))->getRoot();
+        return parser->parseString(sc->convert(String(buffer.c_str())))->getRoot();
     }
     catch (const ParseException & pe)
     {
@@ -175,11 +175,11 @@ bool SopCastService::refreshServiceData(Ref<Layout> layout)
             log_debug("Updating existing SopCast object\n");
             obj->setID(old->getID());
             obj->setParentID(old->getParentID());
-            struct timespec oldt, newt;
-            oldt.tv_nsec = 0;
-            oldt.tv_sec = old->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
-            newt.tv_nsec = 0;
-            newt.tv_sec = obj->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
+//            struct timespec oldt, newt;
+//            oldt.tv_nsec = 0;
+//            oldt.tv_sec = old->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
+//            newt.tv_nsec = 0;
+//            newt.tv_sec = obj->getAuxData(_(ONLINE_SERVICE_LAST_UPDATE)).toLong();
             ContentManager::getInstance()->updateObject(obj);
         }
 

--- a/src/storage/mysql/mysql_storage.h
+++ b/src/storage/mysql/mysql_storage.h
@@ -38,6 +38,8 @@
 #include "storage/sql_storage.h"
 #include <mutex>
 #include <mysql.h>
+#include <string>
+#include <vector>
 
 class MysqlStorage : private SQLStorage {
 private:
@@ -78,8 +80,8 @@ private:
 
     void checkMysqlThreadInit();
 
-    zmm::Ref<zmm::Array<zmm::StringBase>> insertBuffer;
-    virtual void _addToInsertBuffer(zmm::Ref<zmm::StringBuffer> query);
+    std::vector<std::string> insertBuffer;
+    void _addToInsertBuffer(const std::string &query) override;
     virtual void _flushInsertBuffer();
 };
 

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -36,6 +36,9 @@
 #include "tools.h"
 #include "update_manager.h"
 #include <climits>
+#include <algorithm>
+#include <sstream>
+#include <string>
 
 using namespace zmm;
 using namespace std;
@@ -136,9 +139,9 @@ void SQLStorage::init()
     if (table_quote_begin == '\0' || table_quote_end == '\0')
         throw _Exception(_("quote vars need to be overridden!"));
 
-    Ref<StringBuffer> buf(new StringBuffer());
-    *buf << SQL_QUERY_FOR_STRINGBUFFER;
-    this->sql_query = buf->toString();
+    std::ostringstream buf;
+    buf << SQL_QUERY_FOR_STRINGBUFFER;
+    this->sql_query = buf.str();
 
     if (ConfigManager::getInstance()->getBoolOption(CFG_SERVER_STORAGE_CACHING_ENABLED)) {
         cache = Ref<StorageCache>(new StorageCache());
@@ -292,13 +295,13 @@ Ref<Array<SQLStorage::AddUpdateTable>> SQLStorage::_addUpdateObject(Ref<CdsObjec
 
     if (!hasReference || (!obj->getFlag(OBJECT_FLAG_USE_RESOURCE_REF) && !refObj->resourcesEqual(obj))) {
         // encode resources
-        Ref<StringBuffer> resBuf(new StringBuffer());
+        std::ostringstream resBuf;
         for (int i = 0; i < obj->getResourceCount(); i++) {
             if (i > 0)
-                *resBuf << RESOURCE_SEP;
-            *resBuf << obj->getResource(i)->encode();
+                resBuf << RESOURCE_SEP;
+            resBuf << obj->getResource(i)->encode();
         }
-        String resStr = resBuf->toString();
+        String resStr = resBuf.str();
         if (string_ok(resStr))
             cdsObjectSql->put(_("resources"), quote(resStr));
         else
@@ -376,8 +379,8 @@ Ref<Array<SQLStorage::AddUpdateTable>> SQLStorage::_addUpdateObject(Ref<CdsObjec
 
     // check for a duplicate (virtual) object
     if (hasReference && !isUpdate) {
-        Ref<StringBuffer> qb(new StringBuffer());
-        *qb << "SELECT " << TQ("id")
+        std::ostringstream q;
+        q << "SELECT " << TQ("id")
             << " FROM " << TQ(CDS_OBJECT_TABLE)
             << " WHERE " << TQ("parent_id")
             << '=' << quote(obj->getParentID())
@@ -386,7 +389,7 @@ Ref<Array<SQLStorage::AddUpdateTable>> SQLStorage::_addUpdateObject(Ref<CdsObjec
             << " AND " << TQ("dc_title")
             << '=' << quote(obj->getTitle())
             << " LIMIT 1";
-        Ref<SQLResult> res = select(qb);
+        Ref<SQLResult> res = select(q);
         // if duplicate items is found - ignore
         if (res != nullptr && (res->nextRow() != nullptr))
             return nullptr;
@@ -413,35 +416,36 @@ void SQLStorage::addObject(Ref<CdsObject> obj, int* changedContainer)
         String tableName = addUpdateTable->getTable();
         Ref<Array<DictionaryElement>> dataElements = addUpdateTable->getDict()->getElements();
 
-        Ref<StringBuffer> fields(new StringBuffer(128));
-        Ref<StringBuffer> values(new StringBuffer(128));
+        std::ostringstream fields;
+        std::ostringstream values;
 
         for (int j = 0; j < dataElements->size(); j++) {
             Ref<DictionaryElement> element = dataElements->get(j);
             if (j != 0) {
-                *fields << ',';
-                *values << ',';
+                fields << ',';
+                values << ',';
             }
-            *fields << TQ(element->getKey());
+            fields << TQ(element->getKey());
             if (lastInsertID != INVALID_OBJECT_ID && element->getKey() == "id" && element->getValue().toInt() == INVALID_OBJECT_ID)
-                *values << lastInsertID;
+                values << lastInsertID;
             else
-                *values << element->getValue();
+                values << element->getValue();
         }
 
         /* manually generate ID */
         if (lastInsertID == INVALID_OBJECT_ID && tableName == _(CDS_OBJECT_TABLE)) {
             lastInsertID = getNextID();
             obj->setID(lastInsertID);
-            *fields << ',' << TQ("id");
-            *values << ',' << quote(lastInsertID);
+            fields << ',' << TQ("id");
+            values << ',' << quote(lastInsertID);
         }
         /* -------------------- */
 
-        Ref<StringBuffer> qb(new StringBuffer(256));
-        *qb << "INSERT INTO " << TQ(tableName) << " (" << fields->toString() << ") VALUES (" << values->toString() << ')';
+        std::ostringstream qb;
+        qb << "INSERT INTO " << TQ(tableName) << " (" << fields.str()
+                << ") VALUES (" << values.str() << ')';
 
-        log_debug("insert_query: %s\n", qb->toString().c_str());
+        log_debug("insert_query: %s\n", qb.str().c_str());
 
         /*
         if (lastInsertID == INVALID_OBJECT_ID && tableName == _(CDS_OBJECT_TABLE))
@@ -456,7 +460,7 @@ void SQLStorage::addObject(Ref<CdsObject> obj, int* changedContainer)
         if (!doInsertBuffering())
             exec(qb);
         else
-            addToInsertBuffer(qb);
+            addToInsertBuffer(qb.str());
     }
 
     /* add to cache */
@@ -494,21 +498,21 @@ void SQLStorage::updateObject(zmm::Ref<CdsObject> obj, int* changedContainer)
         String tableName = addUpdateTable->getTable();
         Ref<Array<DictionaryElement>> dataElements = addUpdateTable->getDict()->getElements();
 
-        Ref<StringBuffer> qb(new StringBuffer(256));
-        *qb << "UPDATE " << TQ(tableName) << " SET ";
+        std::ostringstream qb;
+        qb << "UPDATE " << TQ(tableName) << " SET ";
 
         for (int j = 0; j < dataElements->size(); j++) {
             Ref<DictionaryElement> element = dataElements->get(j);
             if (j != 0) {
-                *qb << ',';
+                qb << ',';
             }
-            *qb << TQ(element->getKey()) << '='
+            qb << TQ(element->getKey()) << '='
                 << element->getValue();
         }
 
-        *qb << " WHERE id = " << obj->getID();
+        qb << " WHERE id = " << obj->getID();
 
-        log_debug("upd_query: %s\n", qb->toString().c_str());
+        log_debug("upd_query: %s\n", qb.str().c_str());
 
         exec(qb);
     }
@@ -537,11 +541,11 @@ Ref<CdsObject> SQLStorage::loadObject(int objectID)
         return obj;
     throw _Exception(_("Object not found: ") + objectID);
 */
-    Ref<StringBuffer> qb(new StringBuffer());
+    std::ostringstream qb;
 
     //log_debug("sql_query = %s\n",sql_query.c_str());
 
-    *qb << SQL_QUERY << " WHERE " << TQD('f', "id") << '=' << objectID;
+    qb << SQL_QUERY << " WHERE " << TQD('f', "id") << '=' << objectID;
 
     Ref<SQLResult> res = select(qb);
     Ref<SQLRow> row;
@@ -555,8 +559,8 @@ Ref<CdsObject> SQLStorage::loadObjectByServiceID(String serviceID)
 {
     flushInsertBuffer();
 
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << SQL_QUERY << " WHERE " << TQD('f', "service_id") << '=' << quote(serviceID);
+    std::ostringstream qb;
+    qb << SQL_QUERY << " WHERE " << TQD('f', "service_id") << '=' << quote(serviceID);
     Ref<SQLResult> res = select(qb);
     Ref<SQLRow> row;
     if (res != nullptr && (row = res->nextRow()) != nullptr) {
@@ -572,8 +576,8 @@ std::unique_ptr<std::vector<int>> SQLStorage::getServiceObjectIDs(char servicePr
 
     auto objectIDs = std::make_unique<std::vector<int>>();
 
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << "SELECT " << TQ("id")
+    std::ostringstream qb;
+    qb << "SELECT " << TQ("id")
         << " FROM " << TQ(CDS_OBJECT_TABLE)
         << " WHERE " << TQ("service_id")
         << " LIKE " << quote(String(servicePrefix) + '%');
@@ -618,9 +622,9 @@ Ref<Array<CdsObject>> SQLStorage::browse(Ref<BrowseParam> param)
     }
     /* ----------- */
 
-    Ref<StringBuffer> qb(new StringBuffer());
     if (!haveObjectType) {
-        *qb << "SELECT " << TQ("object_type")
+        std::ostringstream qb;
+        qb << "SELECT " << TQ("object_type")
             << " FROM " << TQ(CDS_OBJECT_TABLE)
             << " WHERE " << TQ("id") << '=' << objectID;
         res = select(qb);
@@ -653,14 +657,16 @@ Ref<Array<CdsObject>> SQLStorage::browse(Ref<BrowseParam> param)
     }
 
     // order by code..
-    qb->clear();
-    if (param->getFlag(BROWSE_TRACK_SORT))
-        *qb << TQD('f', "track_number") << ',';
-    *qb << TQD('f', "dc_title");
-    String orderByCode = qb->toString();
+    auto orderByCode = [&]() {
+        std::ostringstream qb;
+        if (param->getFlag(BROWSE_TRACK_SORT))
+            qb << TQD('f', "track_number") << ',';
+        qb << TQD('f', "dc_title");
+        return qb.str();
+    };
 
-    qb->clear();
-    *qb << SQL_QUERY << " WHERE ";
+    std::ostringstream qb;
+    qb << SQL_QUERY << " WHERE ";
 
     if (param->getFlag(BROWSE_DIRECT_CHILDREN) && IS_CDS_CONTAINER(objectType)) {
         int count = param->getRequestedCount();
@@ -672,35 +678,35 @@ Ref<Array<CdsObject>> SQLStorage::browse(Ref<BrowseParam> param)
                 doLimit = false;
         }
 
-        *qb << TQD('f', "parent_id") << '=' << objectID;
+        qb << TQD('f', "parent_id") << '=' << objectID;
 
         if (objectID == CDS_ID_ROOT && hideFsRoot)
-            *qb << " AND " << TQD('f', "id") << "!="
+            qb << " AND " << TQD('f', "id") << "!="
                 << quote(CDS_ID_FS_ROOT);
 
         if (!getContainers && !getItems) {
-            *qb << " AND 0=1";
+            qb << " AND 0=1";
         } else if (getContainers && !getItems) {
-            *qb << " AND " << TQD('f', "object_type") << '='
+            qb << " AND " << TQD('f', "object_type") << '='
                 << quote(OBJECT_TYPE_CONTAINER)
-                << " ORDER BY " << orderByCode;
+                << " ORDER BY " << orderByCode();
         } else if (!getContainers && getItems) {
-            *qb << " AND (" << TQD('f', "object_type") << " & "
+            qb << " AND (" << TQD('f', "object_type") << " & "
                 << quote(OBJECT_TYPE_ITEM) << ") = "
                 << quote(OBJECT_TYPE_ITEM)
-                << " ORDER BY " << orderByCode;
+                << " ORDER BY " << orderByCode();
         } else {
-            *qb << " ORDER BY ("
+            qb << " ORDER BY ("
                 << TQD('f', "object_type") << '=' << quote(OBJECT_TYPE_CONTAINER)
-                << ") DESC, " << orderByCode;
+                << ") DESC, " << orderByCode();
         }
         if (doLimit)
-            *qb << " LIMIT " << count << " OFFSET " << param->getStartingIndex();
+            qb << " LIMIT " << count << " OFFSET " << param->getStartingIndex();
     } else // metadata
     {
-        *qb << TQD('f', "id") << '=' << objectID << " LIMIT 1";
+        qb << TQD('f', "id") << '=' << objectID << " LIMIT 1";
     }
-    log_debug("QUERY: %s\n", qb->toString().c_str());
+    log_debug("QUERY: %s\n", qb.str().c_str());
     res = select(qb);
 
     Ref<Array<CdsObject>> arr(new Array<CdsObject>());
@@ -747,16 +753,16 @@ int SQLStorage::getChildCount(int contId, bool containers, bool items, bool hide
 
     Ref<SQLRow> row;
     Ref<SQLResult> res;
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << "SELECT COUNT(*) FROM " << TQ(CDS_OBJECT_TABLE)
+    std::ostringstream qb;
+    qb << "SELECT COUNT(*) FROM " << TQ(CDS_OBJECT_TABLE)
         << " WHERE " << TQ("parent_id") << '=' << contId;
     if (containers && !items)
-        *qb << " AND " << TQ("object_type") << '=' << OBJECT_TYPE_CONTAINER;
+        qb << " AND " << TQ("object_type") << '=' << OBJECT_TYPE_CONTAINER;
     else if (items && !containers)
-        *qb << " AND (" << TQ("object_type") << " & " << OBJECT_TYPE_ITEM
+        qb << " AND (" << TQ("object_type") << " & " << OBJECT_TYPE_ITEM
             << ") = " << OBJECT_TYPE_ITEM;
     if (contId == CDS_ID_ROOT && hideFsRoot) {
-        *qb << " AND " << TQ("id") << "!=" << quote(CDS_ID_FS_ROOT);
+        qb << " AND " << TQ("id") << "!=" << quote(CDS_ID_FS_ROOT);
     }
     res = select(qb);
     if (res != nullptr && (row = res->nextRow()) != nullptr) {
@@ -782,8 +788,8 @@ Ref<Array<StringBase>> SQLStorage::getMimeTypes()
 
     Ref<Array<StringBase>> arr(new Array<StringBase>());
 
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << "SELECT DISTINCT " << TQ("mime_type")
+    std::ostringstream qb;
+    qb << "SELECT DISTINCT " << TQ("mime_type")
         << " FROM " << TQ(CDS_OBJECT_TABLE)
         << " WHERE " << TQ("mime_type") << " IS NOT NULL ORDER BY "
         << TQ("mime_type");
@@ -832,8 +838,8 @@ Ref<CdsObject> SQLStorage::_findObjectByPath(String fullpath)
     }
     /* ----------- */
 
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << SQL_QUERY
+    std::ostringstream qb;
+    qb << SQL_QUERY
         << " WHERE " << TQD('f', "location_hash") << '=' << quote(stringHash(dbLocation))
         << " AND " << TQD('f', "location") << '=' << quote(dbLocation)
         << " AND " << TQD('f', "ref_id") << " IS NULL "
@@ -841,7 +847,7 @@ Ref<CdsObject> SQLStorage::_findObjectByPath(String fullpath)
 
     Ref<SQLResult> res = select(qb);
     if (res == nullptr)
-        throw _Exception(_("error while doing select: ") + qb->toString());
+        throw _Exception(_("error while doing select: ") + qb.str());
 
     Ref<SQLRow> row = res->nextRow();
     if (row == nullptr)
@@ -917,8 +923,8 @@ int SQLStorage::createContainer(int parentID, String name, String path, bool isV
 
     int newID = getNextID();
 
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << "INSERT INTO "
+    std::ostringstream qb;
+    qb << "INSERT INTO "
         << TQ(CDS_OBJECT_TABLE)
         << " ("
         << TQ("id") << ','
@@ -970,8 +976,9 @@ String SQLStorage::buildContainerPath(int parentID, String title)
     if (parentID == CDS_ID_ROOT)
         return String(VIRTUAL_CONTAINER_SEPARATOR) + title;
 
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << "SELECT " << TQ("location") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE " << TQ("id") << '=' << parentID << " LIMIT 1";
+    std::ostringstream qb;
+    qb << "SELECT " << TQ("location") << " FROM " << TQ(CDS_OBJECT_TABLE)
+            << " WHERE " << TQ("id") << '=' << parentID << " LIMIT 1";
 
     Ref<SQLResult> res = select(qb);
     if (res == nullptr)
@@ -996,9 +1003,9 @@ void SQLStorage::addContainerChain(String path, String lastClass, int lastRefID,
         *containerID = CDS_ID_ROOT;
         return;
     }
-    Ref<StringBuffer> qb(new StringBuffer());
+    std::ostringstream qb;
     String dbLocation = addLocationPrefix(LOC_VIRT_PREFIX, path);
-    *qb << "SELECT " << TQ("id") << " FROM " << TQ(CDS_OBJECT_TABLE)
+    qb << "SELECT " << TQ("id") << " FROM " << TQ(CDS_OBJECT_TABLE)
         << " WHERE " << TQ("location_hash") << '=' << quote(stringHash(dbLocation))
         << " AND " << TQ("location") << '=' << quote(dbLocation)
         << " LIMIT 1";
@@ -1136,8 +1143,8 @@ Ref<CdsObject> SQLStorage::createObjectFromRow(Ref<SQLRow> row)
     if (IS_CDS_ACTIVE_ITEM(objectType)) {
         Ref<CdsActiveItem> aitem = RefCast(obj, CdsActiveItem);
 
-        Ref<StringBuffer> query(new StringBuffer());
-        *query << "SELECT " << TQ("id") << ',' << TQ("action") << ','
+        std::ostringstream query;
+        query << "SELECT " << TQ("id") << ',' << TQ("action") << ','
                << TQ("state") << " FROM " << TQ(CDS_ACTIVE_ITEM_TABLE)
                << " WHERE " << TQ("id") << '=' << quote(aitem->getID());
         Ref<SQLResult> resAI = select(query);
@@ -1163,8 +1170,8 @@ int SQLStorage::getTotalFiles()
 {
     flushInsertBuffer();
 
-    Ref<StringBuffer> query(new StringBuffer());
-    *query << "SELECT COUNT(*) FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE "
+    std::ostringstream query;
+    query << "SELECT COUNT(*) FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE "
            << TQ("object_type") << " != " << quote(OBJECT_TYPE_CONTAINER);
     //<< " AND is_virtual = 0";
     Ref<SQLResult> res = select(query);
@@ -1179,37 +1186,42 @@ String SQLStorage::incrementUpdateIDs(shared_ptr<unordered_set<int>> ids)
 {
     if (ids->empty())
         return nullptr;
-    Ref<StringBuffer> inBuf(new StringBuffer()); // ??? what was that: size * sizeof(int)));
+    std::ostringstream inBuf;
 
     bool first = true;
     for (const auto& id : *ids) {
         if (first) {
-            *inBuf << "IN (" << id;
+            inBuf << "IN (" << id;
             first = false;
         } else {
-            *inBuf << ',' << id;
+            inBuf << ',' << id;
         }
     }
-    *inBuf << ')';
+    inBuf << ')';
 
-    Ref<StringBuffer> buf(new StringBuffer());
-    *buf << "UPDATE " << TQ(CDS_OBJECT_TABLE) << " SET " << TQ("update_id") << '=' << TQ("update_id") << " + 1 WHERE " << TQ("id") << ' ';
-    *buf << inBuf;
-    exec(buf);
+    std::ostringstream bufUpdate;
+    bufUpdate << "UPDATE " << TQ(CDS_OBJECT_TABLE) << " SET " << TQ("update_id")
+            << '=' << TQ("update_id") << " + 1 WHERE " << TQ("id") << ' ';
+    bufUpdate << inBuf.str();
+    exec(bufUpdate);
 
-    buf->clear();
-    *buf << "SELECT " << TQ("id") << ',' << TQ("update_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE " << TQ("id") << ' ';
-    *buf << inBuf;
-    Ref<SQLResult> res = select(buf);
+    std::ostringstream bufSelect;
+    bufSelect << "SELECT " << TQ("id") << ',' << TQ("update_id") << " FROM "
+            << TQ(CDS_OBJECT_TABLE) << " WHERE " << TQ("id") << ' ';
+    bufSelect << inBuf.str();
+    Ref<SQLResult> res = select(bufSelect);
     if (res == nullptr)
         throw _Exception(_("Error while fetching update ids"));
     Ref<SQLRow> row;
-    buf->clear();
-    while ((row = res->nextRow()) != nullptr)
-        *buf << ',' << row->col(0) << ',' << row->col(1);
-    if (buf->length() <= 0)
+    std::list<std::string> rows;
+    while ((row = res->nextRow()) != nullptr) {
+        std::ostringstream s;
+        s << row->col(0) << ',' << row->col(1);
+        rows.emplace_back(s.str());
+    }
+    if (rows.empty())
         return nullptr;
-    return buf->toString(1);
+    return join(rows, ",");
 }
 
 // id is the parent_id for cover media to find, and if set, trackArtBase is the case-folded
@@ -1222,50 +1234,50 @@ String SQLStorage::incrementUpdateIDs(shared_ptr<unordered_set<int>> ids)
 
 String SQLStorage::findFolderImage(int id, String trackArtBase)
 {
-    Ref<StringBuffer> q(new StringBuffer());
+    std::ostringstream q;
     // folder.jpg or cover.jpg [and variants]
     // note - "_" is regexp "." and "%" is regexp ".*" in sql LIKE land
-    *q << "SELECT " << TQ("id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
-    *q << "( ";
+    q << "SELECT " << TQ("id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    q << "( ";
     if (trackArtBase.length() > 0) {
-        *q << TQ("dc_title") << "LIKE " << quote(trackArtBase + _(".jp%")) << " OR ";
+        q << TQ("dc_title") << "LIKE " << quote(trackArtBase + _(".jp%")) << " OR ";
     }
-    *q << TQ("dc_title") << "LIKE " << quote(_("cover.jp%")) << " OR ";
-    *q << TQ("dc_title") << "LIKE " << quote(_("albumart%.jp%")) << " OR ";
-    *q << TQ("dc_title") << "LIKE " << quote(_("album.jp%")) << " OR ";
-    *q << TQ("dc_title") << "LIKE " << quote(_("front.jp%")) << " OR ";
-    *q << TQ("dc_title") << "LIKE " << quote(_("folder.jp%"));
-    *q << " ) AND ";
-    *q << TQ("upnp_class") << '=' << quote(_(UPNP_DEFAULT_CLASS_IMAGE_ITEM)) << " AND ";
+    q << TQ("dc_title") << "LIKE " << quote(_("cover.jp%")) << " OR ";
+    q << TQ("dc_title") << "LIKE " << quote(_("albumart%.jp%")) << " OR ";
+    q << TQ("dc_title") << "LIKE " << quote(_("album.jp%")) << " OR ";
+    q << TQ("dc_title") << "LIKE " << quote(_("front.jp%")) << " OR ";
+    q << TQ("dc_title") << "LIKE " << quote(_("folder.jp%"));
+    q << " ) AND ";
+    q << TQ("upnp_class") << '=' << quote(_(UPNP_DEFAULT_CLASS_IMAGE_ITEM)) << " AND ";
 #ifndef ONLY_REAL_FOLDER_ART
-    *q << "( ";
-    *q <<       "( ";
+    q << "( ";
+    q <<       "( ";
         // virtual listing via Album, Artist etc
-    *q << TQ("parent_id") << " IN ";
-    *q <<       "(";
-    *q << "SELECT " << TQ("parent_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
-    *q << TQ("upnp_class") << '=' << quote(_(UPNP_DEFAULT_CLASS_MUSIC_TRACK)) << " AND ";
-    *q << TQ("id") << " IN ";
-    *q <<               "(";
-    *q << "SELECT " << TQ("ref_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
-    *q << TQ("parent_id") << '=' << quote(String::from(id)) << " AND ";
-    *q << TQ("object_type") << '=' << quote(OBJECT_TYPE_ITEM);
+    q << TQ("parent_id") << " IN ";
+    q <<       "(";
+    q << "SELECT " << TQ("parent_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    q << TQ("upnp_class") << '=' << quote(_(UPNP_DEFAULT_CLASS_MUSIC_TRACK)) << " AND ";
+    q << TQ("id") << " IN ";
+    q <<               "(";
+    q << "SELECT " << TQ("ref_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    q << TQ("parent_id") << '=' << quote(String::from(id)) << " AND ";
+    q << TQ("object_type") << '=' << quote(OBJECT_TYPE_ITEM);
 
     // only use this optimization on sqlite3
     if (ConfigManager::getInstance()->getOption(CFG_SERVER_STORAGE_DRIVER) == "sqlite3") {
-        *q <<               " LIMIT " << MAX_ART_CONTAINERS << ")";
+        q <<               " LIMIT " << MAX_ART_CONTAINERS << ")";
     } else {
-        *q <<               ")";
+        q <<               ")";
     }
-    *q <<       ")";
-    *q << "     ) OR ";
+    q <<       ")";
+    q << "     ) OR ";
 #endif
         // straightforward folder listing of real filesystem
-    *q << TQ("parent_id") << '=' << quote(String::from(id));
+    q << TQ("parent_id") << '=' << quote(String::from(id));
 #ifndef ONLY_REAL_FOLDER_ART
-    *q << ")";
+    q << ")";
 #endif
-    *q << " LIMIT 1";
+    q << " LIMIT 1";
 
     //log_debug("findFolderImage %d, %s\n", id, q->c_str());
     Ref<SQLResult> res = select(q);
@@ -1323,12 +1335,12 @@ shared_ptr<unordered_set<int>> SQLStorage::getObjects(int parentID, bool without
 {
     flushInsertBuffer();
 
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "SELECT " << TQ("id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
+    std::ostringstream q;
+    q << "SELECT " << TQ("id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
     if (withoutContainer)
-        *q << TQ("object_type") << " != " << OBJECT_TYPE_CONTAINER << " AND ";
-    *q << TQ("parent_id") << '=';
-    *q << parentID;
+        q << TQ("object_type") << " != " << OBJECT_TYPE_CONTAINER << " AND ";
+    q << TQ("parent_id") << '=';
+    q << parentID;
     Ref<SQLResult> res = select(q);
     if (res == nullptr)
         throw _Exception(_("db error"));
@@ -1357,35 +1369,31 @@ Ref<Storage::ChangedContainers> SQLStorage::removeObjects(shared_ptr<unordered_s
     if (count <= 0)
         return nullptr;
 
-    Ref<StringBuffer> idsBuf(new StringBuffer());
-    *idsBuf << "SELECT " << TQ("id") << ',' << TQ("object_type")
-            << " FROM " << TQ(CDS_OBJECT_TABLE)
-            << " WHERE " << TQ("id") << " IN (";
-    int firstComma = idsBuf->length();
-
     for (const auto& id : *list) {
         if (IS_FORBIDDEN_CDS_ID(id))
             throw _Exception(_("tried to delete a forbidden ID (") + id + ")!");
-        *idsBuf << ',' << id;
     }
-    idsBuf->setCharAt(firstComma, ' ');
-    *idsBuf << ')';
+
+    std::ostringstream idsBuf;
+    idsBuf << "SELECT " << TQ("id") << ',' << TQ("object_type")
+            << " FROM " << TQ(CDS_OBJECT_TABLE)
+            << " WHERE " << TQ("id") << " IN (" << join(*list, ",") << ")";
+
     Ref<SQLResult> res = select(idsBuf);
-    idsBuf = nullptr;
     if (res == nullptr)
         throw _Exception(_("sql error"));
 
-    Ref<StringBuffer> items(new StringBuffer());
-    Ref<StringBuffer> containers(new StringBuffer());
+    std::ostringstream items;
+    std::ostringstream containers;
     Ref<SQLRow> row;
     while ((row = res->nextRow()) != nullptr) {
         int objectType = row->col(1).toInt();
         if (IS_CDS_CONTAINER(objectType))
-            *containers << ',' << row->col_c_str(0);
+            containers << ',' << row->col_c_str(0);
         else
-            *items << ',' << row->col_c_str(0);
+            items << ',' << row->col_c_str(0);
     }
-    return _purgeEmptyContainers(_recursiveRemove(items, containers, all));
+    return _purgeEmptyContainers(_recursiveRemove(items.str(), containers.str(), all));
 }
 
 void SQLStorage::_removeObjects(Ref<StringBuffer> objectIDs, int offset)
@@ -1452,8 +1460,8 @@ Ref<Storage::ChangedContainers> SQLStorage::removeObject(int objectID, bool all)
 {
     flushInsertBuffer();
 
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "SELECT " << TQ("object_type") << ',' << TQ("ref_id")
+    std::ostringstream q;
+    q << "SELECT " << TQ("object_type") << ',' << TQ("ref_id")
        << " FROM " << TQ(CDS_OBJECT_TABLE)
        << " WHERE " << TQ("id") << '=' << quote(objectID) << " LIMIT 1";
     Ref<SQLResult> res = select(q);
@@ -1476,17 +1484,18 @@ Ref<Storage::ChangedContainers> SQLStorage::removeObject(int objectID, bool all)
     }
     if (IS_FORBIDDEN_CDS_ID(objectID))
         throw _Exception(_("tried to delete a forbidden ID (") + objectID + ")!");
-    Ref<StringBuffer> idsBuf(new StringBuffer());
-    *idsBuf << ',' << objectID;
+    std::ostringstream idsBuf;
+    idsBuf << ',' << objectID;
     Ref<ChangedContainersStr> changedContainers = nullptr;
     if (isContainer)
-        changedContainers = _recursiveRemove(nullptr, idsBuf, all);
+        changedContainers = _recursiveRemove(std::string(), idsBuf.str(), all);
     else
-        changedContainers = _recursiveRemove(idsBuf, nullptr, all);
+        changedContainers = _recursiveRemove(idsBuf.str(), std::string(), all);
     return _purgeEmptyContainers(changedContainers);
 }
 
-Ref<SQLStorage::ChangedContainersStr> SQLStorage::_recursiveRemove(Ref<StringBuffer> items, Ref<StringBuffer> containers, bool all)
+Ref<SQLStorage::ChangedContainersStr> SQLStorage::_recursiveRemove(
+    const std::string &items, const std::string &containers, bool all)
 {
     log_debug("start\n");
     Ref<StringBuffer> recurseItems(new StringBuffer());
@@ -1514,12 +1523,12 @@ Ref<SQLStorage::ChangedContainersStr> SQLStorage::_recursiveRemove(Ref<StringBuf
     Ref<SQLResult> res;
     Ref<SQLRow> row;
 
-    if (items != nullptr && items->length() > 1) {
+    if (items.length() > 1) {
         *recurseItems << items;
         *removeAddParents << items;
     }
 
-    if (containers != nullptr && containers->length() > 1) {
+    if (containers.length() > 1) {
         *recurseContainers << containers;
 
         *remove << containers;
@@ -1640,15 +1649,7 @@ void SQLStorage::addCSV(String csv, std::vector<int>& target)
 
 zmm::String SQLStorage::toCSV(const std::vector<int>& input)
 {
-    const char sep = ',';
-    Ref<StringBuffer> buf(new StringBuffer());
-    for (int i : input) {
-        *buf << sep << i;
-    }
-    if (buf->length() <= 0) {
-        return _("");
-    }
-    return buf->toString(1);
+    return join(input, ",");
 }
 
 Ref<Storage::ChangedContainers> SQLStorage::_purgeEmptyContainers(Ref<ChangedContainersStr> changedContainersStr)
@@ -1762,8 +1763,8 @@ Ref<Storage::ChangedContainers> SQLStorage::_purgeEmptyContainers(Ref<ChangedCon
 
 String SQLStorage::getInternalSetting(String key)
 {
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "SELECT " << TQ("value") << " FROM " << TQ(INTERNAL_SETTINGS_TABLE) << " WHERE " << TQ("key") << '='
+    std::ostringstream q;
+    q << "SELECT " << TQ("value") << " FROM " << TQ(INTERNAL_SETTINGS_TABLE) << " WHERE " << TQ("key") << '='
        << quote(key) << " LIMIT 1";
     Ref<SQLResult> res = select(q);
     if (res == nullptr)
@@ -1783,13 +1784,14 @@ void SQLStorage::updateAutoscanPersistentList(ScanMode scanmode, Ref<AutoscanLis
 
     log_debug("setting persistent autoscans untouched - scanmode: %s;\n", AutoscanDirectory::mapScanmode(scanmode).c_str());
     Ref<StringBuffer> q(new StringBuffer());
-    *q << "UPDATE " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream update;
+    update << "UPDATE " << TQ(AUTOSCAN_TABLE)
        << " SET " << TQ("touched") << '=' << mapBool(false)
        << " WHERE "
        << TQ("persistent") << '=' << mapBool(true)
        << " AND " << TQ("scan_mode") << '='
        << quote(AutoscanDirectory::mapScanmode(scanmode));
-    exec(q);
+    exec(update);
 
     int listSize = list->size();
     log_debug("updating/adding persistent autoscans (count: %d)\n", listSize);
@@ -1808,16 +1810,16 @@ void SQLStorage::updateAutoscanPersistentList(ScanMode scanmode, Ref<AutoscanLis
         if (!string_ok(location))
             throw _Exception(_("AutoscanDirectoy with illegal location given to SQLStorage::updateAutoscanPersistentList"));
 
-        q->clear();
-        *q << "SELECT " << TQ("id") << " FROM " << TQ(AUTOSCAN_TABLE)
+        std::ostringstream q;
+        q << "SELECT " << TQ("id") << " FROM " << TQ(AUTOSCAN_TABLE)
            << " WHERE ";
         int objectID = findObjectIDByPath(location + '/');
         log_debug("objectID = %d\n", objectID);
         if (objectID == INVALID_OBJECT_ID)
-            *q << TQ("location") << '=' << quote(location);
+            q << TQ("location") << '=' << quote(location);
         else
-            *q << TQ("obj_id") << '=' << quote(objectID);
-        *q << " LIMIT 1";
+            q << TQ("obj_id") << '=' << quote(objectID);
+        q << " LIMIT 1";
         Ref<SQLResult> res = select(q);
         if (res == nullptr)
             throw _StorageException(nullptr, _("query error while selecting from autoscan list"));
@@ -1829,19 +1831,19 @@ void SQLStorage::updateAutoscanPersistentList(ScanMode scanmode, Ref<AutoscanLis
             addAutoscanDirectory(ad);
     }
 
-    q->clear();
-    *q << "DELETE FROM " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream del;
+    del << "DELETE FROM " << TQ(AUTOSCAN_TABLE)
        << " WHERE " << TQ("touched") << '=' << mapBool(false)
        << " AND " << TQ("scan_mode") << '='
        << quote(AutoscanDirectory::mapScanmode(scanmode));
-    exec(q);
+    exec(del);
 }
 
 Ref<AutoscanList> SQLStorage::getAutoscanList(ScanMode scanmode)
 {
 #define FLD(field) << TQD('a', field) <<
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "SELECT " FLD("id") ',' FLD("obj_id") ',' FLD("scan_level") ',' FLD("scan_mode") ',' FLD("recursive") ',' FLD("hidden") ',' FLD("interval") ',' FLD("last_modified") ',' FLD("persistent") ',' FLD("location") ',' << TQD('t', "location")
+    std::ostringstream q;
+    q << "SELECT " FLD("id") ',' FLD("obj_id") ',' FLD("scan_level") ',' FLD("scan_mode") ',' FLD("recursive") ',' FLD("hidden") ',' FLD("interval") ',' FLD("last_modified") ',' FLD("persistent") ',' FLD("location") ',' << TQD('t', "location")
        << " FROM " << TQ(AUTOSCAN_TABLE) << ' ' << TQ('a')
        << " LEFT JOIN " << TQ(CDS_OBJECT_TABLE) << ' ' << TQ('t')
        << " ON " FLD("obj_id") '=' << TQD('t', "id")
@@ -1864,8 +1866,8 @@ Ref<AutoscanList> SQLStorage::getAutoscanList(ScanMode scanmode)
 Ref<AutoscanDirectory> SQLStorage::getAutoscanDirectory(int objectID)
 {
 #define FLD(field) << TQD('a', field) <<
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "SELECT " FLD("id") ',' FLD("obj_id") ',' FLD("scan_level") ',' FLD("scan_mode") ',' FLD("recursive") ',' FLD("hidden") ',' FLD("interval") ',' FLD("last_modified") ',' FLD("persistent") ',' FLD("location") ',' << TQD('t', "location")
+    std::ostringstream q;
+    q << "SELECT " FLD("id") ',' FLD("obj_id") ',' FLD("scan_level") ',' FLD("scan_mode") ',' FLD("recursive") ',' FLD("hidden") ',' FLD("interval") ',' FLD("last_modified") ',' FLD("persistent") ',' FLD("location") ',' << TQD('t', "location")
        << " FROM " << TQ(AUTOSCAN_TABLE) << ' ' << TQ('a')
        << " LEFT JOIN " << TQ(CDS_OBJECT_TABLE) << ' ' << TQ('t')
        << " ON " FLD("obj_id") '=' << TQD('t', "id")
@@ -1937,8 +1939,8 @@ void SQLStorage::addAutoscanDirectory(Ref<AutoscanDirectory> adir)
 
     _autoscanChangePersistentFlag(objectID, true);
 
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "INSERT INTO " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream q;
+    q << "INSERT INTO " << TQ(AUTOSCAN_TABLE)
        << " (" << TQ("obj_id") << ','
        << TQ("scan_level") << ','
        << TQ("scan_mode") << ','
@@ -1979,8 +1981,8 @@ void SQLStorage::updateAutoscanDirectory(Ref<AutoscanDirectory> adir)
         _autoscanChangePersistentFlag(objectIDold, false);
         _autoscanChangePersistentFlag(objectID, true);
     }
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "UPDATE " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream q;
+    q << "UPDATE " << TQ(AUTOSCAN_TABLE)
        << " SET " << TQ("obj_id") << '=' << (objectID >= 0 ? quote(objectID) : _(SQL_NULL))
        << ',' << TQ("scan_level") << '='
        << quote(AutoscanDirectory::mapScanlevel(adir->getScanLevel()))
@@ -1990,8 +1992,8 @@ void SQLStorage::updateAutoscanDirectory(Ref<AutoscanDirectory> adir)
        << ',' << TQ("hidden") << '=' << mapBool(adir->getHidden())
        << ',' << TQ("interval") << '=' << quote(adir->getInterval());
     if (adir->getPreviousLMT() > 0)
-        *q << ',' << TQ("last_modified") << '=' << quote(adir->getPreviousLMT());
-    *q << ',' << TQ("persistent") << '=' << mapBool(adir->persistent())
+        q << ',' << TQ("last_modified") << '=' << quote(adir->getPreviousLMT());
+    q << ',' << TQ("persistent") << '=' << mapBool(adir->persistent())
        << ',' << TQ("location") << '=' << (objectID >= 0 ? _(SQL_NULL) : quote(adir->getLocation()))
        << ',' << TQ("path_ids") << '=' << (pathIds == nullptr ? _(SQL_NULL) : quote(_(",") + toCSV(*pathIds) + ','))
        << ',' << TQ("touched") << '=' << mapBool(true)
@@ -2003,8 +2005,8 @@ void SQLStorage::removeAutoscanDirectoryByObjectID(int objectID)
 {
     if (objectID == INVALID_OBJECT_ID)
         return;
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "DELETE FROM " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream q;
+    q << "DELETE FROM " << TQ(AUTOSCAN_TABLE)
        << " WHERE " << TQ("obj_id") << '=' << quote(objectID);
     exec(q);
 
@@ -2016,8 +2018,8 @@ void SQLStorage::removeAutoscanDirectory(int autoscanID)
     if (autoscanID == INVALID_OBJECT_ID)
         return;
     int objectID = _getAutoscanObjectID(autoscanID);
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "DELETE FROM " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream q;
+    q << "DELETE FROM " << TQ(AUTOSCAN_TABLE)
        << " WHERE " << TQ("id") << '=' << quote(autoscanID);
     exec(q);
     if (objectID != INVALID_OBJECT_ID)
@@ -2038,8 +2040,8 @@ int SQLStorage::_getAutoscanDirectoryInfo(int objectID, String field)
 {
     if (objectID == INVALID_OBJECT_ID)
         return 0;
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "SELECT " << TQ(field) << " FROM " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream q;
+    q << "SELECT " << TQ(field) << " FROM " << TQ(AUTOSCAN_TABLE)
        << " WHERE " << TQ("obj_id") << '=' << quote(objectID);
     Ref<SQLResult> res = select(q);
     Ref<SQLRow> row;
@@ -2053,8 +2055,8 @@ int SQLStorage::_getAutoscanDirectoryInfo(int objectID, String field)
 
 int SQLStorage::_getAutoscanObjectID(int autoscanID)
 {
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "SELECT " << TQ("obj_id") << " FROM " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream q;
+    q << "SELECT " << TQ("obj_id") << " FROM " << TQ(AUTOSCAN_TABLE)
        << " WHERE " << TQ("id") << '=' << quote(autoscanID)
        << " LIMIT 1";
     Ref<SQLResult> res = select(q);
@@ -2071,8 +2073,8 @@ void SQLStorage::_autoscanChangePersistentFlag(int objectID, bool persistent)
     if (objectID == INVALID_OBJECT_ID || objectID == INVALID_OBJECT_ID_2)
         return;
 
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "UPDATE " << TQ(CDS_OBJECT_TABLE)
+    std::ostringstream q;
+    q << "UPDATE " << TQ(CDS_OBJECT_TABLE)
        << " SET " << TQ("flags") << " = (" << TQ("flags")
        << (persistent ? _(" | ") : _(" & ~"))
        << OBJECT_FLAG_PERSISTENT_CONTAINER
@@ -2092,8 +2094,8 @@ void SQLStorage::autoscanUpdateLM(Ref<AutoscanDirectory> adir)
     }
     */
     log_debug("id: %d; last_modified: %d\n", adir->getStorageID(), adir->getPreviousLMT());
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "UPDATE " << TQ(AUTOSCAN_TABLE)
+    std::ostringstream q;
+    q << "UPDATE " << TQ(AUTOSCAN_TABLE)
        << " SET " << TQ("last_modified") << '=' << quote(adir->getPreviousLMT())
        << " WHERE " << TQ("id") << '=' << quote(adir->getStorageID());
     exec(q);
@@ -2130,14 +2132,13 @@ std::unique_ptr<std::vector<int>> SQLStorage::_checkOverlappingAutoscans(Ref<Aut
     Ref<SQLResult> res;
     Ref<SQLRow> row;
 
-    Ref<StringBuffer> q(new StringBuffer());
-
-    *q << "SELECT " << TQ("id")
+    std::ostringstream q;
+    q << "SELECT " << TQ("id")
        << " FROM " << TQ(AUTOSCAN_TABLE)
        << " WHERE " << TQ("obj_id") << " = "
        << quote(checkObjectID);
     if (storageID >= 0)
-        *q << " AND " << TQ("id") << " != " << quote(storageID);
+        q << " AND " << TQ("id") << " != " << quote(storageID);
 
     res = select(q);
     if (res == nullptr)
@@ -2152,16 +2153,16 @@ std::unique_ptr<std::vector<int>> SQLStorage::_checkOverlappingAutoscans(Ref<Aut
     }
 
     if (adir->getRecursive()) {
-        q->clear();
-        *q << "SELECT " << TQ("obj_id")
+        std::ostringstream q;
+        q << "SELECT " << TQ("obj_id")
            << " FROM " << TQ(AUTOSCAN_TABLE)
            << " WHERE " << TQ("path_ids") << " LIKE "
            << quote(_("%,") + checkObjectID + ",%");
         if (storageID >= 0)
-            *q << " AND " << TQ("id") << " != " << quote(storageID);
-        *q << " LIMIT 1";
+            q << " AND " << TQ("id") << " != " << quote(storageID);
+        q << " LIMIT 1";
 
-        log_debug("------------ %s\n", q->c_str());
+        log_debug("------------ %s\n", q.str().c_str());
 
         res = select(q);
         if (res == nullptr)
@@ -2180,17 +2181,17 @@ std::unique_ptr<std::vector<int>> SQLStorage::_checkOverlappingAutoscans(Ref<Aut
     auto pathIDs = getPathIDs(checkObjectID);
     if (pathIDs == nullptr)
         throw _Exception(_("getPathIDs returned nullptr"));
-    q->clear();
-    *q << "SELECT " << TQ("obj_id")
+    std::ostringstream q2;
+    q2 << "SELECT " << TQ("obj_id")
        << " FROM " << TQ(AUTOSCAN_TABLE)
        << " WHERE " << TQ("obj_id") << " IN ("
        << toCSV(*pathIDs)
        << ") AND " << TQ("recursive") << '=' << mapBool(true);
     if (storageID >= 0)
-        *q << " AND " << TQ("id") << " != " << quote(storageID);
-    *q << " LIMIT 1";
+        q2 << " AND " << TQ("id") << " != " << quote(storageID);
+    q2 << " LIMIT 1";
 
-    res = select(q);
+    res = select(q2);
     if (res == nullptr)
         throw _Exception(_("SQL error"));
     if ((row = res->nextRow()) == nullptr)
@@ -2263,8 +2264,8 @@ void SQLStorage::loadLastID()
     AutoLock lock(nextIDMutex);
 
     // we don't rely on automatic db generated ids, because of our caching
-    Ref<StringBuffer> qb(new StringBuffer());
-    *qb << "SELECT MAX(" << TQ("id") << ')'
+    std::ostringstream qb;
+    qb << "SELECT MAX(" << TQ("id") << ')'
         << " FROM " << TQ(CDS_OBJECT_TABLE);
     Ref<SQLResult> res = select(qb);
     if (res == nullptr)
@@ -2293,7 +2294,7 @@ void SQLStorage::addObjectToCache(Ref<CdsObject> object, bool dontLock)
     }
 }
 
-void SQLStorage::addToInsertBuffer(Ref<StringBuffer> query)
+void SQLStorage::addToInsertBuffer(const std::string &query)
 {
     assert(doInsertBuffering());
 
@@ -2302,7 +2303,7 @@ void SQLStorage::addToInsertBuffer(Ref<StringBuffer> query)
 
     insertBufferEmpty = false;
     insertBufferStatementCount++;
-    insertBufferByteCount += query->length();
+    insertBufferByteCount += query.length();
 
     if (insertBufferByteCount > 102400)
         flushInsertBuffer(true);
@@ -2327,8 +2328,8 @@ void SQLStorage::flushInsertBuffer(bool dontLock)
 
 void SQLStorage::clearFlagInDB(int flag)
 {
-    Ref<StringBuffer> qb(new StringBuffer(256));
-    *qb << "UPDATE "
+    std::ostringstream qb;
+    qb << "UPDATE "
         << TQ(CDS_OBJECT_TABLE)
         << " SET "
         << TQ("flags")

--- a/src/storage/sql_storage.h
+++ b/src/storage/sql_storage.h
@@ -91,8 +91,18 @@ public:
     /* wrapper functions for select and exec */
     zmm::Ref<SQLResult> select(zmm::Ref<zmm::StringBuffer> buf)
         { return select(buf->c_str(), buf->length()); }
+    zmm::Ref<SQLResult> select(const std::string &buf)
+        { return select(buf.c_str(), buf.length()); }
+    zmm::Ref<SQLResult> select(const std::ostringstream &buf) {
+        auto s = buf.str();
+        return select(s.c_str(), s.length());
+    }
     int exec(zmm::Ref<zmm::StringBuffer> buf, bool getLastInsertId = false)
         { return exec(buf->c_str(), buf->length(), getLastInsertId); }
+    int exec(const std::ostringstream &buf, bool getLastInsertId = false) {
+        auto s = buf.str();
+        return exec(s.c_str(), s.length(), getLastInsertId);
+    }
     
     virtual void addObject(zmm::Ref<CdsObject> object, int *changedContainer) override;
     virtual void updateObject(zmm::Ref<CdsObject> object, int *changedContainer) override;
@@ -209,7 +219,8 @@ private:
     void addCSV(zmm::String csv, std::vector<int>& target);
     zmm::String toCSV(const std::vector<int>& input);
 
-    zmm::Ref<ChangedContainersStr> _recursiveRemove(zmm::Ref<zmm::StringBuffer> items, zmm::Ref<zmm::StringBuffer> containers, bool all);
+    zmm::Ref<ChangedContainersStr> _recursiveRemove(const std::string &items,
+            const std::string &containers, bool all);
     
     virtual zmm::Ref<ChangedContainers> _purgeEmptyContainers(zmm::Ref<ChangedContainersStr> changedContainersStr);
     
@@ -246,11 +257,11 @@ private:
     void addObjectToCache(zmm::Ref<CdsObject> object, bool dontLock = false);
     
     inline bool doInsertBuffering() { return insertBufferOn; }
-    void addToInsertBuffer(zmm::Ref<zmm::StringBuffer> query);
+    void addToInsertBuffer(const std::string &query);
     void flushInsertBuffer(bool dontLock = false);
     
     /* insert buffer functions to be overridden by implementing classes */
-    virtual void _addToInsertBuffer(zmm::Ref<zmm::StringBuffer> query) = 0;
+    virtual void _addToInsertBuffer(const std::string &query) = 0;
     virtual void _flushInsertBuffer() = 0;
     
     bool insertBufferOn;

--- a/src/storage/sql_storage.h
+++ b/src/storage/sql_storage.h
@@ -214,7 +214,7 @@ private:
     zmm::Ref<zmm::Array<AddUpdateTable> > _addUpdateObject(zmm::Ref<CdsObject> obj, bool isUpdate, int *changedContainer);
     
     /* helper for removeObject(s) */
-    void _removeObjects(zmm::Ref<zmm::StringBuffer> objectIDs, int offset);
+    void _removeObjects(std::string objectIDs, int offset);
 
     void addCSV(zmm::String csv, std::vector<int>& target);
     zmm::String toCSV(const std::vector<int>& input);

--- a/src/storage/sqlite3/sqlite3_storage.cc
+++ b/src/storage/sqlite3/sqlite3_storage.cc
@@ -67,7 +67,6 @@ Sqlite3Storage::Sqlite3Storage()
     table_quote_begin = '"';
     table_quote_end = '"';
     startupError = nullptr;
-    insertBuffer = nullptr;
     dirty = false;
 }
 
@@ -158,8 +157,8 @@ void Sqlite3Storage::init()
 
     _exec("PRAGMA locking_mode = EXCLUSIVE");
     int synchronousOption = ConfigManager::getInstance()->getIntOption(CFG_SERVER_STORAGE_SQLITE_SYNCHRONOUS);
-    Ref<StringBuffer> buf(new StringBuffer());
-    *buf << "PRAGMA synchronous = " << synchronousOption;
+    std::ostringstream buf;
+    buf << "PRAGMA synchronous = " << synchronousOption;
     SQLStorage::exec(buf);
 
     log_debug("db_version: %s\n", dbVersion.c_str());
@@ -335,31 +334,29 @@ void Sqlite3Storage::shutdownDriver()
 
 void Sqlite3Storage::storeInternalSetting(String key, String value)
 {
-    Ref<StringBuffer> q(new StringBuffer());
-    *q << "INSERT OR REPLACE INTO " << QTB << INTERNAL_SETTINGS_TABLE << QTE << " (" << QTB << "key" << QTE << ", " << QTB << "value" << QTE << ") "
+    std::ostringstream q;
+    q << "INSERT OR REPLACE INTO " << QTB << INTERNAL_SETTINGS_TABLE << QTE << " (" << QTB << "key" << QTE << ", " << QTB << "value" << QTE << ") "
                                                                                                                                                 "VALUES ("
        << quote(key) << ", " << quote(value) << ") ";
     SQLStorage::exec(q);
 }
 
-void Sqlite3Storage::_addToInsertBuffer(Ref<StringBuffer> query)
+void Sqlite3Storage::_addToInsertBuffer(const std::string &query)
 {
-    if (insertBuffer == nullptr) {
-        insertBuffer = Ref<StringBuffer>(new StringBuffer());
-        *insertBuffer << "BEGIN TRANSACTION;";
+    if (insertBuffer.str().length() == 0) {
+        insertBuffer << "BEGIN TRANSACTION;";
     }
 
-    *insertBuffer << query << ';';
+    insertBuffer << query << ';';
 }
 
 void Sqlite3Storage::_flushInsertBuffer()
 {
-    if (insertBuffer == nullptr)
+    if (insertBuffer.str().length() == 0)
         return;
-    *insertBuffer << "COMMIT;";
+    insertBuffer << "COMMIT;";
     SQLStorage::exec(insertBuffer);
-    insertBuffer->clear();
-    *insertBuffer << "BEGIN TRANSACTION;";
+    insertBuffer.str("");
 }
 
 /* SLTask */

--- a/src/storage/sqlite3/sqlite3_storage.h
+++ b/src/storage/sqlite3/sqlite3_storage.h
@@ -38,6 +38,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <sqlite3.h>
+#include <sstream>
 
 #include "storage/sql_storage.h"
 #include "timer.h"
@@ -194,8 +195,8 @@ private:
     virtual void threadCleanup() override {}
     virtual bool threadCleanupRequired() override { return false; }
 
-    zmm::Ref<zmm::StringBuffer> insertBuffer;
-    virtual void _addToInsertBuffer(zmm::Ref<zmm::StringBuffer> query) override;
+    std::ostringstream insertBuffer;
+    void _addToInsertBuffer(const std::string &query) override;
     virtual void _flushInsertBuffer() override;
 
     bool dirty;

--- a/src/tools.h
+++ b/src/tools.h
@@ -264,6 +264,17 @@ zmm::String fallbackString(zmm::String first, zmm::String fallback);
 /// \return return the (unsigned int) hash value
 unsigned int stringHash(zmm::String str);
 
+template <typename C, typename D>
+std::string join(const C &container, const D &delimiter) {
+    std::ostringstream buf;
+    auto it = container.begin();
+    while (it != container.end()) {
+        buf << *it;
+        if (std::next(it++) != container.end()) buf << delimiter;
+    }
+    return buf.str();
+}
+
 zmm::String toCSV(std::shared_ptr<std::unordered_set<int> > array);
 
 //inline void getTimeval(struct timeval *now) { gettimeofday(now, NULL); }

--- a/src/tools.h
+++ b/src/tools.h
@@ -33,6 +33,7 @@
 
 #include <memory>
 #include <unordered_set>
+#include <sstream>
 
 #include <sys/time.h>
 

--- a/src/url.cc
+++ b/src/url.cc
@@ -38,13 +38,11 @@
 #include "tools.h"
 #include "config_manager.h"
 
+#include <sstream>
+
 using namespace zmm;
 
-URL::URL(size_t buffer_hint) : buffer_hint(buffer_hint)
-{
-}
-
-Ref<StringBuffer> URL::download(String URL, long *HTTP_retcode, 
+std::string URL::download(String URL, long *HTTP_retcode,
                                 CURL *curl_handle, bool only_header, 
                                 bool verbose, bool redirect)
 {
@@ -60,7 +58,8 @@ Ref<StringBuffer> URL::download(String URL, long *HTTP_retcode,
             throw _Exception(_("Invalid curl handle!\n"));
     }
 
-    Ref<StringBuffer> buffer(new StringBuffer(buffer_hint));
+    //Ref<StringBuffer> buffer(new StringBuffer(buffer_hint));
+    std::ostringstream buffer;
 
     curl_easy_reset(curl_handle);
     
@@ -89,14 +88,12 @@ Ref<StringBuffer> URL::download(String URL, long *HTTP_retcode,
     {
         curl_easy_setopt(curl_handle, CURLOPT_NOBODY, 1);
         curl_easy_setopt(curl_handle, CURLOPT_HEADERFUNCTION, URL::dl);
-        curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, 
-                         (void *)buffer.getPtr());
+        curl_easy_setopt(curl_handle, CURLOPT_HEADERDATA, &buffer);
     }
     else
     {
         curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, URL::dl);
-        curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, 
-                         (void *)buffer.getPtr());
+        curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &buffer);
     }
 
     if (redirect)
@@ -126,7 +123,7 @@ Ref<StringBuffer> URL::download(String URL, long *HTTP_retcode,
     if (cleanup)
         curl_easy_cleanup(curl_handle);
 
-    return buffer;
+    return buffer.str();
 }
 
 Ref<URL::Stat> URL::getInfo(String URL, CURL *curl_handle)
@@ -149,7 +146,7 @@ Ref<URL::Stat> URL::getInfo(String URL, CURL *curl_handle)
             throw _Exception(_("Invalid curl handle!\n"));
     }
 
-    Ref<StringBuffer> buffer = download(URL, &retcode, curl_handle, true, true, true);
+    download(URL, &retcode, curl_handle, true, true, true);
     if (retcode != 200)
     {
         if (cleanup)
@@ -253,12 +250,10 @@ Ref<URL::Stat> URL::getInfo(String URL, CURL *curl_handle)
 
 size_t URL::dl(void *buf, size_t size, size_t nmemb, void *data)
 {
-    auto *buffer = (StringBuffer *)data;
-    if (buffer == nullptr)
-        return 0;
+    auto &oss = *reinterpret_cast<std::ostringstream *>(data);
 
     size_t s = size * nmemb;
-    *buffer << String((char *)buf, s);
+    oss << std::string(reinterpret_cast<const char *>(buf), s);
 
     return s;
 }

--- a/src/url.h
+++ b/src/url.h
@@ -36,6 +36,7 @@
 #define __URL_H__
 
 #include <curl/curl.h>
+#include <string>
 
 #include "zmm/zmmf.h"
 #include "zmm/zmm.h"
@@ -48,7 +49,7 @@ public:
     class Stat : public zmm::Object
     {
     public:
-        /// \brief Iinitalizes the class with given values, the values
+        /// \brief Initalizes the class with given values, the values
         /// can not be changed afterwards.
         ///
         /// \param size size of the media in bytes
@@ -67,10 +68,6 @@ public:
         off_t size;
         zmm::String mimetype;
     };
-    /// \brief Constructor allowing to hint the buffer size.
-    /// \param buffer_hint size of the buffer that will be preallocated
-    /// for the download, if too small it will be realloced.
-    URL(size_t buffer_hint = 1024*1024);
 
     /// \brief downloads either the content or the headers to the buffer.
     ///
@@ -83,7 +80,7 @@ public:
     /// \param only_header set true if you only want the header and not the
     /// body
     /// \param vebose enable curl verbose option
-    zmm::Ref<zmm::StringBuffer> download(zmm::String URL,
+    std::string download(zmm::String URL,
                                          long *HTTP_retcode, 
                                          CURL *curl_handle = NULL,
                                          bool only_header=false,
@@ -91,10 +88,8 @@ public:
                                          bool redirect=false);
 
     zmm::Ref<Stat> getInfo(zmm::String URL, CURL *curl_handle = NULL );
-protected:
-    size_t buffer_hint;
-    pthread_t pid;
 
+protected:
     /// \brief This function is installed as a callback for libcurl, when
     /// we download data from a remote site.
     static size_t dl(void *buf, size_t size, size_t nmemb, void *data);

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -129,7 +129,7 @@ void URLRequestHandler::get_info(IN const char *filename, OUT UpnpFileInfo *info
         }
 
         log_debug("Online content url: %s\n", url.c_str());
-        Ref<URL> u(new URL(1024));
+        Ref<URL> u(new URL());
         Ref<URL::Stat> st;
         try
         { 
@@ -243,7 +243,7 @@ Ref<IOHandler> URLRequestHandler::open(IN const char *filename,
     }
     else
     {
-        Ref<URL> u(new URL(1024));
+        Ref<URL> u(new URL());
         Ref<URL::Stat> st;
         try
         {

--- a/src/web_request_handler.cc
+++ b/src/web_request_handler.cc
@@ -122,7 +122,6 @@ void WebRequestHandler::get_info(IN const char* filename, OUT UpnpFileInfo* info
 Ref<IOHandler> WebRequestHandler::open(IN enum UpnpOpenFileMode mode)
 {
     root = Ref<Element>(new Element(_("root")));
-    out = Ref<StringBuffer>(new StringBuffer());
 
     String error = nullptr;
     int error_code = 0;

--- a/src/web_request_handler.h
+++ b/src/web_request_handler.h
@@ -67,12 +67,6 @@ protected:
     /// \brief We can also always see what mode was requested.
     enum UpnpOpenFileMode mode;
     
-    /// \brief This is filled during request processing and holds the output.
-    ///
-    /// The XML or HTML that is the result of a request is put in this buffer,
-    /// this is what is being served to the web browser.
-    zmm::Ref<zmm::StringBuffer> out;
-    
     /// \brief This is the root xml element to be populated by process() method.
     zmm::Ref<mxml::Element> root;
     

--- a/src/zmm/stringbuffer.cc
+++ b/src/zmm/stringbuffer.cc
@@ -35,6 +35,7 @@
 #include "memory.h"
 #include "strings.h"
 #include "exceptions.h"
+#include "atrailers_content_handler.h"
 
 using namespace zmm;
 
@@ -69,6 +70,10 @@ StringBuffer &StringBuffer::operator<<(String other)
         len += otherLen;
     }
     return *this;
+}
+
+StringBuffer &StringBuffer::operator<<(const std::string &other) {
+    return operator<<(String(other));
 }
 
 StringBuffer &StringBuffer::operator<<(Ref<StringBuffer> other)

--- a/src/zmm/stringbuffer.cc
+++ b/src/zmm/stringbuffer.cc
@@ -35,7 +35,6 @@
 #include "memory.h"
 #include "strings.h"
 #include "exceptions.h"
-#include "atrailers_content_handler.h"
 
 using namespace zmm;
 

--- a/src/zmm/stringbuffer.h
+++ b/src/zmm/stringbuffer.h
@@ -33,9 +33,19 @@
 #define __ZMM_STRINGBUFFER_H__
 
 #include "strings.h"
+#include <string>
 
 #define DEFAULT_STRINGBUFFER_CAPACITY 16
 #define STRINGBUFFER_CAPACITY_INCREMENT (1.25)
+
+#include <sstream>
+
+template <typename T>
+std::basic_ostream<T> &operator<<(std::basic_ostream<T> &oss, const zmm::String &s) {
+    oss << s.c_str();
+    return oss;
+}
+
 
 namespace zmm
 {
@@ -52,6 +62,7 @@ public:
     virtual ~StringBuffer();
     
     StringBuffer &operator<<(String other);
+    StringBuffer &operator<<(const std::string &other);
     StringBuffer &operator<<(Ref<StringBuffer> other);
     StringBuffer &operator<<(const char *str);
     StringBuffer &operator<<(signed char *str);
@@ -68,6 +79,9 @@ public:
     char *c_str(int offset = 0);
     String toString();
     String toString(int offset);
+    operator std::string() {
+        return std::string(data, len);
+    }
     void clear();
     void ensureCapacity(int neededCapacity);
     void setCharAt(int index, char c);

--- a/src/zmm/strings.cc
+++ b/src/zmm/strings.cc
@@ -123,6 +123,9 @@ String::String(Ref<StringBase> other)
     if(base)
         base->retain();
 }
+String::String(const std::string &other) : String(other.c_str(), other.length())
+{}
+
 String::~String()
 {
     if(base)
@@ -325,6 +328,12 @@ String& String::operator=(String other)
     base = other.base;
     if(base)
         base->retain();
+    return *this;
+}
+
+String &String::operator=(const std::string &other) {
+    base = new StringBase(other.c_str(), other.length());
+    base->retain();
     return *this;
 }
 

--- a/src/zmm/strings.h
+++ b/src/zmm/strings.h
@@ -92,6 +92,7 @@ public:
     String(const String &other);
     String(StringBase *other);
     String(Ref<StringBase> other);
+    String(const std::string &other);
 
     inline StringBase *getBase()
     {
@@ -108,6 +109,8 @@ public:
     String &operator=(const char *str);
 
     String &operator=(String other);
+
+    String &operator=(const std::string &other);
 
     inline String &operator=(std::nullptr_t)
     {


### PR DESCRIPTION
The only remaining occurrences of zmm::StringBuffer are essentially in sql_storage.cc. Once that's also converted to use std::ostringstream,zmm::StringBuffer can be eliminated.