### PR TITLE
simpliy search_handler.h/cc: replace std::make_shared<std::string> with std::string

### DIFF
--- a/src/search_handler.h
+++ b/src/search_handler.h
@@ -57,24 +57,24 @@ enum class TokenType {
 
 class SearchToken {
 public:
-    SearchToken(TokenType type, std::shared_ptr<std::string> value)
+    SearchToken(TokenType type, const std::string& value)
         : type(type)
-        , value(std::move(value))
+        , value(value)
     {
     }
     virtual ~SearchToken() {};
 
     const TokenType& getType() const { return type; }
-    std::shared_ptr<std::string> getValue() const { return value; }
+    std::string getValue() const { return value; }
 
     friend bool operator==(const SearchToken& lhs, const SearchToken& rhs)
     {
-        return lhs.type == rhs.type && *(lhs.value) == *(rhs.value);
+        return lhs.type == rhs.type && lhs.value == rhs.value;
     }
 
 protected:
     const TokenType type;
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 class SearchLexer {
@@ -93,9 +93,9 @@ public:
     SearchLexer(const SearchLexer&&) = delete;
 
 protected:
-    std::shared_ptr<std::string> nextStringToken(const std::string& input);
-    std::unique_ptr<SearchToken> makeToken(std::shared_ptr<std::string> tokenStr);
-    std::shared_ptr<std::string> getQuotedValue(const std::string& input);
+    std::string nextStringToken(const std::string& input);
+    std::unique_ptr<SearchToken> makeToken(const std::string& tokenStr);
+    std::string getQuotedValue(const std::string& input);
 
     const std::string& input;
     unsigned currentPos;
@@ -111,8 +111,8 @@ class SQLEmitter;
 
 class ASTNode {
 public:
-    std::shared_ptr<std::string> emitSQL();
-    virtual std::shared_ptr<std::string> emit() const = 0;
+    std::string emitSQL();
+    virtual std::string emit() const = 0;
 
     virtual ~ASTNode() = default;
 
@@ -125,38 +125,38 @@ protected:
 
 class ASTAsterisk : public ASTNode {
 public:
-    ASTAsterisk(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTAsterisk(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTAsterisk() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 class ASTProperty : public ASTNode {
 public:
-    ASTProperty(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTProperty(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTProperty() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 class ASTBoolean : public ASTNode {
 public:
-    ASTBoolean(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTBoolean(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTBoolean() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 class ASTParenthesis : public ASTNode {
@@ -164,7 +164,7 @@ public:
     ASTParenthesis(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTNode> node)
         : ASTNode(sqlEmitter)
         , bracketedNode(std::move(node)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTParenthesis() = default;
 
 protected:
@@ -173,26 +173,26 @@ protected:
 
 class ASTDQuote : public ASTNode {
 public:
-    ASTDQuote(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTDQuote(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTDQuote() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 class ASTEscapedString : public ASTNode {
 public:
-    ASTEscapedString(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTEscapedString(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTEscapedString() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 class ASTQuotedString : public ASTNode {
@@ -203,7 +203,7 @@ public:
         , openQuote(std::move(openQuote))
         , escapedString(std::move(escapedString))
         , closeQuote(std::move(closeQuote)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTQuotedString() = default;
 
 protected:
@@ -215,16 +215,16 @@ protected:
 /// \brief Represents a comparison operator such as =, >=, <
 class ASTCompareOperator : public ASTNode {
 public:
-    ASTCompareOperator(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTCompareOperator(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
-    std::shared_ptr<std::string> emit(const std::string& property, const std::string& value) const;
-    std::shared_ptr<std::string> getValue() const { return value; }
+    std::string emit() const override;
+    std::string emit(const std::string& property, const std::string& value) const;
+    std::string getValue() const { return value; }
     virtual ~ASTCompareOperator() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 /// \brief Represents an expression using a comparison operator
@@ -236,7 +236,7 @@ public:
         , lhs(std::move(lhs))
         , operatr(std::move(operatr))
         , rhs(std::move(rhs)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTCompareExpression() = default;
 
 protected:
@@ -248,16 +248,16 @@ protected:
 /// \brief Represents an operator defined by a string such as contains, derivedFrom
 class ASTStringOperator : public ASTNode {
 public:
-    ASTStringOperator(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTStringOperator(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
-    std::shared_ptr<std::string> emit(const std::string& property, const std::string& value) const;
-    std::shared_ptr<std::string> getValue() const { return value; }
+    std::string emit() const override;
+    std::string emit(const std::string& property, const std::string& value) const;
+    std::string getValue() const { return value; }
     virtual ~ASTStringOperator() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 /// \brief Represents an expression using an operator defined by a string
@@ -269,7 +269,7 @@ public:
         , lhs(std::move(lhs))
         , operatr(std::move(operatr))
         , rhs(std::move(rhs)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTStringExpression() = default;
 
 protected:
@@ -280,15 +280,15 @@ protected:
 
 class ASTExistsOperator : public ASTNode {
 public:
-    ASTExistsOperator(const SQLEmitter& sqlEmitter, std::shared_ptr<std::string> value)
+    ASTExistsOperator(const SQLEmitter& sqlEmitter, const std::string& value)
         : ASTNode(sqlEmitter)
         , value(std::move(value)) {};
-    std::shared_ptr<std::string> emit() const override;
-    std::shared_ptr<std::string> emit(const std::string& property, const std::string& value) const;
+    std::string emit() const override;
+    std::string emit(const std::string& property, const std::string& value) const;
     virtual ~ASTExistsOperator() = default;
 
 protected:
-    std::shared_ptr<std::string> value;
+    std::string value;
 };
 
 /// \brief Represents an expression using the exists operator
@@ -300,7 +300,7 @@ public:
         , lhs(std::move(lhs))
         , operatr(std::move(operatr))
         , rhs(std::move(rhs)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTExistsExpression() = default;
 
 protected:
@@ -316,7 +316,7 @@ public:
         : ASTNode(sqlEmitter)
         , lhs(std::move(lhs))
         , rhs(std::move(rhs)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTAndOperator() = default;
 
 protected:
@@ -331,7 +331,7 @@ public:
         : ASTNode(sqlEmitter)
         , lhs(std::move(lhs))
         , rhs(std::move(rhs)) {};
-    std::shared_ptr<std::string> emit() const override;
+    std::string emit() const override;
     virtual ~ASTOrOperator() = default;
 
 protected:
@@ -341,19 +341,19 @@ protected:
 
 class SQLEmitter {
 public:
-    virtual std::shared_ptr<std::string> emitSQL(const ASTNode* node) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTAsterisk* node) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTParenthesis* node, const std::string& bracketedNode) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTDQuote* node) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTCompareOperator* node,
+    virtual std::string emitSQL(const ASTNode* node) const = 0;
+    virtual std::string emit(const ASTAsterisk* node) const = 0;
+    virtual std::string emit(const ASTParenthesis* node, const std::string& bracketedNode) const = 0;
+    virtual std::string emit(const ASTDQuote* node) const = 0;
+    virtual std::string emit(const ASTCompareOperator* node,
         const std::string& property, const std::string& value) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTStringOperator* node,
+    virtual std::string emit(const ASTStringOperator* node,
         const std::string& property, const std::string& value) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTExistsOperator* node,
+    virtual std::string emit(const ASTExistsOperator* node,
         const std::string& property, const std::string& value) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTAndOperator* node,
+    virtual std::string emit(const ASTAndOperator* node,
         const std::string& lhs, const std::string& rhs) const = 0;
-    virtual std::shared_ptr<std::string> emit(const ASTOrOperator* node,
+    virtual std::string emit(const ASTOrOperator* node,
         const std::string& lhs, const std::string& rhs) const = 0;
 
     virtual ~SQLEmitter() = default;
@@ -361,18 +361,18 @@ public:
 };
 
 class DefaultSQLEmitter : public SQLEmitter {
-    std::shared_ptr<std::string> emitSQL(const ASTNode* node) const override;
-    std::shared_ptr<std::string> emit(const ASTAsterisk* node) const override { return std::make_shared<std::string>("*"); };
-    std::shared_ptr<std::string> emit(const ASTParenthesis* node, const std::string& bracketedNode) const override;
-    std::shared_ptr<std::string> emit(const ASTDQuote* node) const override { return std::make_shared<std::string>(""); };
-    std::shared_ptr<std::string> emit(const ASTCompareOperator* node,
+    std::string emitSQL(const ASTNode* node) const override;
+    std::string emit(const ASTAsterisk* node) const override { return "*"; };
+    std::string emit(const ASTParenthesis* node, const std::string& bracketedNode) const override;
+    std::string emit(const ASTDQuote* node) const override { return ""; };
+    std::string emit(const ASTCompareOperator* node,
         const std::string& property, const std::string& value) const override;
-    std::shared_ptr<std::string> emit(const ASTStringOperator* node,
+    std::string emit(const ASTStringOperator* node,
         const std::string& property, const std::string& value) const override;
-    std::shared_ptr<std::string> emit(const ASTExistsOperator* node,
+    std::string emit(const ASTExistsOperator* node,
         const std::string& property, const std::string& value) const override;
-    std::shared_ptr<std::string> emit(const ASTAndOperator* node, const std::string& lhs, const std::string& rhs) const override;
-    std::shared_ptr<std::string> emit(const ASTOrOperator* node, const std::string& lhs, const std::string& rhs) const override;
+    std::string emit(const ASTAndOperator* node, const std::string& lhs, const std::string& rhs) const override;
+    std::string emit(const ASTOrOperator* node, const std::string& lhs, const std::string& rhs) const override;
 
     inline char tableQuote() const override { return '"'; };
 };

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -618,12 +618,12 @@ zmm::Ref<zmm::Array<CdsObject>> SQLStorage::search(zmm::Ref<SearchParam> param, 
 {
     std::unique_ptr<SearchParser> searchParser = std::make_unique<SearchParser>(*sqlEmitter, param->searchCriteria());
     std::shared_ptr<ASTNode> rootNode = searchParser->parse();
-    std::shared_ptr<std::string> searchSQL(rootNode->emitSQL());
-    if (!searchSQL->length())
+    std::string searchSQL(rootNode->emitSQL());
+    if (!searchSQL.length())
         throw _Exception("failed to generate SQL for search");
 
     std::ostringstream countSQL;
-    countSQL << "select count(*) " << *searchSQL << ';';
+    countSQL << "select count(*) " << searchSQL << ';';
     zmm::Ref<SQLResult> sqlResult;
     sqlResult = select(countSQL);
     zmm::Ref<SQLRow> countRow = sqlResult->nextRow();
@@ -632,7 +632,7 @@ zmm::Ref<zmm::Array<CdsObject>> SQLStorage::search(zmm::Ref<SearchParam> param, 
     }
     
     std::ostringstream retrievalSQL;
-    retrievalSQL << SELECT_DATA_FOR_SEARCH << " " << *searchSQL;
+    retrievalSQL << SELECT_DATA_FOR_SEARCH << " " << searchSQL;
     int startingIndex = param->getStartingIndex(), requestedCount = param->getRequestedCount();
     if (startingIndex > 0 || requestedCount > 0) {
         retrievalSQL << " order by c.id"

--- a/test/test_searchhandler/test_searchhandler.cc
+++ b/test/test_searchhandler/test_searchhandler.cc
@@ -48,7 +48,7 @@ decltype(auto) getAllTokens(const std::string& input)
     if (expectedTokens.size() != tokens->size())
         return ::testing::AssertionFailure() << "Expected " << expectedTokens.size() << " tokens, got " << tokens->size();
     for (unsigned i = 0; i < tokens->size(); i++) {
-        if (expectedTokens.at(i).first != *(tokens->at(i)->getValue()))
+        if (expectedTokens.at(i).first != tokens->at(i)->getValue())
             return ::testing::AssertionFailure() << "Token " << i << ": expected ["
                                                  << expectedTokens.at(i).first
                                                  << "], got ["
@@ -73,7 +73,7 @@ decltype(auto) getAllTokens(const std::string& input)
             return ::testing::AssertionFailure() << "Failed to create AST";
 
         auto output = rootNode->emit();
-        if (*output != expectedOutput)
+        if (output != expectedOutput)
             return ::testing::AssertionFailure() << "\nExpected [" << expectedOutput << "]\nActual   [" << output << "]\n";
 
         return ::testing::AssertionSuccess();
@@ -86,62 +86,62 @@ TEST(SearchLexer, OneSimpleTokenRecognized)
 {
     auto tokens = getAllTokens("=");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::COMPAREOP, std::move(std::make_unique<std::string>("="))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::COMPAREOP, "="), *tokens->at(0));
 
     tokens = getAllTokens("!=");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::COMPAREOP, std::move(std::make_unique<std::string>("!="))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::COMPAREOP, "!="), *tokens->at(0));
 
     tokens = getAllTokens(">");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::COMPAREOP, std::move(std::make_unique<std::string>(">"))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::COMPAREOP, ">"), *tokens->at(0));
 
     tokens = getAllTokens("(");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::LPAREN, std::move(std::make_unique<std::string>("("))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::LPAREN, "("), *tokens->at(0));
 }
 
 TEST(SearchLexer,OneComplexTokenRecognized)
 {
     auto tokens = getAllTokens("\"");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_STREQ("\"", tokens->at(0)->getValue()->c_str());
-    EXPECT_EQ(1, tokens->at(0)->getValue()->length());
+    EXPECT_STREQ("\"", tokens->at(0)->getValue().c_str());
+    EXPECT_EQ(1, tokens->at(0)->getValue().length());
     EXPECT_EQ(TokenType::DQUOTE, tokens->at(0)->getType());
 
     tokens = getAllTokens("true");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::BOOLVAL, std::move(std::make_unique<std::string>("true"))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::BOOLVAL, "true"), *tokens->at(0));
 
     tokens = getAllTokens("FALSE");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::BOOLVAL, std::move(std::make_unique<std::string>("FALSE"))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::BOOLVAL, "FALSE"), *tokens->at(0));
 
     tokens = getAllTokens("and");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::AND, std::move(std::make_unique<std::string>("and"))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::AND, "and"), *tokens->at(0));
 
     tokens = getAllTokens("OR");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::OR, std::move(std::make_unique<std::string>("OR"))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::OR, "OR"), *tokens->at(0));
 
     tokens = getAllTokens("exists");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_EQ(SearchToken(TokenType::EXISTS, std::move(std::make_unique<std::string>("exists"))), *(tokens->at(0)));
+    EXPECT_EQ(SearchToken(TokenType::EXISTS, "exists"), *tokens->at(0));
 
     tokens = getAllTokens("@id");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_STREQ("@id", tokens->at(0)->getValue()->c_str());
+    EXPECT_STREQ("@id", tokens->at(0)->getValue().c_str());
     EXPECT_EQ(TokenType::PROPERTY, tokens->at(0)->getType());
 
     tokens = getAllTokens("res@size");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_STREQ("res@size", tokens->at(0)->getValue()->c_str());
+    EXPECT_STREQ("res@size", tokens->at(0)->getValue().c_str());
     EXPECT_EQ(TokenType::PROPERTY, tokens->at(0)->getType());
 
     tokens = getAllTokens("dc:title");
     EXPECT_EQ(1, tokens->size());
-    EXPECT_STREQ("dc:title", tokens->at(0)->getValue()->c_str());
+    EXPECT_STREQ("dc:title", tokens->at(0)->getValue().c_str());
     EXPECT_EQ(TokenType::PROPERTY, tokens->at(0)->getType());
 }
 


### PR DESCRIPTION
as a result of the change from String class to std::string, we can now simplify search_handler.h/cc