### PR TITLE
[clang-tidy] use nullptr

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -877,7 +877,7 @@ void ConfigManager::load(fs::path filename, fs::path userHome)
     if (temp == "yes")
         el = getElement("/transcoding");
     else
-        el = pugi::xml_node(NULL);
+        el = pugi::xml_node(nullptr);
     NEW_TRANSCODING_PROFILELIST_OPTION(createTranscodingProfileListFromNode(el));
     SET_TRANSCODING_PROFILELIST_OPTION(CFG_TRANSCODING_PROFILE_LIST);
 

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -171,7 +171,7 @@ void ContentManager::init()
             log_error("magic_open failed");
         } else {
             std::string optMagicFile = config->getOption(CFG_IMPORT_MAGIC_FILE);
-            const char* magicFile = NULL;
+            const char* magicFile = nullptr;
             if (!optMagicFile.empty())
                 magicFile = optMagicFile.c_str();
             if (magic_load(ms, magicFile) == -1) {

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -121,7 +121,7 @@ MatroskaHandler::MatroskaHandler(std::shared_ptr<ConfigManager> config)
 
 void MatroskaHandler::fillMetadata(std::shared_ptr<CdsItem> item)
 {
-    parseMKV(item, NULL);
+    parseMKV(item, nullptr);
 }
 
 std::unique_ptr<IOHandler> MatroskaHandler::serveContent(std::shared_ptr<CdsItem> item, int resNum)
@@ -140,10 +140,10 @@ void MatroskaHandler::parseMKV(std::shared_ptr<CdsItem> item, MemIOHandler** p_i
     EbmlStream ebml_stream(ebml_file);
 
     EbmlElement * el_l0 = ebml_stream.FindNextID(KaxSegment::ClassInfos, ~0);
-    while (el_l0 != NULL) {
+    while (el_l0 != nullptr) {
         int i_upper_level = 0;
         EbmlElement * el_l1 = ebml_stream.FindNextElement(el_l0->Generic().Context, i_upper_level, ~0, true);
-        while (el_l1 != NULL) {
+        while (el_l1 != nullptr) {
             parseLevel1Element(item, ebml_stream, el_l1, p_io_handler);
 
             el_l1->SkipData(ebml_stream, el_l1->Generic().Context);
@@ -226,7 +226,7 @@ void MatroskaHandler::parseAttachments(std::shared_ptr<CdsItem> item, EbmlStream
             KaxFileData& fileData = GetChild<KaxFileData>(*attachedFile);
             // printf("KaxFileData (size=%ld)\n", fileData.GetSize());
 
-            if (p_io_handler != NULL) {
+            if (p_io_handler != nullptr) {
                 // serveContent
                 *p_io_handler = new MemIOHandler(fileData.GetBuffer(), fileData.GetSize());
             } else {

--- a/src/server.cc
+++ b/src/server.cc
@@ -125,7 +125,7 @@ void Server::run()
     int port = config->getIntOption(CFG_SERVER_PORT);
 
     log_debug("Initialising libupnp with interface: '{}', port: {}", iface.c_str(), port);
-    const char* IfName = NULL;
+    const char* IfName = nullptr;
     if (!iface.empty()) IfName = iface.c_str();
     ret = UpnpInit2(IfName, port);
     if (ret != UPNP_E_SUCCESS) {

--- a/src/upnp_mrreg.cc
+++ b/src/upnp_mrreg.cc
@@ -117,7 +117,7 @@ void MRRegistrarService::processSubscriptionRequest(const std::unique_ptr<Subscr
     propset->print(buf, "", 0);
     std::string xml = buf.str();
 
-    IXML_Document* event = NULL;
+    IXML_Document* event = nullptr;
     int err = ixmlParseBufferEx(xml.c_str(), &event);
     if (err != IXML_SUCCESS) {
         throw UpnpException(UPNP_E_SUBSCRIPTION_FAILED, "Could not convert property set to ixml");

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -613,12 +613,12 @@ std::string getMIME(const fs::path& filepath, const void *buffer, size_t length)
     /* MAGIC_MIME_TYPE tells magic to return ONLY the mimetype */
     magic_t magic_cookie = magic_open(MAGIC_MIME_TYPE);
 
-    if (magic_cookie == NULL) {
+    if (magic_cookie == nullptr) {
         log_warning("Failed to initialize libmagic");
         return "";
     }
 
-    if (magic_load(magic_cookie, NULL) != 0) {
+    if (magic_load(magic_cookie, nullptr) != 0) {
         log_warning("Failed to load magic database: {}", magic_error(magic_cookie));
         magic_close(magic_cookie);
         return "";
@@ -975,8 +975,8 @@ std::string ipToInterface(std::string ip)
         log_error("Could not getifaddrs: {}", mt_strerror(errno).c_str());
     }
 
-    for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
-        if (ifa->ifa_addr == NULL)
+    for (ifa = ifaddr, n = 0; ifa != nullptr; ifa = ifa->ifa_next, n++) {
+        if (ifa->ifa_addr == nullptr)
             continue;
 
         family = ifa->ifa_addr->sa_family;
@@ -985,7 +985,7 @@ std::string ipToInterface(std::string ip)
         if (family == AF_INET || family == AF_INET6) {
             s = getnameinfo(ifa->ifa_addr,
                 (family == AF_INET) ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6),
-                host, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+                host, NI_MAXHOST, nullptr, 0, NI_NUMERICHOST);
             if (s != 0) {
                 log_error("getnameinfo() failed: {}", gai_strerror(s));
                 return "";
@@ -1328,7 +1328,7 @@ int find_local_port(unsigned short range_min, unsigned short range_max)
         }
 
         server = gethostbyname("127.0.0.1");
-        if (server == NULL) {
+        if (server == nullptr) {
             log_error("could not resolve localhost");
             close(fd);
             return -1;


### PR DESCRIPTION
Found with modernize-use-nullptr

Signed-off-by: Rosen Penev <rosenp@gmail.com>