### PR TITLE
Support command line options with string values

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -98,7 +98,20 @@ int main(int argc, char** argv, char** envp)
 
     cxxopts::Options options("gerbera", "Gerbera UPnP Media Server - https://gerbera.io");
 
-    options.add_options()("D,debug", "Enable debugging", cxxopts::value<bool>()->default_value("false"))("e,interface", "Interface to bind with")("p,port", "Port to bind with, must be >=49152", cxxopts::value<int>())("i,ip", "IP to bind with")("c,config", "Path to config file")("m,home", "Search this directory for a .gerbera folder containing a config file")("f,cfgdir", "Override name of config folder (.config/gerbera) by default. -h must also be set.")("l,logfile", "Set log location")("compile-info", "Print compile info and exit")("v,version", "Print version info and exit")("h,help", "Print this help and exit")("create-config", "Print a default config.xml file and exit")("add-file", "Scan a file into the DB on startup, can be specified multiple times", cxxopts::value<std::vector<std::string>>(), "FILE");
+    options.add_options()
+    ("D,debug", "Enable debugging", cxxopts::value<bool>()->default_value("false"))
+    ("e,interface", "Interface to bind with", cxxopts::value<std::string>())
+    ("p,port", "Port to bind with, must be >=49152", cxxopts::value<int>())
+    ("i,ip", "IP to bind with", cxxopts::value<std::string>())
+    ("c,config", "Path to config file", cxxopts::value<std::string>())
+    ("m,home", "Search this directory for a .gerbera folder containing a config file", cxxopts::value<std::string>())
+    ("f,cfgdir", "Override name of config folder (.config/gerbera) by default. -h must also be set.", cxxopts::value<std::string>())
+    ("l,logfile", "Set log location", cxxopts::value<std::string>())
+    ("compile-info", "Print compile info and exit")
+    ("v,version", "Print version info and exit")
+    ("h,help", "Print this help and exit")
+    ("create-config", "Print a default config.xml file and exit")
+    ("add-file", "Scan a file into the DB on startup, can be specified multiple times", cxxopts::value<std::vector<std::string>>(), "FILE");
 
     try {
         cxxopts::ParseResult opts = options.parse(argc, argv);

--- a/test/test_server/fixtures/mock-help.out
+++ b/test/test_server/fixtures/mock-help.out
@@ -3,15 +3,15 @@ Usage:
   gerbera [OPTION...]
 
   -D, --debug          Enable debugging
-  -e, --interface      Interface to bind with
+  -e, --interface arg  Interface to bind with
   -p, --port arg       Port to bind with, must be >=49152
-  -i, --ip             IP to bind with
-  -c, --config         Path to config file
-  -m, --home           Search this directory for a .gerbera folder containing
+  -i, --ip arg         IP to bind with
+  -c, --config arg     Path to config file
+  -m, --home arg       Search this directory for a .gerbera folder containing
                        a config file
-  -f, --cfgdir         Override name of config folder (.config/gerbera) by
+  -f, --cfgdir arg     Override name of config folder (.config/gerbera) by
                        default. -h must also be set.
-  -l, --logfile        Set log location
+  -l, --logfile arg    Set log location
       --compile-info   Print compile info and exit
   -v, --version        Print version info and exit
   -h, --help           Print this help and exit


### PR DESCRIPTION
Fixes #394 

Debugging revealed that the command line options were not parsing as expected when no type is specified (_e.g. `-c ./config.xml`_).

> If a runtime configuration is missing perhaps the code change is not necessary.