### PR TITLE
Use exiv2 header that include all headers

### DIFF
--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -31,8 +31,7 @@
 /// \brief Implementeation of the Exiv2Handler class.
 
 #ifdef HAVE_EXIV2
-#include <exiv2/exif.hpp>
-#include <exiv2/image.hpp>
+#include <exiv2/exiv2.hpp>
 
 #include "config_manager.h"
 #include "exiv2_handler.h"


### PR DESCRIPTION
With latest exiv2 0.27.1 there is a build error
`exiv2_handler.cc:179:21: error: 'AnyError' in namespace 'Exiv2' does not name a type`

The issue was detected during buildroot autobuild tests after the bump of exiv2 to version 0.27.1
http://autobuild.buildroot.net/results/3831acf7f4c5a9f1a404e0ced3d6bec7a2249601/
http://autobuild.buildroot.net/results/de0545462c6017fe54acc284b914b9fa8b0172d8/