### PR TITLE
Fix #310 - Config Generator to use native BSD UUID when available

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -29,7 +29,11 @@ Gerbera - https://gerbera.io/
 #include <common.h>
 #include <tools.h>
 #include <metadata_handler.h>
+#ifdef BSD_NATIVE_UUID
+#include <uuid.h>
+#else
 #include <uuid/uuid.h>
+#endif
 #include "config_generator.h"
 
 using namespace zmm;


### PR DESCRIPTION
The method code **does** use native UUID, but the import did not.