### PR TITLE
link test binaries against libgerbera

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,12 +214,12 @@ set(libgerberaFILES
         src/web/web_autoscan.cc
         src/web/web_update.cc)
 
-add_library(libgerbera OBJECT ${libgerberaFILES})
-
+add_library(libgerbera STATIC ${libgerberaFILES})
 target_include_directories(libgerbera PRIVATE "${CMAKE_SOURCE_DIR}/src")
 
-add_executable(gerbera src/main.cc $<TARGET_OBJECTS:libgerbera>)
+add_executable(gerbera src/main.cc)
 target_include_directories(gerbera PRIVATE "${CMAKE_SOURCE_DIR}/src")
+target_link_libraries(gerbera libgerbera)
 
 target_compile_features(gerbera PUBLIC cxx_std_17)
 target_compile_features(libgerbera PUBLIC cxx_std_17)

--- a/test/test_config/CMakeLists.txt
+++ b/test/test_config/CMakeLists.txt
@@ -1,13 +1,13 @@
 find_package(Threads REQUIRED)
 
 add_executable(testconfig
-        $<TARGET_OBJECTS:libgerbera>
         main.cc
         test_configgenerator.cc
         test_configmanager.cc
         )
 
 include_directories(
+        "${CMAKE_SOURCE_DIR}/src"
         ${UPNP_INCLUDE_DIRS}
         ${UUID_INCLUDE_DIRS}
         ${MAGIC_INCLUDE_DIRS}
@@ -27,6 +27,7 @@ include_directories(
 )
 
 target_link_libraries(testconfig PRIVATE
+        libgerbera
         ${UUID_LIBRARIES}
         ${UPNP_LIBRARIES}
         ${MAGIC_LIBRARIES}

--- a/test/test_handler/CMakeLists.txt
+++ b/test/test_handler/CMakeLists.txt
@@ -1,11 +1,11 @@
 find_package(Threads REQUIRED)
 
 add_executable(testhandler
-        $<TARGET_OBJECTS:libgerbera>
         test_http_protocol_helper.cc
         )
 
 include_directories(
+        "${CMAKE_SOURCE_DIR}/src"
         ${UPNP_INCLUDE_DIRS}
         ${UUID_INCLUDE_DIRS}
         ${MAGIC_INCLUDE_DIRS}
@@ -26,6 +26,7 @@ include_directories(
 )
 
 target_link_libraries(testhandler PRIVATE
+        libgerbera
         ${UUID_LIBRARIES}
         ${UPNP_LIBRARIES}
         ${MAGIC_LIBRARIES}

--- a/test/test_runtime/CMakeLists.txt
+++ b/test/test_runtime/CMakeLists.txt
@@ -1,13 +1,13 @@
 find_package(Threads REQUIRED)
 
 add_executable(testruntime
-        $<TARGET_OBJECTS:libgerbera>
         main.cc
         test_runtime.h
         test_runtime.cc
         )
 
 include_directories(
+        "${CMAKE_SOURCE_DIR}/src"
         ${UPNP_INCLUDE_DIRS}
         ${UUID_INCLUDE_DIRS}
         ${MAGIC_INCLUDE_DIRS}
@@ -27,6 +27,7 @@ include_directories(
 )
 
 target_link_libraries(testruntime PRIVATE
+        libgerbera
         ${UUID_LIBRARIES}
         ${UPNP_LIBRARIES}
         ${MAGIC_LIBRARIES}

--- a/test/test_script/CMakeLists.txt
+++ b/test/test_script/CMakeLists.txt
@@ -1,7 +1,6 @@
 find_package(Threads REQUIRED)
 
 add_executable(testscript
-        $<TARGET_OBJECTS:libgerbera>
         main.cc
         mock/duk_helper.h
         mock/duk_helper.cc
@@ -17,6 +16,7 @@ add_executable(testscript
         test_internal_pls_playlist.cc)
 
 include_directories(
+        "${CMAKE_SOURCE_DIR}/src"
         ${UPNP_INCLUDE_DIRS}
         ${UUID_INCLUDE_DIRS}
         ${MAGIC_INCLUDE_DIRS}
@@ -37,6 +37,7 @@ include_directories(
 )
 
 target_link_libraries(testscript PRIVATE
+        libgerbera
         ${UUID_LIBRARIES}
         ${UPNP_LIBRARIES}
         ${MAGIC_LIBRARIES}

--- a/test/test_searchhandler/CMakeLists.txt
+++ b/test/test_searchhandler/CMakeLists.txt
@@ -1,12 +1,12 @@
 find_package(Threads REQUIRED)
 
 add_executable(testsearchhandler
-        $<TARGET_OBJECTS:libgerbera>
         main.cc
         test_searchhandler.cc
         )
 
 include_directories(
+        "${CMAKE_SOURCE_DIR}/src"
         ${UPNP_INCLUDE_DIRS}
         ${UUID_INCLUDE_DIRS}
         ${MAGIC_INCLUDE_DIRS}
@@ -26,6 +26,7 @@ include_directories(
 )
 
 target_link_libraries(testsearchhandler PRIVATE
+        libgerbera
         ${UUID_LIBRARIES}
         ${UPNP_LIBRARIES}
         ${MAGIC_LIBRARIES}

--- a/test/test_server/CMakeLists.txt
+++ b/test/test_server/CMakeLists.txt
@@ -1,12 +1,12 @@
 find_package(Threads REQUIRED)
 
 add_executable(testserver
-        $<TARGET_OBJECTS:libgerbera>
         main.cc
         test_main.cc
         )
 
 include_directories(
+        "${CMAKE_SOURCE_DIR}/src"
         ${UPNP_INCLUDE_DIRS}
         ${UUID_INCLUDE_DIRS}
         ${MAGIC_INCLUDE_DIRS}
@@ -26,6 +26,7 @@ include_directories(
 )
 
 target_link_libraries(testserver PRIVATE
+        libgerbera
         ${UUID_LIBRARIES}
         ${UPNP_LIBRARIES}
         ${MAGIC_LIBRARIES}

--- a/test/test_upnp/CMakeLists.txt
+++ b/test/test_upnp/CMakeLists.txt
@@ -1,11 +1,11 @@
 find_package(Threads REQUIRED)
 
 add_executable(testupnp
-        $<TARGET_OBJECTS:libgerbera>
         main.cc
         test_upnp_xml.cc)
 
 include_directories(
+        "${CMAKE_SOURCE_DIR}/src"
         ${UPNP_INCLUDE_DIRS}
         ${UUID_INCLUDE_DIRS}
         ${MAGIC_INCLUDE_DIRS}
@@ -26,6 +26,7 @@ include_directories(
 )
 
 target_link_libraries(testupnp PRIVATE
+        libgerbera
         ${UUID_LIBRARIES}
         ${UPNP_LIBRARIES}
         ${MAGIC_LIBRARIES}


### PR DESCRIPTION
seems more logical: make libgerbera STATIC and reuse it for gerbera + all test binaries
