### PR TITLE
Fix basic_string::_M_construct null not valid in autoscan

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -224,7 +224,7 @@ int main(int argc, char** argv, char** envp)
         if (opts.count("create-config") > 0) {
             ConfigGenerator configGenerator;
 
-            std::string generated = configGenerator.generate(*home, *confdir, *prefix, *magic);
+            std::string generated = configGenerator.generate(home.value_or(""), confdir.value_or(""), prefix.value_or(""), magic.value_or(""));
             std::cout << generated.c_str() << std::endl;
             exit(EXIT_SUCCESS);
         }

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -115,7 +115,7 @@ void web::autoscan::process()
             //    AutoscanDirectory::mapScanlevel(scan_level).c_str(), recursive, interval, hidden);
 
             auto autoscan = std::make_shared<AutoscanDirectory>(
-                nullptr, //location
+                "", //location
                 scan_mode,
                 scan_level,
                 recursive,


### PR DESCRIPTION
Fixes #628