### PR TITLE
Update cache-dir documentation for thumbnails

### DIFF
--- a/config/config2.xsd
+++ b/config/config2.xsd
@@ -158,6 +158,7 @@
     <xs:element name="ffmpegthumbnailer">
         <xs:complexType>
             <xs:all>
+                <xs:element ref="cache-dir" minOccurs="0"/>
                 <xs:element ref="thumbnail-size" minOccurs="1"/>
                 <xs:element ref="seek-percentage" minOccurs="1"/>
                 <xs:element ref="filmstrip-overlay" minOccurs="0"/>
@@ -177,6 +178,11 @@
         </xs:simpleType>
     </xs:element>
 
+    <xs:element name="cache-dir">
+        <xs:complexType>
+            <xs:attribute name="enabled" type="boolean" default="yes"/>
+        </xs:complexType>
+    </xs:element>
     <xs:element name="thumbnail-size" type="xs:positiveInteger" default="128"/>
     <xs:element name="seek-percentage" type="xs:positiveInteger" default="5"/>
     <xs:element name="workaround-bugs" default="no">

--- a/doc/config-extended.rst
+++ b/doc/config-extended.rst
@@ -41,6 +41,27 @@ ones offered by the ffmpegthumbnailer command line application). All tags below 
 
     ::
 
+        <cache-dir enabled="yes">/home/gerbera/cache-dir</cache-dir>
+
+    * Optional
+    * Default: **<gerbera-home>/cache-dir**
+
+    Storage location for the thumbnail cache when FFMPEGThumbnailer is enabled.  Defaults to Gerbera Home.
+    Creates a thumbnail with file format as: ``<movie-filename>-thumb.jpg``
+
+    The attributes of the tag have the following meaning:
+
+    ::
+
+            enabled=...
+
+    * Optional
+    * Default: **yes**
+
+    Enables or disables the use of cache directory for thumbnails, set to ``yes`` to enable the feature.
+
+    ::
+
         <thumbnail-size>128</thumbnail-size>
 
     * Optional


### PR DESCRIPTION
Fixes #347 - Add `<cache-dir>` to `config2.xsd` and to documentation.