### PR TITLE
cmake/FindFFMPEG: do not quieten messages when using pkg-config

### DIFF
--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -85,7 +85,7 @@ get_filename_component(FFMPEG_INCLUDE_DIR ${FFMPEG_INCLUDE_DIR} ABSOLUTE)
 CHECK_STRUCT_HAS_MEMBER("struct AVStream" codecpar libavformat/avformat.h HAVE_AVSTREAM_CODECPAR LANGUAGE C)
 
 FIND_PACKAGE(PkgConfig QUIET)
-PKG_CHECK_MODULES(FFMPEG QUIET libavformat libavutil)
+PKG_CHECK_MODULES(FFMPEG libavformat libavutil)
 IF (NOT FFMPEG_FOUND)
 	FIND_LIBRARY(FFMPEG_avformat_LIBRARY avformat
 		/usr/local/lib


### PR DESCRIPTION
gerbera does print some configuration status messages, e.g. _"Found TagLib: ..."_, _"Found ZLIB: ..."_, but it does not so for FFmpeg. To make the status message behaviour more consistent, do not quieten the log messages from pkg-config module.

On my system, this prints:

```
-- Checking for modules 'libavformat;libavutil'
--   Found libavformat, version 57.83.100
--   Found libavutil, version 55.78.100
```