### PR TITLE
Add Server Name to Web UI Menu & Title

### DIFF
--- a/gerbera-web/mock-api/auth/config.json
+++ b/gerbera-web/mock-api/auth/config.json
@@ -19,6 +19,7 @@
     },
     "actions": {
       "action": []
-    }
+    },
+    "friendlyName" : "Gerbera Media Server"
   }
 }

--- a/gerbera-web/test/client/fixtures/config.json
+++ b/gerbera-web/test/client/fixtures/config.json
@@ -17,6 +17,7 @@
     },
     "actions": {
       "action": []
-    }
+    },
+    "friendlyName" : "Gerbera Media Server"
   }
 }

--- a/gerbera-web/test/client/fixtures/converted-config.json
+++ b/gerbera-web/test/client/fixtures/converted-config.json
@@ -17,6 +17,7 @@
     },
     "actions": {
       "action": []
-    }
+    },
+    "friendlyName" : "Gerbera Media Server"
   }
 }

--- a/gerbera-web/test/client/gerbera.app.spec.js
+++ b/gerbera-web/test/client/gerbera.app.spec.js
@@ -45,6 +45,7 @@ describe('Gerbera UI App', () => {
 
       expect(GERBERA.App.serverConfig).toEqual(convertedConfig.config);
       expect(GERBERA.Auth.checkSID).toHaveBeenCalled();
+      expect($(document).attr('title')).toBe('Gerbera Media Server');
     });
 
     it('reports an error when the ajax calls fails', async () => {

--- a/gerbera-web/test/client/gerbera.menu.spec.js
+++ b/gerbera-web/test/client/gerbera.menu.spec.js
@@ -6,12 +6,15 @@ jasmine.getJSONFixtures().fixturesPath = 'base/test/client/fixtures';
 describe('Gerbera Menu', () => {
   'use strict';
   describe('initialize()', () => {
-    let ajaxSpy;
+    let ajaxSpy, mockConfig;
 
     beforeEach(() => {
+      loadJSONFixtures('config.json');
       loadFixtures('index.html');
+      mockConfig = getJSONFixture('config.json');
       spyOn(GERBERA.Updates, 'getUpdates');
       ajaxSpy = spyOn($, 'ajax');
+      GERBERA.App.serverConfig = mockConfig.config;
     });
 
     afterEach(() => {

--- a/gerbera-web/test/e2e/menu.spec.js
+++ b/gerbera-web/test/e2e/menu.spec.js
@@ -71,6 +71,17 @@ suite(() => {
       expect(tree.length).to.equal(0);
     });
 
+    it('shows the friendly name in the Home menu', async () => {
+      const homeMenu = await homePage.getHomeMenu();
+      const text = await homeMenu.getText();
+      expect(text).to.equal('Home [Gerbera Media Server]')
+    });
+
+    it('shows the friendly name in the document title', async () => {
+      const title = await homePage.getTitle();
+      expect(title).to.equal('Gerbera Media Server')
+    });
+
     it('loads the parent database container list when clicking Database Icon', async () => {
       await homePage.clickMenuIcon('nav-db');
       const tree = await homePage.treeItems();

--- a/gerbera-web/test/e2e/page/home.page.js
+++ b/gerbera-web/test/e2e/page/home.page.js
@@ -10,6 +10,14 @@ module.exports = function (driver) {
     return await driver.findElement(By.id('nav-fs'));
   };
 
+  this.getHomeMenu = async () => {
+    return await driver.findElement(By.id('nav-home'));
+  };
+
+  this.getTitle = async () => {
+    return await driver.getTitle();
+  };
+
   this.clickMenu = async (menuId) => {
     const tree = await driver.findElement(By.id('tree'));
     if (menuId === 'nav-home') {

--- a/src/web/auth.cc
+++ b/src/web/auth.cc
@@ -125,6 +125,10 @@ void web::auth::process()
         //actions->appendTextChild(_("action"), _("fokel2"));
         
         config->appendElementChild(actions);
+
+        Ref<Element> friendlyName (new Element(_("friendlyName")));
+        friendlyName->setText(cm->getOption(CFG_SERVER_NAME));
+        config->appendElementChild(friendlyName);
     }
     else if (action == "get_sid")
     {

--- a/web/js/gerbera.app.js
+++ b/web/js/gerbera.app.js
@@ -104,6 +104,9 @@ GERBERA.App = (function () {
       GERBERA.App.serverConfig = $.extend({}, response.config)
       var pollingInterval = response.config['poll-interval']
       GERBERA.App.serverConfig['poll-interval'] = parseInt(pollingInterval) * 1000
+      if(GERBERA.App.serverConfig.friendlyName) {
+        $(document).attr('title', GERBERA.App.serverConfig.friendlyName)
+      }
       deferred = $.Deferred().resolve().promise()
     } else {
       deferred = $.Deferred().reject(response).promise()

--- a/web/js/gerbera.menu.js
+++ b/web/js/gerbera.menu.js
@@ -34,6 +34,9 @@ GERBERA.Menu = (function () {
       allLinks.click(GERBERA.Menu.click)
       allLinks.removeClass('disabled')
       $('#nav-home').click()
+      if(GERBERA.App.serverConfig.friendlyName) {
+        $('#nav-home').text('Home [' + GERBERA.App.serverConfig.friendlyName +']');
+      }
     } else {
      disable()
     }


### PR DESCRIPTION
Support ability to show configured server name in the Web UI. Includes:

* Show in the Home menu option
* Show as the web page title

![gerbera-friendly-name](https://user-images.githubusercontent.com/8599799/48174046-4eee8a00-e2d4-11e8-9e1b-2a570429e013.png)

Defaults to CMake Project Name(_Gerbera_) when not defined in `config.xml`

Fixes #363 