### PR TITLE
[clang-tidy] use empty instead of comparing size

### DIFF
--- a/src/autoscan_inotify.cc
+++ b/src/autoscan_inotify.cc
@@ -402,7 +402,7 @@ void AutoscanInotify::recheckNonexistingMonitors(int wd, std::shared_ptr<Wd> wdO
         if (watch->getType() == WatchType::Autoscan) {
             auto watchAs = std::static_pointer_cast<WatchAutoscan>(watch);
             auto pathAr = watchAs->getNonexistingPathArray();
-            if (pathAr.size() != 0) {
+            if (!pathAr.empty()) {
                 recheckNonexistingMonitor(wd, pathAr, watchAs->getAutoscanDirectory());
             }
         }

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -108,7 +108,7 @@ ContentManager::ContentManager(std::shared_ptr<ConfigManager> config, std::share
 
     ignore_unknown_extensions = config->getBoolOption(CFG_IMPORT_MAPPINGS_IGNORE_UNKNOWN_EXTENSIONS);
 
-    if (ignore_unknown_extensions && (extension_mimetype_map.size() == 0)) {
+    if (ignore_unknown_extensions && (extension_mimetype_map.empty())) {
         log_warning("Ignore unknown extensions set, but no mappings specified");
         log_warning("Please review your configuration!");
         ignore_unknown_extensions = false;
@@ -715,7 +715,7 @@ void ContentManager::_rescanDirectory(int containerID, int scanID, ScanMode scan
     if ((shutdownFlag) || ((task != nullptr) && !task->isValid()))
         return;
 
-    if (list != nullptr && list->size() > 0) {
+    if (list != nullptr && !list->empty()) {
         auto changedContainers = storage->removeObjects(list);
         if (changedContainers != nullptr) {
             session_manager->containerChangedUI(changedContainers->ui);

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -275,7 +275,7 @@ std::vector<std::shared_ptr<SQLStorage::AddUpdateTable>> SQLStorage::_addUpdateO
     if (isUpdate)
         cdsObjectSql["auxdata"] = SQL_NULL;
     dict = obj->getAuxData();
-    if (dict.size() > 0 && (!hasReference || !std::equal(dict.begin(), dict.end(), refObj->getAuxData().begin()))) {
+    if (!dict.empty() && (!hasReference || !std::equal(dict.begin(), dict.end(), refObj->getAuxData().begin()))) {
         cdsObjectSql["auxdata"] = quote(dict_encode(obj->getAuxData()));
     }
 

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -124,7 +124,7 @@ bool Session::hasUIUpdateIDs()
     if (updateAll)
         return true;
     // AutoLock lock(mutex); only accessing an int - shouldn't be necessary
-    return (uiUpdateIDs->size() > 0);
+    return (!uiUpdateIDs->empty());
 }
 
 void Session::clearUpdateIDs()
@@ -198,7 +198,7 @@ std::string SessionManager::getUserPassword(std::string user)
 
 void SessionManager::containerChangedUI(int objectID)
 {
-    if (sessions.size() <= 0)
+    if (sessions.empty())
         return;
     AutoLock lock(mutex);
     for (size_t i = 0; i < sessions.size(); i++) {
@@ -210,7 +210,7 @@ void SessionManager::containerChangedUI(int objectID)
 
 void SessionManager::containerChangedUI(const std::vector<int>& objectIDs)
 {
-    if (sessions.size() <= 0)
+    if (sessions.empty())
         return;
     AutoLock lock(mutex);
     for (size_t i = 0; i < sessions.size(); i++) {
@@ -222,10 +222,10 @@ void SessionManager::containerChangedUI(const std::vector<int>& objectIDs)
 
 void SessionManager::checkTimer()
 {
-    if (sessions.size() > 0 && !timerAdded) {
+    if (!sessions.empty() && !timerAdded) {
         timer->addTimerSubscriber(this, SESSION_TIMEOUT_CHECK_INTERVAL);
         timerAdded = true;
-    } else if (sessions.size() <= 0 && timerAdded) {
+    } else if (sessions.empty() && timerAdded) {
         timer->removeTimerSubscriber(this);
         timerAdded = false;
     }


### PR DESCRIPTION
Found with readability-container-size-empty

Signed-off-by: Rosen Penev <rosenp@gmail.com>