### PR TITLE
First run documentation now mentions config generation

### DIFF
--- a/doc/config-overview.rst
+++ b/doc/config-overview.rst
@@ -35,9 +35,10 @@ The server configuration file has several options.  Below are links to the confi
 * :doc:`Online Content </config-online>`
 * :doc:`Transcode Content </config-transcode>`
 
+.. _generateConfig:
 
 Generating Configuration
-========================
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The gerbera runtime requires a configuration file to launch the application. Gerbera provides a command line utility
 ``--create-config`` to generate a standard ``config.xml`` file with defaults.  You will need to generate

--- a/doc/run.rst
+++ b/doc/run.rst
@@ -46,7 +46,8 @@ First Time Launch
 ~~~~~~~~~~~~~~~~~
 
 First time startup of Gerbera creates a folder called ``~/.config/gerbera`` in your home directory.
-Gerbera also generates a default server configuration file, called ``config.xml`` in the directory.
+You must generate a ``config.xml`` file for Gerbera to use.  Review the :ref:`Generating Configuration <generateConfig>`
+section of the documentation to see how to use ``gerbera`` to create a default configuration file.
 
 .. index:: Sqlite
 


### PR DESCRIPTION
* Make `Generating Configuration` a sub-topic of `Configuration Overview`
* Add link from `First Time Run` back to `Generating Configuration`

> Improve documentation following elimination of automatic configuration generation