### PR TITLE
Update UDN startup doc, cleanup other startup info

### DIFF
--- a/doc/config-server.rst
+++ b/doc/config-server.rst
@@ -171,11 +171,11 @@ page of the device.
     <udn/>
 
 * Required
-* Default: **automatically generated if the tag is empty**
+* Default: **none**
 
 Unique Device Name, according to the UPnP spec it must be consistent throughout reboots. You can fill in something
-yourself, but we suggest that you leave this tag empty - it will be filled out and saved automatically after the
-first launch of the server.
+yourself.  Review the :ref:`Generating Configuration <generateConfig>` section of the documentation to see how to use
+``gerbera`` to create a default configuration file.
 
 ``home``
 ~~~~~~~~

--- a/doc/daemon.rst
+++ b/doc/daemon.rst
@@ -41,7 +41,7 @@ Verify that the ``gerbera`` user was created
 Set Gerbera Permissions
 -----------------------
 
-Gerbera creates a default ``config.xml`` file on startup.  The **gerbera** user must have access to this file and
+The **gerbera** user must have access to ``config.xml`` file and
 to the directory referenced as the gerbera home.  For example ``/etc/gerbera``
 
 ::


### PR DESCRIPTION
Remove invalid startup information from documentation, including:
* UDN generation
* Daemon startup

Fixes #350 