### PR TITLE
Fix variadic non-trivial type in macOS

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -182,7 +182,7 @@ int main(int argc, char** argv, char** envp)
                 log_error("Could not determine users home directory\n");
                 exit(EXIT_FAILURE);
             }
-            log_debug("Home detected as: %s\n", home.value());
+            log_debug("Home detected as: %s\n", home->c_str());
         }
 
         std::optional<std::string> prefix;


### PR DESCRIPTION
Following changes to CXXOpts, Gerbera does not compile on macOS due to variadic non-trivial type being passed to `log_debug`

https://github.com/gerbera/gerbera/commit/6cf290d725a98b7d9b4f3d09db1e94ea66c35258#diff-ddaa7d6e643bc0d374add600b02445beR188

```bash
[ 98%] Building CXX object CMakeFiles/gerbera.dir/src/main.cc.o
/gerbera/src/main.cc:185:54: error: cannot pass object of non-trivial 
type 'std::__1::optional<std::__1::basic_string<char> >::value_type' 
(aka 'std::__1::basic_string<char>')
through variadic function; call will abort at runtime [-Wnon-pod-varargs]
            log_debug("Home detected as: %s\n", home.value());
                                                     ^
1 error generated.
```