### PR TITLE
cmake/FindLibUpnp.cmake: drop libupnp-1.8

### DIFF
--- a/cmake/FindLibUpnp.cmake
+++ b/cmake/FindLibUpnp.cmake
@@ -7,7 +7,7 @@
 #  UPNP_HAS_IPV6 - If LinUPnP was built with IPv6 support
 #  UPNP_HAS_REUSEADDR - If LinUPnP was built with SO_REUSEADDR support
 find_package(PkgConfig QUIET)
-pkg_search_module (PC_UPNP QUIET libupnp-1.8 libupnp)
+pkg_search_module (PC_UPNP QUIET libupnp)
 
 find_path(UPNP_INCLUDE_DIR upnp.h
     HINTS ${PC_UPNP_INCLUDEDIR} ${PC_UPNP_INCLUDE_DIRS}


### PR DESCRIPTION
-1.8 suffix has been dropped from pupnp since version 1.8.2 and commit
https://github.com/pupnp/pupnp/commit/07f504c61bd9e4d93eb3d373ffc8527cafe0b9af,
so drop search for libupnp-1.8 to avoid retrieving old or broken libupnp
versions

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>