### PR TITLE
Set language to support xenial & latest chrome

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # None as otherwise it clobbers our compiler choce
-language: none
+language: cpp
 
 # Ubuntu 16.04 Xenial support
 sudo: required


### PR DESCRIPTION
## Changes

Update the travis CI build to define `language: cpp`

* Solves issue where Travis gives `trusty` when `language` is not defined
* Solves `dpkg` support for new Chrome packaging by using `xenial`

## Verified 

Travis builds with `xenial`

```
Operating System Details
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.6 LTS
Release:	16.04
Codename:	xenial
```

Travis builds with each different C++ version

```
[  0%] Building CXX object CMakeFiles/libgerbera.dir/src/action_request.cc.o
/usr/bin/g++-7  -DATRAILERS
```
```
[  0%] Building CXX object CMakeFiles/libgerbera.dir/src/action_request.cc.o
/usr/bin/g++-8  -DATRAILERS
```
```
[  0%] Building CXX object CMakeFiles/libgerbera.dir/src/action_request.cc.o
/usr/bin/clang++-7  -DATRAILERS
```