### PR TITLE
 cmake - Set ffmpeg includes to avoid deprecated struct member 

### DIFF
--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -206,6 +206,7 @@ IF (FFMPEG_INCLUDE_DIR)
 
                 SET(FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} CACHE INTERNAL "All presently found FFMPEG libraries.")
 
+		LIST(APPEND CMAKE_REQUIRED_INCLUDES ${FFMPEG_INCLUDE_DIR})
                 CHECK_STRUCT_HAS_MEMBER("struct AVStream" codecpar libavformat/avformat.h HAVE_AVSTREAM_CODECPAR LANGUAGE C)
 
             ENDIF (FFMPEG_avutil_LIBRARY)


### PR DESCRIPTION
av_register_all() got deprecated in lavf 58.9.100
It is now useless
https://github.com/FFmpeg/FFmpeg/blob/70d25268c21cbee5f08304da95be1f647c630c15/doc/APIchanges#L86
