### PR TITLE
Adds WavPack file extension to config

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -282,6 +282,7 @@ Ref<Element> ConfigGenerator::generateMappings() {
   ext2mt->appendElementChild(map_from_to("mka", "audio/x-matroska"));
   ext2mt->appendElementChild(map_from_to("dsf", "audio/x-dsd"));
   ext2mt->appendElementChild(map_from_to("dff", "audio/x-dsd"));
+  ext2mt->appendElementChild(map_from_to("wv", "audio/x-wavpack"));
 
   Ref<Comment> ps3info(new Comment(_(" Uncomment the line below for PS3 divx support "), true));
   Ref<Comment> ps3avi(new Comment(_(" <map from=\"avi\" to=\"video/divx\"/> "), true));

--- a/test/test_config/fixtures/mock-config-all.xml
+++ b/test/test_config/fixtures/mock-config-all.xml
@@ -98,6 +98,7 @@
         <map from="mka" to="audio/x-matroska"/>
         <map from="dsf" to="audio/x-dsd"/>
         <map from="dff" to="audio/x-dsd"/>
+        <map from="wv" to="audio/x-wavpack"/>
         <!-- Uncomment the line below for PS3 divx support -->
         <!-- <map from="avi" to="video/divx"/> -->
         <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/test_config/fixtures/mock-config-minimal.xml
+++ b/test/test_config/fixtures/mock-config-minimal.xml
@@ -86,6 +86,7 @@
         <map from="mka" to="audio/x-matroska"/>
         <map from="dsf" to="audio/x-dsd"/>
         <map from="dff" to="audio/x-dsd"/>
+        <map from="wv" to="audio/x-wavpack"/>
         <!-- Uncomment the line below for PS3 divx support -->
         <!-- <map from="avi" to="video/divx"/> -->
         <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/test_config/fixtures/mock-import-magic-js-online.xml
+++ b/test/test_config/fixtures/mock-import-magic-js-online.xml
@@ -30,6 +30,7 @@
       <map from="mka" to="audio/x-matroska"/>
       <map from="dsf" to="audio/x-dsd"/>
       <map from="dff" to="audio/x-dsd"/>
+      <map from="wv" to="audio/x-wavpack"/>
       <!-- Uncomment the line below for PS3 divx support -->
       <!-- <map from="avi" to="video/divx"/> -->
       <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/test_config/fixtures/mock-import-magic-js.xml
+++ b/test/test_config/fixtures/mock-import-magic-js.xml
@@ -30,6 +30,7 @@
       <map from="mka" to="audio/x-matroska"/>
       <map from="dsf" to="audio/x-dsd"/>
       <map from="dff" to="audio/x-dsd"/>
+      <map from="wv" to="audio/x-wavpack"/>
       <!-- Uncomment the line below for PS3 divx support -->
       <!-- <map from="avi" to="video/divx"/> -->
       <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/test_config/fixtures/mock-import-mappings.xml
+++ b/test/test_config/fixtures/mock-import-mappings.xml
@@ -21,6 +21,7 @@
     <map from="mka" to="audio/x-matroska"/>
     <map from="dsf" to="audio/x-dsd"/>
     <map from="dff" to="audio/x-dsd"/>
+    <map from="wv" to="audio/x-wavpack"/>
     <!-- Uncomment the line below for PS3 divx support -->
     <!-- <map from="avi" to="video/divx"/> -->
     <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/test_config/fixtures/mock-import-none.xml
+++ b/test/test_config/fixtures/mock-import-none.xml
@@ -25,6 +25,7 @@
       <map from="mka" to="audio/x-matroska"/>
       <map from="dsf" to="audio/x-dsd"/>
       <map from="dff" to="audio/x-dsd"/>
+      <map from="wv" to="audio/x-wavpack"/>
       <!-- Uncomment the line below for PS3 divx support -->
       <!-- <map from="avi" to="video/divx"/> -->
       <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->


### PR DESCRIPTION
Seemed like this should be there by default given that all other supported file-types are. 