### PR TITLE
Fix atrailers build

### DIFF
--- a/src/string_converter.cc
+++ b/src/string_converter.cc
@@ -226,7 +226,7 @@ Ref<StringConverter> StringConverter::p2i()
 }
 #endif
 
-#if defined (HAVE_JS) || defined(HAVE_TAGLIB) || defined(YOUTUBE) || defined(HAVE_LIBMP4V2)
+#if defined (HAVE_JS) || defined(HAVE_TAGLIB) || defined(ATRAILERS)
 
 Ref<StringConverter> StringConverter::i2i()
 {

--- a/src/string_converter.h
+++ b/src/string_converter.h
@@ -66,7 +66,7 @@ public:
     static zmm::Ref<StringConverter> p2i();
 
 #endif
-#if defined(HAVE_JS) || defined(HAVE_TAGLIB) || defined(YOUTUBE) || defined(HAVE_LIBMP4V2)
+#if defined(HAVE_JS) || defined(HAVE_TAGLIB) || defined(ATRAILERS)
     /// \brief safeguard - internal to internal - needed to catch some
     /// scenarious where the user may have forgotten to add proper conversion
     /// in the script.


### PR DESCRIPTION
i2i function is used in atrailers_service.cc but this function is
defined only if defined(HAVE_JS) || defined(HAVE_TAGLIB) ||
defined(YOUTUBE) || defined(HAVE_LIBMP4V2) as a result compilation
fails if HAVE_CURL is set but HAVE_JS and HAVE_TAGLIG are not.
As youtube and libmp4v2 support have been dropped, replace those by
ATRAILERS in this list.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>