### PR TITLE
Playlist meta support

### DIFF
--- a/scripts/js/playlists.js
+++ b/scripts/js/playlists.js
@@ -38,21 +38,15 @@ function addPlaylistItem(location, title, playlistChain, order) {
         exturl.playlistOrder = (order ? order : playlistOrder++);
         addCdsObject(exturl, playlistChain,  UPNP_CLASS_PLAYLIST_CONTAINER);
     } else {
-        if (location.substr(0,1) !== '/')
+        if (location.substr(0,1) !== '/') {
             location = playlistLocation + location;
-        var item  = {};
-        item.location = location;
-        if (title)
-            item.title = title;
-        else
-        {
-            var locationParts = location.split('/');
-            item.title = locationParts[locationParts.length - 1];
-            if (! item.title)
-                item.title = location;
         }
-        item.objectType = OBJECT_TYPE_ITEM;
+
+        var cds = getCdsObject(location);
+        var item = copyObject(cds);
+
         item.playlistOrder = (order ? order : playlistOrder++);
+        item.title = item.meta[M_TITLE];
         addCdsObject(item, playlistChain,  UPNP_CLASS_PLAYLIST_CONTAINER);
     }
 }

--- a/test/test_script/mock/common_script_mock.h
+++ b/test/test_script/mock/common_script_mock.h
@@ -19,6 +19,8 @@ class CommonScriptInterface {
   virtual duk_ret_t getLastPath(string path) = 0;
   virtual duk_ret_t readln(string line) = 0;
   virtual duk_ret_t addCdsObject(map<string, string> item, string playlistContainer, string objectType) = 0;
+  virtual duk_ret_t copyObject(bool isObject) = 0;
+  virtual duk_ret_t getCdsObject(string location) = 0;
   virtual duk_ret_t getYear(string year) = 0;
   virtual duk_ret_t getRootPath(string objScriptPath, string location) = 0;
   virtual duk_ret_t abcBox(string inputValue, int boxType, string divChar) = 0;
@@ -32,6 +34,8 @@ class CommonScriptMock : public CommonScriptInterface {
   MOCK_METHOD1(getLastPath, duk_ret_t(string path));
   MOCK_METHOD1(readln, duk_ret_t(string line));
   MOCK_METHOD3(addCdsObject, duk_ret_t(map<string, string> item, string playlistContainer, string objectType));
+  MOCK_METHOD1(copyObject, duk_ret_t(bool isObject));
+  MOCK_METHOD1(getCdsObject, duk_ret_t(string location));
   MOCK_METHOD1(getYear, duk_ret_t(string year));
   MOCK_METHOD2(getRootPath, duk_ret_t(string objScriptPath, string location));
   MOCK_METHOD3(abcBox, duk_ret_t(string inputValue, int boxType, string divChar));

--- a/test/test_script/mock/duk_helper.cc
+++ b/test/test_script/mock/duk_helper.cc
@@ -87,4 +87,24 @@ tuple<string, string> DukTestHelper::extractObjectValues(duk_context *ctx, strin
   return make_tuple(key, string(""));
 }
 
+void DukTestHelper::createObject(duk_context *ctx, map<string, string> objectProps, map<string, string> metaProps) {
+  // obj
+  {
+    duk_push_object(ctx);
+    for (const auto &x : objectProps) {
+      duk_push_string(ctx, x.second.c_str());
+      duk_put_prop_string(ctx, -2, x.first.c_str());
+    }
+  }
+
+  // obj.meta
+  {
+    duk_push_object(ctx);
+    for (const auto &x : metaProps) {
+      duk_push_string(ctx, x.second.c_str());
+      duk_put_prop_string(ctx, -2, x.first.c_str());
+    }
+    duk_put_prop_string(ctx, -2, "meta");
+  }
+}
 #endif //HAVE_JS

--- a/test/test_script/mock/duk_helper.h
+++ b/test/test_script/mock/duk_helper.h
@@ -24,6 +24,9 @@ class DukTestHelper {
   // to a map of its properties using the property keys passed into
   // the method
   map<string, string> extractValues(duk_context *ctx, vector<string> keys, duk_idx_t idx);
+
+  // Adds a new object to the duk_context with meta data
+  void createObject(duk_context *ctx, map<string, string> objectProps, map<string, string> metaProps);
  private:
 
   // Extracts the property value given a complex associative array key

--- a/test/test_script/mock/script_test_fixture.cc
+++ b/test/test_script/mock/script_test_fixture.cc
@@ -226,6 +226,28 @@ addCdsObjectParams ScriptTestFixture::addCdsObject(duk_context *ctx, vector<stri
   return params;
 }
 
+copyObjectParams ScriptTestFixture::copyObject(duk_context *ctx, map<string, string> obj, map<string, string> meta) {
+  duk_bool_t isObjectParam = duk_is_object(ctx, 0);
+  copyObjectParams params;
+  params.isObject = isObjectParam;
+
+  DukTestHelper dukHelper;
+  dukHelper.createObject(ctx, std::move(obj), std::move(meta));
+
+  return params;
+}
+
+getCdsObjectParams ScriptTestFixture::getCdsObject(duk_context *ctx, map<string, string> obj, map<string, string> meta) {
+  string location = duk_get_string(ctx, 0);
+  getCdsObjectParams params;
+  params.location = location;
+
+  DukTestHelper dukHelper;
+  dukHelper.createObject(ctx, std::move(obj), std::move(meta));
+
+  return params;
+}
+
 abcBoxParams ScriptTestFixture::abcBox(duk_context *ctx) {
   string inputValue;
   int boxType;

--- a/test/test_script/mock/script_test_fixture.h
+++ b/test/test_script/mock/script_test_fixture.h
@@ -113,10 +113,10 @@ class ScriptTestFixture : public ::testing::Test {
   // Proxy the Duktape script with `getRootPath` common.js function
   static getRootPathParams getRootPath(duk_context *ctx);
 
-  // Porxy the Duktape script with `copyObject` global function
+  // Proxy the Duktape script with `copyObject` global function
   static copyObjectParams copyObject(duk_context *ctx, map<string, string> obj, map<string, string> meta);
 
-  // Porxy the Duktape script with `copyObject` global function
+  // Proxy the Duktape script with `copyObject` global function
   static getCdsObjectParams getCdsObject(duk_context *ctx, map<string, string> obj, map<string, string> meta);
 
   // Script file name under test

--- a/test/test_script/mock/script_test_fixture.h
+++ b/test/test_script/mock/script_test_fixture.h
@@ -33,6 +33,16 @@ struct _getRootPathParams {
 };
 typedef struct _getRootPathParams getRootPathParams;
 
+struct _copyObjectParams {
+    bool isObject;
+};
+typedef struct _copyObjectParams copyObjectParams;
+
+struct _getCdsObjectParams {
+    string location;
+};
+typedef struct _getCdsObjectParams getCdsObjectParams;
+
 // The class provides a way to test the Duktape scripts
 // providing various c++ translations of script functions
 // useful for mocking said functions with expectations.
@@ -102,6 +112,12 @@ class ScriptTestFixture : public ::testing::Test {
 
   // Proxy the Duktape script with `getRootPath` common.js function
   static getRootPathParams getRootPath(duk_context *ctx);
+
+  // Porxy the Duktape script with `copyObject` global function
+  static copyObjectParams copyObject(duk_context *ctx, map<string, string> obj, map<string, string> meta);
+
+  // Porxy the Duktape script with `copyObject` global function
+  static getCdsObjectParams getCdsObject(duk_context *ctx, map<string, string> obj, map<string, string> meta);
 
   // Script file name under test
   // System defaults to known project path `/scripts/js/<scriptName>`

--- a/test/test_script/test_internal_m3u_playlist.cc
+++ b/test/test_script/test_internal_m3u_playlist.cc
@@ -79,6 +79,40 @@ static duk_ret_t addCdsObject(duk_context *ctx) {
   return InternalUrlM3UPlaylistTest::commonScriptMock->addCdsObject(params.objectValues, params.containerChain, params.objectType);
 }
 
+static duk_ret_t copyObject(duk_context *ctx) {
+  map<string, string> obj = {
+    make_pair("title", "example.mp3"),
+    make_pair("objectType", "2"),
+    make_pair("location", "/home/gerbera/example.mp3"),
+    make_pair("playlistOrder", "1")
+  };
+  map<string, string> meta = {
+    make_pair("dc:title", "example.mp3"),
+    make_pair("upnp:artist", "Artist"),
+    make_pair("upnp:album", "Album"),
+    make_pair("dc:date", "2018")
+  };
+  copyObjectParams params = ScriptTestFixture::copyObject(ctx, obj, meta);
+  return InternalUrlM3UPlaylistTest::commonScriptMock->copyObject(params.isObject);
+}
+
+static duk_ret_t getCdsObject(duk_context *ctx) {
+  map<string, string> obj = {
+          make_pair("title", "example.mp3"),
+          make_pair("objectType", "2"),
+          make_pair("location", "/home/gerbera/example.mp3"),
+          make_pair("playlistOrder", "1")
+  };
+  map<string, string> meta = {
+          make_pair("dc:title", "example.mp3"),
+          make_pair("upnp:artist", "Artist"),
+          make_pair("upnp:album", "Album"),
+          make_pair("dc:date", "2018")
+  };
+  getCdsObjectParams params = ScriptTestFixture::getCdsObject(ctx, obj, meta);
+  return InternalUrlM3UPlaylistTest::commonScriptMock->getCdsObject(params.location);
+}
+
 // Mock the Duktape C methods
 // that are called from the playlists.js script
 // * These are static methods, which makes mocking difficult.
@@ -90,6 +124,8 @@ static  duk_function_list_entry js_global_functions[] =
   { "getLastPath",           getLastPath,          1 },
   { "readln",                readln,               1 },
   { "addCdsObject",          addCdsObject,         3 },
+  { "copyObject",            copyObject,           1 },
+  { "getCdsObject",          getCdsObject,         1 },
   { nullptr,                 nullptr,              0 },
 };
 
@@ -140,6 +176,8 @@ TEST_F(InternalUrlM3UPlaylistTest, AddsCdsObjectFromM3UPlaylistWithInternalUrlPl
   EXPECT_CALL(*commonScriptMock, addCdsObject(IsIdenticalMap(asPlaylistDirChain),
       "\\/Playlists\\/Directories\\/of\\/Playlist Title",
       "object.container.playlistContainer")).WillOnce(Return(0));
+  EXPECT_CALL(*commonScriptMock, getCdsObject(Eq("/home/gerbera/example.mp3"))).WillRepeatedly(Return(1));
+  EXPECT_CALL(*commonScriptMock, copyObject(Eq(true))).WillRepeatedly(Return(1));
 
   addGlobalFunctions(ctx, js_global_functions);
   dukMockPlaylist(ctx, "Playlist Title", "/location/of/playlist.m3u", "audio/x-mpegurl");

--- a/test/test_script/test_internal_pls_playlist.cc
+++ b/test/test_script/test_internal_pls_playlist.cc
@@ -87,6 +87,40 @@ static duk_ret_t addCdsObject(duk_context *ctx) {
   return InternalUrlPLSPlaylistTest::commonScriptMock->addCdsObject(params.objectValues, params.containerChain, params.objectType);
 }
 
+static duk_ret_t copyObject(duk_context *ctx) {
+  map<string, string> obj = {
+          make_pair("title", "Song from Playlist Title"),
+          make_pair("objectType", "2"),
+          make_pair("location", "/home/gerbera/example.mp3"),
+          make_pair("playlistOrder", "1")
+  };
+  map<string, string> meta = {
+          make_pair("dc:title", "Song from Playlist Title"),
+          make_pair("upnp:artist", "Artist"),
+          make_pair("upnp:album", "Album"),
+          make_pair("dc:date", "2018")
+  };
+  copyObjectParams params = ScriptTestFixture::copyObject(ctx, obj, meta);
+  return InternalUrlPLSPlaylistTest::commonScriptMock->copyObject(params.isObject);
+}
+
+static duk_ret_t getCdsObject(duk_context *ctx) {
+  map<string, string> obj = {
+          make_pair("title", "Song from Playlist Title"),
+          make_pair("objectType", "2"),
+          make_pair("location", "/home/gerbera/example.mp3"),
+          make_pair("playlistOrder", "1")
+  };
+  map<string, string> meta = {
+          make_pair("dc:title", "Song from Playlist Title"),
+          make_pair("upnp:artist", "Artist"),
+          make_pair("upnp:album", "Album"),
+          make_pair("dc:date", "2018")
+  };
+  getCdsObjectParams params = ScriptTestFixture::getCdsObject(ctx, obj, meta);
+  return InternalUrlPLSPlaylistTest::commonScriptMock->getCdsObject(params.location);
+}
+
 // Mock the Duktape C methods
 // that are called from the playlists.js script
 // * These are static methods, which makes mocking difficult.
@@ -98,6 +132,8 @@ static  duk_function_list_entry js_global_functions[] =
   { "getLastPath",           getLastPath,          1 },
   { "readln",                readln,               1 },
   { "addCdsObject",          addCdsObject,         3 },
+  { "copyObject",            copyObject,           1 },
+  { "getCdsObject",          getCdsObject,         1 },
   { nullptr,                 nullptr,              0 },
 };
 
@@ -145,6 +181,8 @@ TEST_F(InternalUrlPLSPlaylistTest, AddsCdsObjectFromM3UPlaylistWithInternalUrlPl
   EXPECT_CALL(*commonScriptMock, addCdsObject(IsIdenticalMap(asPlaylistChain),
       "\\/Playlists\\/Directories\\/of\\/Playlist Title",
       "object.container.playlistContainer")).WillOnce(Return(0));
+  EXPECT_CALL(*commonScriptMock, getCdsObject(Eq("/home/gerbera/example.mp3"))).WillRepeatedly(Return(1));
+  EXPECT_CALL(*commonScriptMock, copyObject(Eq(true))).WillRepeatedly(Return(1));
 
   addGlobalFunctions(ctx, js_global_functions);
   dukMockPlaylist(ctx, "Playlist Title", "/location/of/playlist.pls", "audio/x-scpls");


### PR DESCRIPTION
Add `copyObject` and `getCdsObject` to playlist script, including test fixtures.

Resolves failures in #407.