### PR TITLE
Improve accuracy of error message for missing config

### DIFF
--- a/src/config_manager.cc
+++ b/src/config_manager.cc
@@ -113,7 +113,14 @@ void ConfigManager::init()
         if (check_path(home + DIR_SEPARATOR + DEFAULT_CONFIG_NAME)) {
             filename = home + DIR_SEPARATOR + DEFAULT_CONFIG_NAME;
         } else {
-            throw _Exception(_("\nThe server configuration file could not be found in ~/.config/gerbera\n") + "Gerbera could not find a default configuration file.\n" + "Try specifying an alternative configuration file on the command line.\n" + "For a list of options run: gerbera -h\n");
+            std::ostringstream expErrMsg;
+            expErrMsg << "\nThe server configuration file could not be found in: ";
+            expErrMsg << home << "\n";
+            expErrMsg << "Gerbera could not find a default configuration file.\n";
+            expErrMsg << "Try specifying an alternative configuration file on the command line.\n";
+            expErrMsg << "For a list of options run: gerbera -h\n";
+
+            throw _Exception(expErrMsg.str());
         }
     }
 

--- a/test/test_config/test_configmanager.cc
+++ b/test/test_config/test_configmanager.cc
@@ -113,11 +113,24 @@ TEST_F(ConfigManagerTest, LoadsWebUIDefaultValues) {
 }
 
 TEST_F(ConfigManagerTest, ThrowsExceptionWhenMissingConfigFileAndNoDefault) {
-  config_file = nullptr;
+  std::ostringstream expErrMsg;
   std::string notExistsDir = home + DIR_SEPARATOR + "not_exists";
+
+  expErrMsg << "\nThe server configuration file could not be found in: ";
+  expErrMsg << notExistsDir << DIR_SEPARATOR << confdir << "\n";
+  expErrMsg << "Gerbera could not find a default configuration file.\n";
+  expErrMsg << "Try specifying an alternative configuration file on the command line.\n";
+  expErrMsg << "For a list of options run: gerbera -h\n";
+
+  config_file = nullptr;
+
   subject->setStaticArgs(config_file, _(notExistsDir.c_str()), _(confdir.c_str()), _(prefix.c_str()), _(magic.c_str()));
 
-  ASSERT_THROW(subject->init(), zmm::Exception);
+  try {
+    subject->init();
+  }catch(zmm::Exception const & err) {
+    EXPECT_EQ(err.getMessage(), expErrMsg.str());
+  }
 }
 
 TEST_F(ConfigManagerTest, LoadsConfigFromDefaultHomeWhenExistsButNotSpecified) {


### PR DESCRIPTION
Utilize `home` variable and improve inline message format using `std::ostringstream`

Fixes #329 

**Example**
```
The server configuration file could not be found in: ~/.config/gerbera
Gerbera could not find a default configuration file.
Try specifying an alternative configuration file on the command line.
For a list of options run: gerbera -h
```