### PR TITLE
UPNP Description field does not get populated

### DIFF
--- a/scripts/js/import.js
+++ b/scripts/js/import.js
@@ -71,7 +71,7 @@ function addAudio(obj) {
     
     var description = obj.meta[M_DESCRIPTION];
     if (!description) {
-        obj.meta[M_DESCRIPTION] = desc;
+        obj.description = desc;
     }
 
     var composer = obj.meta[M_COMPOSER];


### PR DESCRIPTION
First of all a huge "Thank you" for reviving this project. I had been using MT in the past until updating my LTS Ubuntu became to painful because of the libmoz issue. As a classical music lover I like the scripting facilities very much. Here is a small fix of an old bug that did survive until now:

If an audio file comes without a description tag, import.js gathers some information in order to compose a description like "artist, album, title, date, genre" but fails to write it to the proper field.