### PR TITLE
[clang-tidy] remove redundant string initializations

### DIFF
--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -793,7 +793,7 @@ void ContentManager::addRecursive(fs::path path, bool hidden, std::shared_ptr<CM
                 if (IS_CDS_ITEM(obj->getObjectType())) {
                     if (layout != nullptr) {
                         try {
-                            std::string rootpath = "";
+                            std::string rootpath;
                             if (task != nullptr)
                                 rootpath = task->getRootPath();
                             layout->processCdsObject(obj, rootpath);

--- a/src/scripting/js_functions.cc
+++ b/src/scripting/js_functions.cc
@@ -74,7 +74,7 @@ duk_ret_t js_addCdsObject(duk_context *ctx)
         ts = "/";
     fs::path path = ts;
     //stack: js_cds_obj path
-    std::string containerclass = "";
+    std::string containerclass;
     if (!duk_is_null_or_undefined(ctx, 2))
     {
         containerclass = duk_to_string(ctx, 2);

--- a/src/storage/sqlite3/sqlite3_storage.cc
+++ b/src/storage/sqlite3/sqlite3_storage.cc
@@ -480,7 +480,7 @@ void SLInitTask::run(sqlite3** db, Sqlite3Storage* sl)
         nullptr,
         nullptr,
         &err);
-    std::string error = "";
+    std::string error;
     if (err != nullptr) {
         error = err;
         sqlite3_free(err);
@@ -511,7 +511,7 @@ void SLSelectTask::run(sqlite3** db, Sqlite3Storage* sl)
         &pres->nrow,
         &pres->ncolumn,
         &err);
-    std::string error = "";
+    std::string error;
     if (err != nullptr) {
         log_debug(err);
         error = err;
@@ -544,7 +544,7 @@ void SLExecTask::run(sqlite3** db, Sqlite3Storage* sl)
         nullptr,
         nullptr,
         &err);
-    std::string error = "";
+    std::string error;
     if (err != nullptr) {
         error = err;
         sqlite3_free(err);

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -189,7 +189,7 @@ fs::path find_in_path(const fs::path& exec)
         return "";
 
     auto st = std::make_unique<StringTokenizer>(PATH);
-    std::string path = "";
+    std::string path;
     std::string next;
     do {
         if (path.empty())

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -136,7 +136,7 @@ std::unique_ptr<IOHandler> WebRequestHandler::open(enum UpnpOpenFileMode mode)
 
     xml2JsonHints = std::make_shared<Xml2Json::Hints>();
 
-    std::string error = "";
+    std::string error;
     int error_code = 0;
 
     std::string output;


### PR DESCRIPTION
Found with readability-redundant-string-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>