### PR TITLE
Close toast manually to speed up UI tests

### DIFF
--- a/gerbera-web/test/e2e/add.object.spec.js
+++ b/gerbera-web/test/e2e/add.object.spec.js
@@ -63,9 +63,7 @@ suite(() => {
 
       result = await homePage.getToastMessage();
       expect(result).to.equal('Successfully added object');
-
-      result = await homePage.waitForToastClose();
-      expect(result).to.be.false;
+      await homePage.closeToast();
     });
   });
 });

--- a/gerbera-web/test/e2e/autoscan.spec.js
+++ b/gerbera-web/test/e2e/autoscan.spec.js
@@ -78,8 +78,7 @@ suite(() => {
       result = await homePage.getToastMessage();
       expect(result).to.equal('Performing full scan: /Movies');
 
-      result = await homePage.waitForToastClose();
-      expect(result).to.be.false;
+      await homePage.closeToast();
     });
 
     it('an existing autoscan item loads edit overlay', async () => {

--- a/gerbera-web/test/e2e/delete.item.spec.js
+++ b/gerbera-web/test/e2e/delete.item.spec.js
@@ -46,8 +46,7 @@ suite(() => {
       result = await homePage.getToastMessage();
       expect(result).to.equal('Successfully removed item');
 
-      result = await homePage.waitForToastClose();
-      expect(result).to.be.false;
+      await homePage.closeToast();
     });
   });
 });

--- a/gerbera-web/test/e2e/login.spec.js
+++ b/gerbera-web/test/e2e/login.spec.js
@@ -55,8 +55,7 @@ suite(() => {
       let result = await loginPage.getToastMessage();
       expect(result).to.equal('Please enter username and password');
 
-      result = await loginPage.waitForToastClose();
-      expect(result).to.be.false;
+      await loginPage.closeToast();
     });
 
     it('when successful login show logout button, and show form on logout', async () => {
@@ -73,9 +72,7 @@ suite(() => {
     it('hides menu, hides login and shows message when UI is disabled', async () => {
       let result = await loginPage.getToastMessage();
       expect(result).to.equal('The UI is disabled in the configuration file. See README.');
-
-      result = await loginPage.waitForToastClose();
-      expect(result).to.be.false;
+      await loginPage.closeToast();
 
       result = await loginPage.menuList();
       const style = await result.getAttribute('style');

--- a/gerbera-web/test/e2e/page/home.page.js
+++ b/gerbera-web/test/e2e/page/home.page.js
@@ -123,6 +123,7 @@ module.exports = function (driver) {
 
   this.submitEditor = async () => {
     await driver.findElement(By.id('editSave')).click();
+    await driver.sleep(500); // todo: wait on .modal-backdrop somehow
     return await driver.wait(until.elementIsNotVisible(driver.findElement(By.id('editModal'))), 5000);
   };
 
@@ -261,6 +262,12 @@ module.exports = function (driver) {
   this.waitForToastClose = async () => {
     await driver.wait(until.elementIsNotVisible(driver.findElement(By.id('toast'))), 6000);
     return await driver.findElement(By.css('#grb-toast-msg')).isDisplayed();
+  };
+
+  this.closeToast = async () => {
+    await driver.wait(until.elementIsNotVisible(driver.findElement(By.id('editModal'))), 5000);
+    await driver.findElement(By.css('#toast button.close')).click();
+    return await driver.wait(until.elementIsNotVisible(driver.findElement(By.id('toast'))), 2000);
   };
 
   this.getPages = async () => {

--- a/gerbera-web/test/e2e/page/login.page.js
+++ b/gerbera-web/test/e2e/page/login.page.js
@@ -60,6 +60,12 @@ module.exports = function (driver) {
     return await driver.findElement(By.css('#grb-toast-msg')).isDisplayed();
   };
 
+  this.closeToast = async () => {
+    await driver.wait(until.elementIsNotVisible(driver.findElement(By.id('editModal'))), 5000);
+    await driver.findElement(By.css('#toast button.close')).click();
+    return await driver.wait(until.elementIsNotVisible(driver.findElement(By.id('toast'))), 2000);
+  };
+
   this.getCookie = async (cookie) => {
     return await driver.manage().getCookie(cookie);
   };


### PR DESCRIPTION
Instead of waiting 5 seconds for the toast message to close, the tests now close it manually.

> This removes any warning alerts in test output for tests steps running > 5 seconds.