### PR TITLE
Entware-ng/-3x merged into Entware

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Gerbera is avaiable on [software.opensuse.org](https://software.opensuse.org/pac
 Gerbera is included in [Testing](https://packages.debian.org/buster/gerbera) and [Unstable](https://packages.debian.org/sid/gerbera).
 
 ### Entware (Optware)
-Gerbera is available in [Entware-ng](https://github.com/Entware-ng/rtndev/tree/master/gerbera) for your embedded device/router!
+Gerbera is available in [Entware](https://github.com/Entware/rtndev/tree/master/gerbera) for your embedded device/router!
 
 ## Building
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -32,5 +32,5 @@ Gerbera is included in `Testing <https://packages.debian.org/buster/gerbera>`_ a
 .. index:: Optware
 
 **Entware (Optware)** -
-Gerbera is available in `Entware-ng <https://github.com/Entware-ng/rtndev/tree/master/gerbera>`_ for your embedded device/router!
+Gerbera is available in `Entware <https://github.com/Entware/rtndev/tree/master/gerbera>`_ for your embedded device/router!
 


### PR DESCRIPTION
Entware links [update](https://github.com/Entware/entware#entware-ng-3x-and-entware-ng-merged-to-become-entware).