### PR TITLE
fix matroska build without js, taglib or atrailers

### DIFF
--- a/src/string_converter.cc
+++ b/src/string_converter.cc
@@ -218,7 +218,7 @@ Ref<StringConverter> StringConverter::p2i()
 }
 #endif
 
-#if defined(HAVE_JS) || defined(HAVE_TAGLIB) || defined(ATRAILERS)
+#if defined(HAVE_JS) || defined(HAVE_TAGLIB) || defined(ATRAILERS) || defined(HAVE_MATROSKA)
 
 Ref<StringConverter> StringConverter::i2i()
 {

--- a/src/string_converter.h
+++ b/src/string_converter.h
@@ -65,7 +65,7 @@ public:
     static zmm::Ref<StringConverter> p2i();
 
 #endif
-#if defined(HAVE_JS) || defined(HAVE_TAGLIB) || defined(ATRAILERS)
+#if defined(HAVE_JS) || defined(HAVE_TAGLIB) || defined(ATRAILERS) || defined(HAVE_MATROSKA)
     /// \brief safeguard - internal to internal - needed to catch some
     /// scenarious where the user may have forgotten to add proper conversion
     /// in the script.


### PR DESCRIPTION
i2i function is used in matroska_handler.cc but this function is defined
only if defined(HAVE_JS) || defined(HAVE_TAGLIB) || defined(ATRAILERS)
as a result compilation fails if HAVE_MATROSKA is set but HAVE_JS,
HAVE_TAGLIG or ATRAILERS are not.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>