### PR TITLE
Readme.md: specify that zlib is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ sudo make install
 | expat        	|         	| Required  	|                      	     |                     |          |
 | libiconv     	|         	| Required  	|                      	     |                     |          |
 | sqlite3      	|         	| Required  	| Database storage     	     |                     |          |
+| zlib          |        	| Required  	|                            |                     |          |
 | duktape      	| 2.1.0   	| Optional  	| Scripting Support    	     | WITH_JS             | Enabled  |
 | mysql        	|         	| Optional  	| Alternate database storage | WITH_MYSQL          | Disabled |
 | curl         	|         	| Optional  	| Enables web services 	     | WITH_CURL           | Enabled  |


### PR DESCRIPTION
zlib was optional but highly recommended in mediatomb. In gerbera, this
is a mandatory dependency as zlib is used by sqlite3 storage which is
mandatory.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>