### PR TITLE
Fix unit tests to be repeatable across versions

### DIFF
--- a/test/test_server/fixtures/mock-help.out
+++ b/test/test_server/fixtures/mock-help.out
@@ -1,12 +1,3 @@
-
-Gerbera UPnP Server version 1.2.0_alpha - http://gerbera.io/
-
-===============================================================================
-Gerbera is free software, covered by the GNU General Public License version 2
-
-Copyright 2016-2018 Gerbera Contributors.
-Gerbera is based on MediaTomb: Copyright 2005-2010 Gena Batsyan, Sergey Bostandzhyan, Leonhard Wimmer.
-===============================================================================
 Usage: gerbera [options]
 
 Supported options:

--- a/test/test_server/fixtures/mock-version.out
+++ b/test/test_server/fixtures/mock-version.out
@@ -1,9 +1,0 @@
-
-Gerbera UPnP Server version 1.2.0_alpha - http://gerbera.io/
-
-===============================================================================
-Gerbera is free software, covered by the GNU General Public License version 2
-
-Copyright 2016-2018 Gerbera Contributors.
-Gerbera is based on MediaTomb: Copyright 2005-2010 Gena Batsyan, Sergey Bostandzhyan, Leonhard Wimmer.
-===============================================================================

--- a/test/test_server/test_main.cc
+++ b/test/test_server/test_main.cc
@@ -45,17 +45,7 @@ TEST_F(ServerTest, ServerOutputsHelpInformation) {
   ss << CMAKE_BINARY_DIR <<  DIR_SEPARATOR << "gerbera --help 2>&1";
   std::string cmd = ss.str();
   std::string output = exec(cmd.c_str());
-  ASSERT_STREQ(output.c_str(), expectedOutput.c_str());
-}
-
-TEST_F(ServerTest, ServerOutputsVersionInformation) {
-  std::string expectedOutput = mockText("fixtures/mock-version.out");
-
-  std::stringstream ss;
-  ss << CMAKE_BINARY_DIR << DIR_SEPARATOR << "gerbera --version 2>&1";
-  std::string cmd = ss.str();
-  std::string output = exec(cmd.c_str());
-  ASSERT_STREQ(output.c_str(), expectedOutput.c_str());
+  ASSERT_THAT(output.c_str(), HasSubstr(expectedOutput.c_str()));
 }
 
 TEST_F(ServerTest, ServerOutputsCompileInformationIncludingGit) {


### PR DESCRIPTION
Fixes #293 

Initially objective was to cover the ability for the server to startup following configuration geneator changes in the `main.cc` class.  The signal to update version numbers via unit test validation is rather inconvenient.

Updated the tests to only validate Help Content.  I think this is a valid signal, so developers don't forget to include/modify help output.

Let me know if you think another approach would be more appropriate.

Thanks,
Eamonn