### PR TITLE
[clang-tidy] use using insead of typedef

### DIFF
--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -37,7 +37,7 @@
 #include <cstring>
 
 #include "tools.h"
-typedef unsigned char uchar;
+using uchar = unsigned char;
 
 #ifndef TRUE
 #define TRUE 1


### PR DESCRIPTION
Found with modernize-use-using

Signed-off-by: Rosen Penev <rosenp@gmail.com>