### PR TITLE
Adds Resource Attributes to scripting.

### DIFF
--- a/scripts/js/import.js
+++ b/scripts/js/import.js
@@ -91,6 +91,19 @@ function addAudio(obj) {
     // comment the following line out if you uncomment the stuff above  :)
     var track = '';
 
+// uncomment this if you want to have channel numbers in front of the title
+/*
+    var channels = obj.res[R_NRAUDIOCHANNELS];
+    if (channels) {
+        if (channels === "1") {
+            track = track + '[MONO]';
+        } else if (channels === "2") {
+            track = track + '[STEREO]';
+        } else {
+            track = track + '[MULTI]';
+        }
+    }
+*/
     var chain = ['Audio', 'All Audio'];
     obj.title = title;
     addCdsObject(obj, createContainerChain(chain));

--- a/src/scripting/script.cc
+++ b/src/scripting/script.cc
@@ -177,6 +177,11 @@ Script::Script(Ref<Runtime> runtime, std::string name) : Object(), name(name)
     {
         duk_push_string(ctx, MT_KEYS[i].upnp); duk_put_global_string(ctx, MT_KEYS[i].sym);
     }
+
+    for (int i = 0; i < R_MAX; i++)
+    {
+        duk_push_string(ctx, RES_KEYS[i].upnp); duk_put_global_string(ctx, RES_KEYS[i].sym);
+    }
  
     duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_ALBUM); duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_ALBUM");
     duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_ARTIST); duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_ARTIST");
@@ -631,7 +636,27 @@ void Script::cdsObject2dukObject(Ref<CdsObject> obj)
     }
 
 
-    /// \todo add resources
+    // setting resource
+    {
+        duk_push_object(ctx);
+        // stack: js res_js
+
+        if (obj->getResourceCount() > 0) {
+            auto res = obj->getResource(0);
+
+            auto attributes = res->getAttributes();
+            auto elements = attributes->getElements();
+            auto len = elements->size();
+            for (auto i = 0; i < len; i++)
+            {
+                Ref<DictionaryElement> el = elements->get(i);
+                setProperty(el->getKey(), el->getValue());
+            }
+        }
+
+        duk_put_prop_string(ctx, -2, "res");
+        // stack: js
+    }
 
     // CdsItem
     if (IS_CDS_ITEM(objectType))

--- a/test/test_script/mock/script_test_fixture.cc
+++ b/test/test_script/mock/script_test_fixture.cc
@@ -34,10 +34,12 @@ void ScriptTestFixture::TearDown() {
 }
 
 duk_ret_t ScriptTestFixture::dukMockItem(duk_context *ctx, string mimetype, string id, int theora, string title,
-  map<string, string> meta, map<string, string> aux, string location, int online_service) {
+map<string, string> meta, map<string, string> aux, map<string, string> res,
+                                         string location, int online_service) {
   duk_idx_t orig_idx;
   duk_idx_t meta_idx;
   duk_idx_t aux_idx;
+  duk_idx_t res_idx;
   const string OBJECT_NAME = "orig";
   orig_idx = duk_push_object(ctx);
   duk_push_string(ctx, mimetype.c_str()); duk_put_prop_string(ctx, orig_idx, "mimetype");
@@ -54,6 +56,16 @@ duk_ret_t ScriptTestFixture::dukMockItem(duk_context *ctx, string mimetype, stri
     duk_put_prop_string(ctx, meta_idx, val.first.c_str());
   }
   duk_put_prop_string(ctx, orig_idx, "meta");
+
+  // obj.res
+  if(!res.empty()) {
+    res_idx = duk_push_object(ctx);
+    for (auto const &val: res) {
+      duk_push_string(ctx, val.second.c_str());
+      duk_put_prop_string(ctx, res_idx, val.first.c_str());
+    }
+    duk_put_prop_string(ctx, orig_idx, "res");
+  }
 
   // obj.aux
   if(!aux.empty()) {
@@ -101,6 +113,11 @@ void ScriptTestFixture::addGlobalFunctions(duk_context *ctx, const duk_function_
   for (int i = 0; i < M_MAX; i++)
   {
     duk_push_string(ctx, MT_KEYS[i].upnp); duk_put_global_string(ctx, MT_KEYS[i].sym);
+  }
+
+  for (int i = 0; i < R_MAX; i++)
+  {
+    duk_push_string(ctx, RES_KEYS[i].upnp); duk_put_global_string(ctx, RES_KEYS[i].sym);
   }
 
   duk_push_int(ctx, OBJECT_TYPE_ITEM_EXTERNAL_URL); duk_put_global_string(ctx, "OBJECT_TYPE_ITEM_EXTERNAL_URL");

--- a/test/test_script/mock/script_test_fixture.h
+++ b/test/test_script/mock/script_test_fixture.h
@@ -49,7 +49,8 @@ class ScriptTestFixture : public ::testing::Test {
 
   // Creates a mock item(orig) global object in Duktape context
   duk_ret_t dukMockItem(duk_context *ctx, string mimetype, string id, int theora, string title,
-                        map<string, string> meta, map<string, string> aux, string location, int online_service);
+                        map<string, string> meta, map<string, string> aux, map<string, string> res,
+                        string location, int online_service);
 
   // Creates a mock playlist global object in Duktape context
   duk_ret_t dukMockPlaylist(duk_context* ctx, string title, string location, string mimetype);

--- a/test/test_script/test_import_script.cc
+++ b/test/test_script/test_import_script.cc
@@ -116,6 +116,7 @@ TEST_F(ImportScriptTest, AddsAudioItemToVariousCdsContainerChains) {
   string desc = "Description";
   string id = "2";
   string location = "/home/gerbera/audio.mp3";
+  string channels = "2";
   int online_service = 0;
   int theora = 0;
   map<string, string> aux;
@@ -127,6 +128,10 @@ TEST_F(ImportScriptTest, AddsAudioItemToVariousCdsContainerChains) {
       make_pair("dc:date", date),
       make_pair("upnp:genre", genre),
       make_pair("dc:description", desc)
+  };
+
+  map<string, string> res = {
+      make_pair("res['nrAudioChannels']", channels)
   };
 
   // Represents the values passed to `addCdsObject`, extracted from keys defined there.
@@ -190,7 +195,7 @@ TEST_F(ImportScriptTest, AddsAudioItemToVariousCdsContainerChains) {
       "\\/Audio\\/Year\\/2018", "undefined")).WillOnce(Return(0));
 
   addGlobalFunctions(ctx, js_global_functions);
-  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, location, online_service);
+  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, res, location, online_service);
   executeScript(ctx);
 }
 
@@ -203,6 +208,7 @@ TEST_F(ImportScriptTest, AddsVideoItemToCdsContainerChainWithDirs) {
   int theora = 0;
   map<string, string> aux;
   map<string, string> meta;
+  map<string, string> res;
 
   // Represents the values passed to `addCdsObject`, extracted from keys defined there.
   map<string, string> asVideoAllVideo = {
@@ -225,7 +231,7 @@ TEST_F(ImportScriptTest, AddsVideoItemToCdsContainerChainWithDirs) {
     "\\/Video\\/Directories\\/home\\/gerbera", "undefined")).WillOnce(Return(0));
 
   addGlobalFunctions(ctx, js_global_functions);
-  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, location, online_service);
+  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, res, location, online_service);
   executeScript(ctx);
 }
 
@@ -238,6 +244,7 @@ TEST_F(ImportScriptTest, AddsAppleTrailerVideoItemToCdsContainerChains) {
   string location = "/home/gerbera/video.mp4";
   int online_service = (int)OS_ATrailers;
   int theora = 0;
+  map<string, string> res;
 
   map<string, string> meta = {
     make_pair("dc:date", date),
@@ -277,7 +284,7 @@ TEST_F(ImportScriptTest, AddsAppleTrailerVideoItemToCdsContainerChains) {
     "\\/Online Services\\/Apple Trailers\\/Post Date\\/2018-01", "undefined")).WillOnce(Return(0));
 
   addGlobalFunctions(ctx, js_global_functions);
-  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, location, online_service);
+  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, res, location, online_service);
   executeScript(ctx);
 }
 
@@ -295,6 +302,7 @@ TEST_F(ImportScriptTest, AddsImageItemToCdsContainerChains) {
   };
 
   map<string, string> aux;
+  map<string, string> res;
 
   // Represents the values passed to `addCdsObject`, extracted from keys defined there.
   map<string, string> asImagePhotos = {
@@ -326,7 +334,7 @@ TEST_F(ImportScriptTest, AddsImageItemToCdsContainerChains) {
     "\\/Photos\\/Directories\\/home\\/gerbera", "undefined")).WillOnce(Return(0));
 
   addGlobalFunctions(ctx, js_global_functions);
-  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, location, online_service);
+  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, res, location, online_service);
   executeScript(ctx);
 }
 
@@ -339,6 +347,7 @@ TEST_F(ImportScriptTest, AddsOggTheoraVideoItemToCdsContainerChainWithDirs) {
   int theora = 1;
   map<string, string> aux;
   map<string, string> meta;
+  map<string, string> res;
 
   // Represents the values passed to `addCdsObject`, extracted from keys defined there.
   map<string, string> asVideoAllVideo = {
@@ -361,7 +370,7 @@ TEST_F(ImportScriptTest, AddsOggTheoraVideoItemToCdsContainerChainWithDirs) {
     "\\/Video\\/Directories\\/home\\/gerbera", "undefined")).WillOnce(Return(0));
 
   addGlobalFunctions(ctx, js_global_functions);
-  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, location, online_service);
+  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, res, location, online_service);
   executeScript(ctx);
 }
 
@@ -375,6 +384,7 @@ TEST_F(ImportScriptTest, AddsOggTheoraAudioItemToVariousCdsContainerChains) {
   string desc = "Description";
   string id = "2";
   string location = "/home/gerbera/audio.mp3";
+  string channels = "2";
   int online_service = 0;
   int theora = 0;
   map<string, string> aux;
@@ -386,6 +396,10 @@ TEST_F(ImportScriptTest, AddsOggTheoraAudioItemToVariousCdsContainerChains) {
     make_pair("dc:date", date),
     make_pair("upnp:genre", genre),
     make_pair("dc:description", desc)
+  };
+
+  map<string, string> res = {
+    make_pair("res['nrAudioChannels']", channels)
   };
 
   // Represents the values passed to `addCdsObject`, extracted from keys defined there.
@@ -448,7 +462,7 @@ TEST_F(ImportScriptTest, AddsOggTheoraAudioItemToVariousCdsContainerChains) {
     "\\/Audio\\/Year\\/2018", "undefined")).WillOnce(Return(0));
 
   addGlobalFunctions(ctx, js_global_functions);
-  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, location, online_service);
+  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, res, location, online_service);
   executeScript(ctx);
 }
 

--- a/test/test_script/test_import_struct_script.cc
+++ b/test/test_script/test_import_struct_script.cc
@@ -125,6 +125,7 @@ TEST_F(ImportStructuredScriptTest, AddsAudioItemWithABCBoxFormat) {
   int online_service = 0;
   int theora = 0;
   map<string, string> aux;
+  map<string, string> res;
 
   map<string, string> meta = {
     make_pair("dc:title", title),
@@ -255,7 +256,7 @@ TEST_F(ImportStructuredScriptTest, AddsAudioItemWithABCBoxFormat) {
      "\\/-Year-\\/2010 - 2019\\/2018\\/Artist\\/Album", "object.container.album.musicAlbum")).WillOnce(Return(0));
 
   addGlobalFunctions(ctx, js_global_functions);
-  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, location, online_service);
+  dukMockItem(ctx, mimetype, id, theora, title, meta, aux, res, location, online_service);
   executeScript(ctx);
 }
 


### PR DESCRIPTION
Looks like this was a pending todo in the code. Primarily useful for dealing with Stereo & Multichannel audio in your collection.

Only part I was not too sure about was `res = obj->getResource(0);`. I only found one resource to ever be used and didn't know how key collisions should be handled so left it as is. 

Let me know if I should change it.