### PR TITLE
Add Gerbera version to UI

### DIFF
--- a/gerbera-web/mock-api/auth/config.json
+++ b/gerbera-web/mock-api/auth/config.json
@@ -20,6 +20,7 @@
     "actions": {
       "action": []
     },
-    "friendlyName" : "Gerbera Media Server"
+    "friendlyName" : "Gerbera Media Server",
+    "version": "1.4.0alpha"
   }
 }

--- a/gerbera-web/test/client/fixtures/config.json
+++ b/gerbera-web/test/client/fixtures/config.json
@@ -18,6 +18,7 @@
     "actions": {
       "action": []
     },
-    "friendlyName" : "Gerbera Media Server"
+    "friendlyName" : "Gerbera Media Server",
+    "version": "1.4.0alpha"
   }
 }

--- a/gerbera-web/test/client/fixtures/converted-config.json
+++ b/gerbera-web/test/client/fixtures/converted-config.json
@@ -18,6 +18,7 @@
     "actions": {
       "action": []
     },
-    "friendlyName" : "Gerbera Media Server"
+    "friendlyName" : "Gerbera Media Server",
+    "version": "1.4.0alpha"
   }
 }

--- a/gerbera-web/test/e2e/menu.spec.js
+++ b/gerbera-web/test/e2e/menu.spec.js
@@ -73,6 +73,12 @@ describe('Menu Suite', () => {
       expect(title).to.equal('Gerbera Media Server | Gerbera Media Server')
     });
 
+    it('shows the version in the menu', async () => {
+      const version = await homePage.getVersion();
+      const text = await version.getText();
+      expect(text).to.equal('1.4.0alpha');
+    });
+
     it('loads the parent database container list when clicking Database Icon', async () => {
       await homePage.clickMenuIcon('nav-db');
       const tree = await homePage.treeItems();

--- a/gerbera-web/test/e2e/page/home.page.js
+++ b/gerbera-web/test/e2e/page/home.page.js
@@ -282,4 +282,8 @@ module.exports = function (driver) {
   this.mockTaskMessage = async (msg) => {
     return await driver.executeScript('return $(\'#toast\').toast(\'showTask\', {message: "'+ msg +'", type: "info", icon: "fa-refresh fa-spin fa-fw"});')
   };
+
+  this.getVersion = async () => {
+    return await driver.findElement(By.css('#gerbera-version span'));
+  }
 };

--- a/src/web/auth.cc
+++ b/src/web/auth.cc
@@ -131,6 +131,10 @@ void web::auth::process()
         Ref<Element> friendlyName(new Element(_("friendlyName")));
         friendlyName->setText(cm->getOption(CFG_SERVER_NAME));
         config->appendElementChild(friendlyName);
+
+        Ref<Element> gerberaVersion(new Element(_("version")));
+        gerberaVersion->setText(VERSION);
+        config->appendElementChild(gerberaVersion);
     } else if (action == "get_sid") {
         log_debug("checking/getting sid...\n");
         Ref<Session> session = nullptr;

--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,9 @@
                     <li class="nav-item">
                         <a id="report-issue" class="nav-link noactive" href="http://github.com/gerbera/gerbera/issues" target="_blank"><i class="fa fa-bug"></i> Report an Issue <i class="fa fa-external-link" aria-hidden="true"></i></a>
                     </li>
+                    <li class="nav-item" hidden>
+                        <div class="nav-link disabled noactive" id="gerbera-version"><i class="fa fa-code-fork"></i><span></span></div>
+                    </li>
                 </ul>
                 <form id="login-form" class="form-inline my-2 my-lg-0">
                     <input id="username" class="form-control mr-sm-2 login-field" placeholder="Username" style="display:none;">

--- a/web/js/gerbera.menu.js
+++ b/web/js/gerbera.menu.js
@@ -37,6 +37,13 @@ GERBERA.Menu = (function () {
       if(GERBERA.App.serverConfig.friendlyName) {
         $('#nav-home').text('Home [' + GERBERA.App.serverConfig.friendlyName +']');
       }
+      var version = $('#gerbera-version');
+      if(GERBERA.App.serverConfig.version) {
+        version.children('span').text(GERBERA.App.serverConfig.version);
+        version.parent('li').removeAttr('hidden');
+      } else {
+        version.parent('li').attr('hidden');
+      }
     } else {
      disable()
     }


### PR DESCRIPTION
Fixes #468 

Add the Gerbera Server version to the UI menu bar.

<img width="476" alt="version-menu-bar" src="https://user-images.githubusercontent.com/8599799/57971066-42b84900-7957-11e9-9fbb-c5ff527d4bde.png">

> Presently gerbera does not support pulling server info, unless a Session ID has been established.  This shows only after login is complete.
