### PR TITLE
Fix find_program taglib-config when cross-compiling

### DIFF
--- a/cmake/FindTaglib.cmake
+++ b/cmake/FindTaglib.cmake
@@ -19,6 +19,9 @@ ELSE()
 	endif(NOT TAGLIB_MIN_VERSION)
 
 	if(NOT WIN32)
+            if (CMAKE_CROSSCOMPILING)
+              set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM ONLY)
+            endif(CMAKE_CROSSCOMPILING)
             find_program(TAGLIBCONFIG_EXECUTABLE NAMES taglib-config PATHS
 		   ${BIN_INSTALL_DIR}
             )


### PR DESCRIPTION
When cross-compiling Gerbera CMakes `find_program()` will search for
binaries on the host. This is typically correct, e.g. when search for
compilers or shells.

When cross-compiling searching for `taglib-config` should not find the
binary on the host, instead it should find the binary in the sysroot
directory, as the host `taglib-config` will output the wrong host paths
and libs, whereas the sysroot `taglib-config` will output the correct sysroot
paths and libs.

Therefore, use the `CMAKE_FIND_ROOT_PATH_MODE_PROGRAM` variable when
cross-compiling. This variable controls whether the `CMAKE_FIND_ROOT_PATH`
and `CMAKE_SYSROOT` are used by find_program().