### PR TITLE
227 rootpath still missing in js

### DIFF
--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -1318,8 +1318,6 @@ int ContentManager::addFile(zmm::String path, bool recursive, bool async,
 int ContentManager::addFile(zmm::String path, zmm::String rootpath, bool recursive, bool async,
     bool hidden, bool lowPriority, bool cancellable)
 {
-    //if (check_path(path, true))
-    //    rootpath = path;
     return addFileInternal(path, rootpath, recursive, async, hidden, lowPriority, 0, cancellable);
 }
 

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -1318,8 +1318,8 @@ int ContentManager::addFile(zmm::String path, bool recursive, bool async,
 int ContentManager::addFile(zmm::String path, zmm::String rootpath, bool recursive, bool async,
     bool hidden, bool lowPriority, bool cancellable)
 {
-    if (check_path(path, true))
-        rootpath = path;
+    //if (check_path(path, true))
+    //    rootpath = path;
     return addFileInternal(path, rootpath, recursive, async, hidden, lowPriority, 0, cancellable);
 }
 

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -1840,7 +1840,7 @@ void CMAddFileTask::run()
 {
     log_debug("running add file task with path %s recursive: %d\n", path.c_str(), recursive);
     Ref<ContentManager> cm = ContentManager::getInstance();
-    cm->_addFile(path, nullptr, recursive, hidden, Ref<GenericTask>(this));
+    cm->_addFile(path, rootpath, recursive, hidden, Ref<GenericTask>(this));
 }
 
 CMRemoveObjectTask::CMRemoveObjectTask(int objectID, bool all)


### PR DESCRIPTION
Dear gerbera maintainers,

I still encountered some problems regarding null values for object_script_path when renaming whole directories in inotify-watched sub-trees. I introduced some further code changes which seemed to have solved the problem.

Hope that helps!

Cheers --

    Torsten