### PR TITLE
Set required CMake version to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 set(GERBERA_MAJOR_VERSION 1)
 set(GERBERA_MINOR_VERSION 3)


### PR DESCRIPTION
It is not compiling with older versions (it failed with 3.7)

> The "Compile Features" functionality is now aware of C++ 17. 
https://cmake.org/cmake/help/v3.8/release/3.8.html