### PR TITLE
[clang-tidy] use emplace_back

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -445,7 +445,7 @@ void ConfigManager::load(fs::path filename, fs::path userHome)
     std::vector<std::string> menu_opts;
     for (pugi::xml_node child: tmpEl.children()) {
         if (std::string(child.name()) == "option")
-            menu_opts.push_back(child.text().as_string());
+            menu_opts.emplace_back(child.text().as_string());
     }
     NEW_STRARR_OPTION(menu_opts);
     SET_STRARR_OPTION(CFG_SERVER_UI_ITEMS_PER_PAGE_DROPDOWN);

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -223,10 +223,10 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
                 // request header.
                 std::vector<std::string> subexts;
                 subexts.reserve(4);
-                subexts.push_back(".srt");
-                subexts.push_back(".ssa");
-                subexts.push_back(".smi");
-                subexts.push_back(".sub");
+                subexts.emplace_back(".srt");
+                subexts.emplace_back(".ssa");
+                subexts.emplace_back(".smi");
+                subexts.emplace_back(".sub");
 
                 // remove .ext
                 std::string pathNoExt = path.parent_path() / path.stem();

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -86,7 +86,7 @@ std::vector<std::string> split_string(std::string str, char sep, bool empty)
         } else if (pos == data) {
             data++;
             if ((data < end) && empty)
-                ret.push_back("");
+                ret.emplace_back("");
         } else {
             std::string part(data, pos - data);
             ret.push_back(part);


### PR DESCRIPTION
Found with modernize-use-emplace

Signed-off-by: Rosen Penev <rosenp@gmail.com>