### PR TITLE
Set Cache-Control on all AJAX calls

### DIFF
--- a/gerbera-web/test/client/gerbera.app.spec.js
+++ b/gerbera-web/test/client/gerbera.app.spec.js
@@ -5,7 +5,7 @@ jasmine.getJSONFixtures().fixturesPath = 'base/test/client/fixtures';
 
 describe('Gerbera UI App', () => {
   describe('initialize()', () => {
-    let mockConfig, convertedConfig, ajaxSpy, cookieSpy, uiDisabled;
+    let mockConfig, convertedConfig, ajaxSpy, cookieSpy, uiDisabled, ajaxSetupSpy;
 
     beforeAll(() => {
       loadJSONFixtures('converted-config.json');
@@ -15,6 +15,7 @@ describe('Gerbera UI App', () => {
       convertedConfig = getJSONFixture('converted-config.json');
       uiDisabled = getJSONFixture('ui-disabled.json');
       ajaxSpy = spyOn($, 'ajax');
+      ajaxSetupSpy = spyOn($, 'ajaxSetup');
       spyOn(GERBERA.Auth, 'checkSID');
     });
 
@@ -28,6 +29,7 @@ describe('Gerbera UI App', () => {
 
     afterEach(() => {
       ajaxSpy.and.callThrough();
+      ajaxSetupSpy.and.callThrough();
     });
 
     it('retrieves the configuration from the server using AJAX', async () => {
@@ -115,6 +117,18 @@ describe('Gerbera UI App', () => {
       expect(GERBERA.Trail.initialize).toHaveBeenCalled();
       expect(GERBERA.Autoscan.initialize).toHaveBeenCalled();
       expect(GERBERA.Updates.initialize).toHaveBeenCalled();
+    });
+
+    it('sets up Cache-Control headers for all AJAX requests', async () => {
+      ajaxSpy.and.callFake(() => {
+        return $.Deferred().resolve(mockConfig).promise();
+      });
+
+      await GERBERA.App.initialize();
+
+      expect(ajaxSetupSpy).toHaveBeenCalledWith({
+        beforeSend: jasmine.any(Function)
+      });
     });
   });
 

--- a/gerbera-web/test/client/gerbera.menu.spec.js
+++ b/gerbera-web/test/client/gerbera.menu.spec.js
@@ -111,15 +111,19 @@ describe('Gerbera Menu', () => {
 
   describe('click()', () => {
     let fsMenu;
+    let mockConfig;
 
     beforeEach(async () => {
       loadFixtures('index.html');
+      loadJSONFixtures('config.json');
       spyOn(GERBERA.Tree, 'selectType');
       spyOn(GERBERA.App, 'setType');
       spyOn(GERBERA.Auth, 'isLoggedIn').and.returnValue(true);
       spyOn(GERBERA.Items, 'destroy');
       spyOn(GERBERA.Tree, 'destroy');
       spyOn(GERBERA.Trail, 'destroy');
+      mockConfig = getJSONFixture('config.json');
+      GERBERA.App.serverConfig = mockConfig.config;
       await GERBERA.Menu.initialize();
       fsMenu = $('#nav-fs');
     });

--- a/web/js/gerbera.app.js
+++ b/web/js/gerbera.app.js
@@ -82,6 +82,11 @@ GERBERA.App = (function () {
     if (getType() === undefined) {
       setType('db');
     }
+    $.ajaxSetup({
+      beforeSend: function (xhr) {
+        xhr.setRequestHeader('Cache-Control', 'no-cache, must-revalidate');
+      }
+    });
     return $.Deferred().resolve().promise()
   }
 


### PR DESCRIPTION
Adjust AJAX calls to have no client-side cache.  Cache-Control header allows repeated requests to always be directly to the server, rather than returned from browser cache.

> Applies `no-cache` to all AJAX calls.

Allows long-polling and tree navigation to work properly when re-visiting folders.