### PR TITLE
Update test assertions for new UI toast

### DIFF
--- a/gerbera-web/test/client/fixtures/index.html
+++ b/gerbera-web/test/client/fixtures/index.html
@@ -175,8 +175,12 @@
     </div><!-- /.modal-dialog -->
 </div>
 
-<div id="toast" class="alert alert-warning">
-    <span class="grb-toast-msg"></span>
+<div id="toast" class="alert">
+    <div id="grb-toast-wrapper">
+        <i id="grb-toast-icon" class="fa fa-star"></i>
+        <span id="grb-toast-msg"></span>
+    </div>
+
     <button type="button" class="close" aria-label="Close">
         <span aria-hidden="true">&times;</span>
     </button>

--- a/gerbera-web/test/client/fixtures/toast.html
+++ b/gerbera-web/test/client/fixtures/toast.html
@@ -1,5 +1,9 @@
-<div id="toast" class="alert alert-warning">
-    <span class="grb-toast-msg"></span>
+<div id="toast" class="alert">
+    <div id="grb-toast-wrapper">
+        <i id="grb-toast-icon" class="fa fa-star"></i>
+        <span id="grb-toast-msg"></span>
+    </div>
+
     <button type="button" class="close" aria-label="Close">
         <span aria-hidden="true">&times;</span>
     </button>

--- a/gerbera-web/test/client/gerbera.app.spec.js
+++ b/gerbera-web/test/client/gerbera.app.spec.js
@@ -58,7 +58,7 @@ describe('Gerbera UI App', function () {
       })
 
       GERBERA.App.initialize().fail(function () {
-        expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Internal Server Error')
+        expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Internal Server Error', undefined, 'info', 'fa-exclamation-triangle')
         isDone()
       })
     })
@@ -71,7 +71,7 @@ describe('Gerbera UI App', function () {
       })
 
       GERBERA.App.initialize().fail(function () {
-        expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('The UI is disabled in the configuration file. See README.')
+        expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('The UI is disabled in the configuration file. See README.', undefined, 'warning', 'fa-exclamation-triangle')
         isDone()
       })
     })
@@ -160,7 +160,7 @@ describe('Gerbera UI App', function () {
       var event = 'Error Message'
       GERBERA.App.error(event)
 
-      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Error Message')
+      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Error Message', undefined, 'warning', 'fa-exclamation-triangle')
     })
 
     it('shows the event as error message when event has responseText', function () {
@@ -168,7 +168,7 @@ describe('Gerbera UI App', function () {
       var event = {responseText : 'Response Text Error'}
       GERBERA.App.error(event)
 
-      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Response Text Error')
+      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Response Text Error', undefined, 'info', 'fa-exclamation-triangle')
     })
 
     it('shows the event error taken from the response error', function () {
@@ -177,7 +177,7 @@ describe('Gerbera UI App', function () {
 
       GERBERA.App.error(event)
 
-      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('The UI is disabled in the configuration file. See README.')
+      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('The UI is disabled in the configuration file. See README.', undefined, 'warning', 'fa-exclamation-triangle')
     })
 
     it('shows unspecified error when event is invalid', function () {
@@ -186,7 +186,7 @@ describe('Gerbera UI App', function () {
 
       GERBERA.App.error(event)
 
-      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('The system encountered an error')
+      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('The system encountered an error', undefined, 'danger', 'fa-frown-o')
     })
   });
 })

--- a/gerbera-web/test/client/gerbera.autoscan.spec.js
+++ b/gerbera-web/test/client/gerbera.autoscan.spec.js
@@ -201,7 +201,7 @@ describe('Gerbera Autoscan', function () {
       spyOn(GERBERA.Updates, 'showMessage')
       GERBERA.Autoscan.submitComplete(response)
 
-      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Performing full scan: /Movies')
+      expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Performing full scan: /Movies', undefined, 'success', 'fa-check')
     })
 
     it('when successful for one-time scan reports message to user', function () {

--- a/gerbera-web/test/client/gerbera.trail.spec.js
+++ b/gerbera-web/test/client/gerbera.trail.spec.js
@@ -104,7 +104,7 @@ describe('Gerbera Trail', function () {
         expect(GERBERA.App.error).not.toHaveBeenCalled()
         expect(GERBERA.Items.deleteGerberaItem).toHaveBeenCalledWith(event.data)
         expect(GERBERA.Updates.updateTreeByIds).toHaveBeenCalled()
-        expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Successfully removed item')
+        expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Successfully removed item', undefined, 'success', 'fa-check')
         isDone()
       })
     })
@@ -132,7 +132,7 @@ describe('Gerbera Trail', function () {
           expect(GERBERA.App.error).not.toHaveBeenCalled()
           expect(GERBERA.Items.deleteGerberaItem).toHaveBeenCalledWith(event.data, true)
           expect(GERBERA.Updates.updateTreeByIds).toHaveBeenCalled()
-          expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Successfully deleted all items')
+          expect(GERBERA.Updates.showMessage).toHaveBeenCalledWith('Successfully removed all items', undefined, 'success', 'fa-check')
           isDone()
         })
       })
@@ -149,7 +149,7 @@ describe('Gerbera Trail', function () {
 
       GERBERA.Trail.deleteItem(event)
 
-      expect(GERBERA.App.error).toHaveBeenCalledWith('Failed to delete item')
+      expect(GERBERA.App.error).toHaveBeenCalledWith('Failed to remove item')
       expect(GERBERA.Updates.updateTreeByIds).not.toHaveBeenCalled()
     })
   })

--- a/gerbera-web/test/client/gerbera.updates.spec.js
+++ b/gerbera-web/test/client/gerbera.updates.spec.js
@@ -17,7 +17,7 @@ describe('Gerbera Updates', function () {
 
       GERBERA.Updates.showMessage('a message')
 
-      expect($.fn.toast).toHaveBeenCalledWith('show', {message: 'a message'})
+      expect($.fn.toast).toHaveBeenCalledWith('show', {message: 'a message', type: undefined, icon: undefined})
     })
   })
 

--- a/gerbera-web/test/client/jquery.gerbera.toast.spec.js
+++ b/gerbera-web/test/client/jquery.gerbera.toast.spec.js
@@ -31,7 +31,12 @@ describe('The jQuery Gerbera Toast Message', function () {
         done()
       }
 
-      toaster.toast('showTask', {message: 'This is a message', callback: testExpects})
+      toaster.toast('showTask', {
+        message: 'This is a message',
+        callback: testExpects,
+        type: 'success',
+        icon: 'fa-check'
+      })
     })
 
     it('has specific task style', function (done) {
@@ -41,7 +46,12 @@ describe('The jQuery Gerbera Toast Message', function () {
         done()
       }
 
-      toaster.toast('showTask', {message: 'This is a message', callback: testExpects})
+      toaster.toast('showTask', {
+        message: 'This is a message',
+        callback: testExpects,
+        type: 'success',
+        icon: 'fa-check'
+      })
     })
   })
 })

--- a/gerbera-web/test/e2e/delete.item.spec.js
+++ b/gerbera-web/test/e2e/delete.item.spec.js
@@ -50,7 +50,7 @@ test.describe('The gerbera delete item', function () {
       })
 
       homePage.getToastMessage().then(function (message) {
-        expect(message).to.equal('Successfully deleted item')
+        expect(message).to.equal('Successfully removed item')
       })
 
       homePage.waitForToastClose().then(function (displayed) {


### PR DESCRIPTION
Change UI test suite to support new UI toast message:

* Fix method assertions for `GERBERA.Updates.showMessage`
* Add new `toast` object to toast tests
* Update test HTML fixtures with **id** and **class** attributes
* Update E2E assertions for delete --> remove