### PR TITLE
Removing sudo dependecy and fixing shellcheck warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install -y uuid-dev libexpat1-dev libsqlite3-dev libmysqlclient-dev libmagic-dev libexif-dev libcurl4-openssl-dev cmake
+  - sudo apt-get install -y uuid-dev libexpat1-dev libsqlite3-dev libmysqlclient-dev libmagic-dev libexif-dev libcurl4-openssl-dev cmake3
   - sudo ./scripts/install-duktape.sh
   - sudo ./scripts/install-pupnp18.sh
   - sudo ./scripts/install-taglib111.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,10 @@ addons:
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y uuid-dev libexpat1-dev libsqlite3-dev libmysqlclient-dev libmagic-dev libexif-dev libcurl4-openssl-dev cmake
-  - ./scripts/install-duktape.sh
-  - ./scripts/install-pupnp18.sh
-  - ./scripts/install-taglib111.sh
-  - ./scripts/install-googletest.sh
+  - sudo ./scripts/install-duktape.sh
+  - sudo ./scripts/install-pupnp18.sh
+  - sudo ./scripts/install-taglib111.sh
+  - sudo ./scripts/install-googletest.sh
 
 # Build
 script:

--- a/scripts/install-duktape.sh
+++ b/scripts/install-duktape.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
+if ! [ "$(id -u)" = 0 ]; then
+    echo "Please run this script with superuser access!"
+    exit 1
+fi
 set -ex
 
 makeCMD="make"
-unamestr=`uname`
+unamestr=$(uname)
 if [ "$unamestr" == 'FreeBSD' ]; then
    makeCMD="gmake"
 fi
@@ -17,5 +21,5 @@ if [ "$unamestr" == 'Darwin' ]; then
   sed -i -e 's/-soname/-install_name/g' Makefile.sharedlibrary
 fi
 
-$makeCMD -f Makefile.sharedlibrary && sudo $makeCMD -f Makefile.sharedlibrary install\
- && sudo ldconfig
+$makeCMD -f Makefile.sharedlibrary && $makeCMD -f Makefile.sharedlibrary install\
+ && ldconfig

--- a/scripts/install-googletest.sh
+++ b/scripts/install-googletest.sh
@@ -1,28 +1,32 @@
 #!/usr/bin/env bash
+if ! [ "$(id -u)" = 0 ]; then
+    echo "Please run this script with superuser access!"
+    exit 1
+fi
 ##
 ## Install the latest version of GoogleTest
 ##
 pwd=$(pwd)
-unamestr=`uname`
-if [ -f "$pwd/master.zip" ]; then rm -f $pwd/master.zip; fi
-if [ -d "$pwd/googletest-master" ]; then rm -Rf $pwd/googletest-master; fi
+unamestr=$(uname)
+if [ -f "$pwd/master.zip" ]; then rm -f "$pwd/master.zip"; fi
+if [ -d "$pwd/googletest-master" ]; then rm -Rf "$pwd/googletest-master"; fi
 
 ## Download GoogleTest from GitHub
 wget https://github.com/google/googletest/archive/master.zip
 unzip master.zip
-cd googletest-master
+cd googletest-master || exit 1
 
 ## Build GoogleTest using CMake
-mkdir build && cd build
+mkdir build && cd build || exit 1
 if [[ $CXX == clang++* ]]; then
 	cmake -DCMAKE_CXX_FLAGS="-stdlib=libc++" ../
 else
 	cmake ../
 fi
-make && sudo make install
+make && make install
 
 if [ "$unamestr" != 'Darwin' ]; then
-    sudo ldconfig
+    ldconfig
 fi
 
-cd $pwd
+cd "$pwd" || exit 1

--- a/scripts/install-lastfm.sh
+++ b/scripts/install-lastfm.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if ! [ "$(id -u)" = 0 ]; then
+    echo "Please run this script with superuser access!"
+    exit 1
+fi
 set -ex
 LASTFM_VERSION="0.4.0"
 wget "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/lastfmlib/lastfmlib-${LASTFM_VERSION}.tar.gz"
@@ -6,5 +10,5 @@ tar -xzvf "lastfmlib-${LASTFM_VERSION}.tar.gz"
 cd "lastfmlib-${LASTFM_VERSION}"
 ./configure --prefix=/usr/local
 make
-sudo make install
-sudo ldconfig
+make install
+ldconfig

--- a/scripts/install-pupnp18.sh
+++ b/scripts/install-pupnp18.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
+if ! [ "$(id -u)" = 0 ]; then
+    echo "Please run this script with superuser access!"
+    exit 1
+fi
 set -ex
 
-unamestr=`uname`
+unamestr=$(uname)
 if [ "$unamestr" == 'FreeBSD' ]; then
    extraFlags=""
 else
@@ -11,5 +15,5 @@ fi
 wget https://github.com/mrjimenez/pupnp/archive/release-1.8.3.tar.gz -O pupnp-1.8.3.tgz
 tar -xzvf pupnp-1.8.3.tgz
 cd pupnp-release-1.8.3
-./bootstrap && ./configure $extraFlags --enable-ipv6 --enable-reuseaddr && make && sudo make install\
- && sudo ldconfig
+./bootstrap && ./configure $extraFlags --enable-ipv6 --enable-reuseaddr && make && make install\
+ && ldconfig

--- a/scripts/install-taglib111.sh
+++ b/scripts/install-taglib111.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+if ! [ "$(id -u)" = 0 ]; then
+    echo "Please run this script with superuser access!"
+    exit 1
+fi
 set -ex
 wget http://taglib.github.io/releases/taglib-1.11.1.tar.gz
 tar -xzvf taglib-1.11.1.tar.gz
@@ -9,4 +13,4 @@ if [[ $CXX == clang++* ]]; then
 else
 	cmake ../taglib-1.11.1
 fi
-make && sudo make install && sudo ldconfig
+make && make install && ldconfig

--- a/scripts/search.sh
+++ b/scripts/search.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-egrep -R -- "$1" src/ |grep -v '\.svn'  | grep -v '~'
+grep  -E -R -- "$1" src/ |grep -v '\.svn'  | grep -v '~'


### PR DESCRIPTION
Hey everybody,
I just recently tried to install gerbera on a fresh FreeBSD Jail and the installation script failed because I did not had sudo installed. So I just changed the scripts. Also this is my first pull request ever so please be kind ;)

Remove the sudo dependecy in the install scripts and added a
if-statement to check if the script is run with superuser access to
    perform the install.
This removes the need to have sudo installed and also has a better
error-handeling if the user types in the root password wrong 3 times.

Fixed shellcheck warnings which should result in robuster code.