### PR TITLE
Generate config.xml with XML Declaration

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -62,7 +62,7 @@ std::string ConfigGenerator::generate(std::string userHome, std::string configDi
   config->appendElementChild(generateTranscoding());
   config->indent();
 
-  return std::string((config->print() + "\n").c_str());
+  return std::string((_(XML_HEADER) + config->print() + "\n").c_str());
 }
 
 Ref<Element> ConfigGenerator::generateServer(std::string userHome, std::string configDir, std::string prefixDir) {

--- a/test/test_config/fixtures/mock-config-all.xml
+++ b/test/test_config/fixtures/mock-config-all.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
   <!--
      See http://gerbera.io or read the docs for more

--- a/test/test_config/fixtures/mock-config-minimal.xml
+++ b/test/test_config/fixtures/mock-config-minimal.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
   <!--
      See http://gerbera.io or read the docs for more


### PR DESCRIPTION
Fix #446 

Prepend the `XML_HEADER` declaration on the `gerbera --create-config` option.

This was previously cut when configuration generator was pushed via #282