### PR TITLE
cmake - set ffmpeg includes to avoid deprecated struct member

### DIFF
--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -206,6 +206,7 @@ IF (FFMPEG_INCLUDE_DIR)
 
                 SET(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} CACHE INTERNAL "All presently found FFMPEG libraries.")
 
+		LIST(APPEND CMAKE_REQUIRED_INCLUDES ${FFMPEG_INCLUDE_DIR})
                 CHECK_STRUCT_HAS_MEMBER("struct AVStream" codecpar libavformat/avformat.h HAVE_AVSTREAM_CODECPAR LANGUAGE C)
 
             ENDIF (FFMPEG_avutil_LIBRARY)


### PR DESCRIPTION
ffmpeg deprecated a while ago the codec member of the struct AVStream, replacing it with codecpar

When building gerbera with -DWITH_AVCODEC=1, the cmake detection process fails to set HAVE_AVSTREAM_CODECPAR because ffmpeg headers are in a specific location.