### PR TITLE
CMakeLists.txt: check for atomic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,11 @@ endif()
 find_package(Threads REQUIRED)
 target_link_libraries(gerbera ${CMAKE_THREAD_LIBS_INIT})
 
+check_library_exists(atomic __atomic_fetch_add_4 "" HAVE_ATOMIC)
+if(HAVE_ATOMIC)
+    target_link_libraries(gerbera atomic)
+endif(HAVE_ATOMIC)
+
 find_package(Iconv REQUIRED)
 include_directories(${ICONV_INCLUDE_DIR})
 target_link_libraries(gerbera ${ICONV_LIBRARIES})


### PR DESCRIPTION
On some architectures, atomic binutils are provided by the libatomic
library from gcc. Linking with libatomic is therefore necessary,
otherwise the build fails with:

```
[100%] Linking CXX executable gerbera
/home/fabrice/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/sparc-buildroot-linux-uclibc/7.4.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: CMakeFiles/libgerbera.dir/src/zmm/object.cc.o: undefined reference to symbol '__atomic_fetch_add_4@@LIBATOMIC_1.0'
/home/fabrice/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/sparc-buildroot-linux-uclibc/7.4.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/fabrice/buildroot/output/host/sparc-buildroot-linux-uclibc/sysroot/lib/libatomic.so.1: error adding symbols: DSO missing from command line
```

This is often for example the case on sparc v8 32 bits.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>