### PR TITLE
Add DeviceDescriptionHandler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ set(libgerberaFILES
         src/contrib/md5.h
         src/curl_io_handler.cc
         src/curl_io_handler.h
+        src/device_description_handler.cc
+        src/device_description_handler.h
         src/dictionary.cc
         src/dictionary.h
         src/exceptions.cc

--- a/src/common.h
+++ b/src/common.h
@@ -124,6 +124,8 @@
 #define CONTENT_SERVE_HANDLER "serve"
 #define CONTENT_ONLINE_HANDLER "online"
 #define CONTENT_UI_HANDLER "interface"
+#define DEVICE_DESCRIPTION_PATH "description.xml"
+
 // REQUEST TYPES
 #define REQ_TYPE_BROWSE "browse"
 #define REQ_TYPE_LOGIN "login"

--- a/src/device_description_handler.cc
+++ b/src/device_description_handler.cc
@@ -1,0 +1,47 @@
+/*GRB*
+
+Gerbera - https://gerbera.io/
+
+    device_description_handler.cc - this file is part of Gerbera.
+
+    Copyright (C) 2019 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file device_description_handler.cc
+
+#include "device_description_handler.h"
+#include "mem_io_handler.h"
+#include "tools.h"
+
+DeviceDescriptionHandler::DeviceDescriptionHandler(UpnpXMLBuilder* xmlBuilder)
+    : RequestHandler()
+    , xmlBuilder(xmlBuilder) {}
+
+void DeviceDescriptionHandler::getInfo(const char* filename, UpnpFileInfo* info)
+{
+    if (!string_ok(deviceDescription)) {
+        deviceDescription = _("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n") + xmlBuilder->renderDeviceDescription()->print();
+    }
+    UpnpFileInfo_set_FileLength(info, deviceDescription.length());
+    UpnpFileInfo_set_ContentType(info, "application/xml");
+    UpnpFileInfo_set_IsReadable(info, 1);
+    UpnpFileInfo_set_IsDirectory(info, 0);
+}
+
+zmm::Ref<IOHandler> DeviceDescriptionHandler::open(const char* filename, enum UpnpOpenFileMode mode, zmm::String range)
+{
+    log_debug("Device description requested!");
+    return zmm::Ref<IOHandler>(new MemIOHandler(deviceDescription.c_str(), deviceDescription.length()));
+}

--- a/src/device_description_handler.cc
+++ b/src/device_description_handler.cc
@@ -31,10 +31,8 @@ DeviceDescriptionHandler::DeviceDescriptionHandler(UpnpXMLBuilder* xmlBuilder)
 
 void DeviceDescriptionHandler::getInfo(const char* filename, UpnpFileInfo* info)
 {
-    if (!string_ok(deviceDescription)) {
-        deviceDescription = _("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n") + xmlBuilder->renderDeviceDescription()->print();
-    }
-    UpnpFileInfo_set_FileLength(info, deviceDescription.length());
+    // We should be able to do the generation here, but libupnp doesnt support the request cookies yet
+    UpnpFileInfo_set_FileLength(info, -1);
     UpnpFileInfo_set_ContentType(info, "application/xml");
     UpnpFileInfo_set_IsReadable(info, 1);
     UpnpFileInfo_set_IsDirectory(info, 0);
@@ -42,6 +40,11 @@ void DeviceDescriptionHandler::getInfo(const char* filename, UpnpFileInfo* info)
 
 zmm::Ref<IOHandler> DeviceDescriptionHandler::open(const char* filename, enum UpnpOpenFileMode mode, zmm::String range)
 {
-    log_debug("Device description requested!");
-    return zmm::Ref<IOHandler>(new MemIOHandler(deviceDescription.c_str(), deviceDescription.length()));
+    log_debug("Device description requested\n");
+    if (!string_ok(deviceDescription)) { // This always true for now
+        deviceDescription = _("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n") + xmlBuilder->renderDeviceDescription()->print();
+    }
+    auto t = zmm::Ref<IOHandler>(new MemIOHandler(deviceDescription));
+    t->open(mode);
+    return t;
 }

--- a/src/device_description_handler.h
+++ b/src/device_description_handler.h
@@ -1,0 +1,44 @@
+/*GRB*
+
+Gerbera - https://gerbera.io/
+
+    device_description_handler.h - this file is part of Gerbera.
+
+    Copyright (C) 2019 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file device_description_handler.h
+
+#ifndef GERBERA_DEVICE_DESCRIPTION_HANDLER_H
+#define GERBERA_DEVICE_DESCRIPTION_HANDLER_H
+
+#include "request_handler.h"
+#include "upnp_xml.h"
+
+class DeviceDescriptionHandler : public RequestHandler {
+public:
+    explicit DeviceDescriptionHandler(UpnpXMLBuilder* xmlBuilder);
+
+    void getInfo(IN const char *filename, OUT UpnpFileInfo *info) override;
+    zmm::Ref<IOHandler> open(IN const char* filename, IN enum UpnpOpenFileMode mode, IN zmm::String range) override;
+
+protected:
+    UpnpXMLBuilder* xmlBuilder;
+    zmm::String deviceDescription;
+};
+
+
+
+#endif //GERBERA_DEVICE_DESCRIPTION_HANDLER_H

--- a/src/server.cc
+++ b/src/server.cc
@@ -429,7 +429,7 @@ Ref<RequestHandler> Server::createRequestHandler(const char* filename) const
         } else {
             ret = createWebRequestHandler(_("index"));
         }
-    } else if (link.startsWith(_("/") + DEVICE_DESCRIPTION_PATH)) {
+    } else if (link.startsWith(_("/") + SERVER_VIRTUAL_DIR + "/" + DEVICE_DESCRIPTION_PATH)) {
         ret = new DeviceDescriptionHandler(xmlbuilder.get());
     } else if (link.startsWith(_("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_SERVE_HANDLER)) {
         if (string_ok(ConfigManager::getInstance()->getOption(CFG_SERVER_SERVEDIR)))

--- a/src/server.cc
+++ b/src/server.cc
@@ -45,6 +45,7 @@
 #ifdef HAVE_CURL
 #include "url_request_handler.h"
 #endif
+#include "device_description_handler.h"
 #include "serve_request_handler.h"
 #include "web/pages.h"
 
@@ -132,7 +133,7 @@ void Server::run()
 
     log_info("Server bound to: %s\n", ip.c_str());
 
-    virtual_url = _("http://") + ip + ":" + port + "/" + virtual_directory;
+    virtualUrl = _("http://") + ip + ":" + port + "/" + virtual_directory;
 
     // next set webroot directory
     String web_root = config->getOption(CFG_SERVER_WEBROOT);
@@ -191,10 +192,10 @@ void Server::run()
     }
 
     log_debug("Creating UpnpXMLBuilder\n");
-    xmlbuilder = std::make_unique<UpnpXMLBuilder>(virtual_url);
+    xmlbuilder = std::make_unique<UpnpXMLBuilder>(virtualUrl, presentationURL);
 
     // register root device with the library
-    String deviceDescription = _("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n") + xmlbuilder->renderDeviceDescription(presentationURL)->print();
+    String deviceDescription = _("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n") + xmlbuilder->renderDeviceDescription()->print();
     //log_debug("Device Description: \n%s\n", deviceDescription.c_str());
 
     log_debug("Registering with UPnP...\n");
@@ -428,6 +429,8 @@ Ref<RequestHandler> Server::createRequestHandler(const char* filename) const
         } else {
             ret = createWebRequestHandler(_("index"));
         }
+    } else if (link.startsWith(_("/") + DEVICE_DESCRIPTION_PATH)) {
+        ret = new DeviceDescriptionHandler(xmlbuilder.get());
     } else if (link.startsWith(_("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_SERVE_HANDLER)) {
         if (string_ok(ConfigManager::getInstance()->getOption(CFG_SERVER_SERVEDIR)))
             ret = new ServeRequestHandler();

--- a/src/server.h
+++ b/src/server.h
@@ -138,7 +138,7 @@ protected:
     /// The URL is constructed upon server initialization, since
     /// the real port is not known before. The value of this variable
     /// is returned by the getVirtualURL() function.
-    zmm::String virtual_url;
+    zmm::String virtualUrl;
 
     /// \brief Device description document is created on the fly and
     /// stored here.

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -38,7 +38,11 @@
 using namespace zmm;
 using namespace mxml;
 
-UpnpXMLBuilder::UpnpXMLBuilder(String virtualUrl): virtualUrl(virtualUrl) {};
+UpnpXMLBuilder::UpnpXMLBuilder(String virtualUrl, String presentationURL)
+    : virtualURL(virtualUrl)
+    , presentationURL(presentationURL)
+{
+}
 
 Ref<Element> UpnpXMLBuilder::createResponse(String actionName, String serviceType)
 {
@@ -113,7 +117,7 @@ Ref<Element> UpnpXMLBuilder::renderObject(Ref<CdsObject> obj, bool renderActions
                 Ref<Dictionary> dict(new Dictionary());
                 dict->put(_(URL_OBJECT_ID), aa_id);
 
-                url = virtualUrl + _(_URL_PARAM_SEPARATOR) + CONTENT_MEDIA_HANDLER + _(_URL_PARAM_SEPARATOR) + dict->encodeSimple() + _(_URL_PARAM_SEPARATOR) + _(URL_RESOURCE_ID) + _(_URL_PARAM_SEPARATOR) + "0";
+                url = virtualURL + _(_URL_PARAM_SEPARATOR) + CONTENT_MEDIA_HANDLER + _(_URL_PARAM_SEPARATOR) + dict->encodeSimple() + _(_URL_PARAM_SEPARATOR) + _(URL_RESOURCE_ID) + _(_URL_PARAM_SEPARATOR) + "0";
                 log_debug("UpnpXMLRenderer::DIDLRenderObject: url: %s\n", url.c_str());
                 Ref<Element> aa(new Element(MetadataHandler::getMetaFieldName(M_ALBUMARTURI)));
                 aa->setText(url);
@@ -191,7 +195,7 @@ Ref<Element> UpnpXMLBuilder::renderObject(Ref<CdsObject> obj, bool renderActions
                 Ref<Dictionary> dict(new Dictionary());
                 dict->put(_(URL_OBJECT_ID), aa_id);
 
-                url = virtualUrl + _(_URL_PARAM_SEPARATOR) + CONTENT_MEDIA_HANDLER + _(_URL_PARAM_SEPARATOR) + dict->encodeSimple() + _(_URL_PARAM_SEPARATOR) + _(URL_RESOURCE_ID) + _(_URL_PARAM_SEPARATOR) + "0";
+                url = virtualURL + _(_URL_PARAM_SEPARATOR) + CONTENT_MEDIA_HANDLER + _(_URL_PARAM_SEPARATOR) + dict->encodeSimple() + _(_URL_PARAM_SEPARATOR) + _(URL_RESOURCE_ID) + _(_URL_PARAM_SEPARATOR) + "0";
 
                 result->appendElementChild(renderAlbumArtURI(url));
 
@@ -295,7 +299,7 @@ Ref<Element> UpnpXMLBuilder::createEventPropertySet()
     return propset;
 }
 
-Ref<Element> UpnpXMLBuilder::renderDeviceDescription(String presentationURL)
+Ref<Element> UpnpXMLBuilder::renderDeviceDescription()
 {
     Ref<ConfigManager> config = ConfigManager::getInstance();
 
@@ -588,9 +592,9 @@ String UpnpXMLBuilder::getArtworkUrl(zmm::Ref<CdsItem> item) {
 
     Ref<PathBase> urlBase = getPathBase(item);
     if (urlBase->addResID) {
-        return virtualUrl + urlBase->pathBase + 1 + "/rct/aa";
+        return virtualURL + urlBase->pathBase + 1 + "/rct/aa";
     }
-    return virtualUrl + urlBase->pathBase;
+    return virtualURL + urlBase->pathBase;
 }
 
 String UpnpXMLBuilder::renderExtension(String contentType, String location)
@@ -867,7 +871,7 @@ void UpnpXMLBuilder::addResources(Ref<CdsItem> item, Ref<Element> element)
 
                 if (rct == ID3_ALBUM_ART) {
                     Ref<Element> aa(new Element(MetadataHandler::getMetaFieldName(M_ALBUMARTURI)));
-                    aa->setText(virtualUrl + url);
+                    aa->setText(virtualURL + url);
                     if (config->getBoolOption(CFG_SERVER_EXTEND_PROTOCOLINFO)) {
                         /// \todo clean this up, make sure to check the mimetype and
                         /// provide the profile correctly
@@ -946,7 +950,7 @@ void UpnpXMLBuilder::addResources(Ref<CdsItem> item, Ref<Element> element)
         // URL is path until now
         int objectType = item->getObjectType();
         if(!IS_CDS_ITEM_EXTERNAL_URL(objectType)) {
-            url = virtualUrl + url;
+            url = virtualURL + url;
         }
 
         if (!hide_original_resource || transcoded || (hide_original_resource && (original_resource != i)))

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -38,7 +38,7 @@
 
 class UpnpXMLBuilder {
 public:
-    explicit UpnpXMLBuilder(zmm::String virtualUrl);
+    explicit UpnpXMLBuilder(zmm::String virtualUrl, zmm::String presentationURL);
 
     /// \brief Renders XML for the action response header.
     /// \param actionName Name of the action.
@@ -74,7 +74,7 @@ public:
     ///
     /// Some elements are statically defined in common.h, others are loaded
     /// from the config with the help of the ConfigManager.
-    zmm::Ref<mxml::Element> renderDeviceDescription(zmm::String presentationUTL = nullptr);
+    zmm::Ref<mxml::Element> renderDeviceDescription();
 
     /// \brief Renders a resource tag (part of DIDL-Lite XML)
     /// \param URL download location of the item (will be child element of the <res> tag)
@@ -103,7 +103,8 @@ public:
     static zmm::String getFirstResourcePath(zmm::Ref<CdsItem> item);
 
 protected:
-    zmm::String virtualUrl;
+    zmm::String virtualURL;
+    zmm::String presentationURL;
 
     // Holds a part of path and bool which says if we need to append the resource
     // TODO: Remove this and use centralised routing instead of building URLs all over the place

--- a/test/test_upnp/test_upnp_xml.cc
+++ b/test/test_upnp/test_upnp_xml.cc
@@ -13,7 +13,8 @@ class UpnpXmlTest : public ::testing::Test {
 
   virtual void SetUp() {
     zmm::String virtualDir = "/dir/virtual";
-    subject = new UpnpXMLBuilder(virtualDir);
+    zmm::String presentationURl = "http://someurl/";
+    subject = new UpnpXMLBuilder(virtualDir, presentationURl);
   }
 
   virtual void TearDown() {


### PR DESCRIPTION
This is currently not used, but will be needed when we switch to the
newer `UpnpRegisterRootDeviceX` methods.

It serves the device description XML as generated by
`renderDeviceDescription()` at `<serverpath>/content/description.xml`