### PR TITLE
Add virtualUrl to AlbumArt resource for consistent resource URIs

### DIFF
--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -866,7 +866,7 @@ void UpnpXMLBuilder::addResources(Ref<CdsItem> item, Ref<Element> element)
 
                 if (rct == ID3_ALBUM_ART) {
                     Ref<Element> aa(new Element(MetadataHandler::getMetaFieldName(M_ALBUMARTURI)));
-                    aa->setText(url);
+                    aa->setText(virtualUrl + url);
                     if (config->getBoolOption(CFG_SERVER_EXTEND_PROTOCOLINFO)) {
                         /// \todo clean this up, make sure to check the mimetype and
                         /// provide the profile correctly


### PR DESCRIPTION
Proposal to fix #459  

It seems logical to render the resource with full URL.

> Although not sure how this correlates to Docker...

The method could use rework to support multiple resource types through method abstraction + TDD...however, that is a larger scale effort at this time.