### PR TITLE
Update to xenial distribution in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # None as otherwise it clobbers our compiler choce
 language: none
 
-# Ubuntu 14.04 Trusty support
+# Ubuntu 16.04 Xenial support
 sudo: required
-dist: trusty
+dist: xenial
 
 # The default build
 env: CXX=g++-6 CC=gcc-6


### PR DESCRIPTION
The Trusty Ubuntu 14.04 build works well, it is nearing the end-of-life in April 2019 _see: [Ubuntu Releases](https://wiki.ubuntu.com/Releases)_

The Travis CI system supports Xenial, updating to that allows for recent improvements.

https://docs.travis-ci.com/user/reference/xenial/#differences-from-the-trusty-images

> This is only tech currency related improvements and is low priority for merge.