### PR TITLE
Only output copyright message if we are not creating gerbera config

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -158,7 +158,9 @@ int main(int argc, char** argv, char** envp)
         }
 
         // Action starts here
-        log_copyright();
+        if (opts.count("create-config") == 0) {
+            log_copyright();
+        }
 
         std::optional<std::string> home;
         if (opts.count("home") > 0) {


### PR DESCRIPTION
Introduced in recent [commit](https://github.com/gerbera/gerbera/commit/a0ad8a6b29ab24aa144db6f0b9b09d0dde91ed25#diff-ddaa7d6e643bc0d374add600b02445beR146) the `gerbera` executable will always display a copyright message. This causes problems when using `create-config` since the output isn't valid XML.

Example:
```
root@742210bc9cd6:~# gerbera --create-config
2020-01-16 02:50:30   info: Gerbera UPnP Server version 1.5.0_git - http://gerbera.io/
2020-01-16 02:50:30   info: ===============================================================================
2020-01-16 02:50:30   info: Gerbera is free software, covered by the GNU General Public License version 2
2020-01-16 02:50:30   info: Copyright 2016-2019 Gerbera Contributors.
2020-01-16 02:50:30   info: Gerbera is based on MediaTomb: Copyright 2005-2010 Gena Batsyan, Sergey Bostandzhyan, Leonhard Wimmer.
2020-01-16 02:50:30   info: ===============================================================================
<?xml version="1.0" encoding="UTF-8"?>
<config version="2" xmlns="http://mediatomb.cc/config/2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://mediatomb.cc/config/2 http://mediatomb.cc/config/2.xsd">
  <!--
     See http://gerbera.io or read the docs for more
     information on creating and using config.xml configration files.
    -->
  <server>
```

This change will only display copyright info if it's explicitly not a `--create-config` situation.

I'm not much of a coder so you may have a better way to get around this issue :rofl: