### PR TITLE
main: bugfix `interface` CLI option

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -237,7 +237,7 @@ int main(int argc, char** argv, char** envp)
 
         std::optional<std::string> interface;
         if (opts.count("interface") > 0) {
-            ip = opts["interface"].as<std::string>();
+            interface = opts["interface"].as<std::string>();
         }
 
         // FIXME: We will remove the singletons at some point.. and this compat


### PR DESCRIPTION
CLI `interface` option parsing is broken after changes in 6cf290d725a98b7d9b4f3d09db1e94ea66c35258. This fixes interface value assignment to correct variable.