### PR TITLE
Use Chrome Headless for E2E Suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,10 +64,6 @@ matrix:
       before_install: skip
       install:
         - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web/ install $TRAVIS_BUILD_DIR/gerbera-web/
-      before_script:
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start
-        - sleep 3 # give xvfb some time to start
       script:
         - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run lint
         - npm --prefix $TRAVIS_BUILD_DIR/gerbera-web run test

--- a/gerbera-web/test/e2e/add.object.spec.js
+++ b/gerbera-web/test/e2e/add.object.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/autoscan.spec.js
+++ b/gerbera-web/test/e2e/autoscan.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/delete.item.spec.js
+++ b/gerbera-web/test/e2e/delete.item.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/items.spec.js
+++ b/gerbera-web/test/e2e/items.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/login.spec.js
+++ b/gerbera-web/test/e2e/login.spec.js
@@ -12,7 +12,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/logout.spec.js
+++ b/gerbera-web/test/e2e/logout.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/menu.spec.js
+++ b/gerbera-web/test/e2e/menu.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/overlay.spec.js
+++ b/gerbera-web/test/e2e/overlay.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/toast.spec.js
+++ b/gerbera-web/test/e2e/toast.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)

--- a/gerbera-web/test/e2e/trail.spec.js
+++ b/gerbera-web/test/e2e/trail.spec.js
@@ -13,7 +13,7 @@ suite(() => {
 
   before(async () => {
     const chromeOptions = new chrome.Options();
-    chromeOptions.addArguments(['--window-size=1280,1024']);
+    chromeOptions.addArguments(['--headless', '--window-size=1280,1024']);
     driver = new Builder()
       .forBrowser('chrome')
       .setChromeOptions(chromeOptions)


### PR DESCRIPTION
The E2E suite used Xvfb to hide the Chrome window when running in Travis CI.

Chrome Headless is now the common testing tool for the E2E and Unit Test suites.

------------
* Use Chrome Headless for E2E
* Remove Xvfb in favor of Chrome Headless