### PR TITLE
[clang-tidy] use '' with single character

### DIFF
--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -436,7 +436,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, std::shared_ptr<CdsIt
                 const TagLib::String frameContents = textFrame->toString();
                 std::string value(frameContents.toCString(true));
 
-                size_t subTagEnd = value.find("]");
+                size_t subTagEnd = value.find(']');
                 std::string subTag = value.substr(1, subTagEnd - 1); // Cut out brackets
                 std::string content = value.substr(subTagEnd + 2); // Skip bracket and space
                 // log_debug("TXXX Tag: {}", subTag.c_str());

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -739,7 +739,7 @@ void UpnpXMLBuilder::addResources(std::shared_ptr<CdsItem> item, pugi::xml_node*
         std::string protocolInfo = getValueOrDefault(res_attrs, MetadataHandler::getResAttrName(R_PROTOCOLINFO));
         std::string mimeType = getMTFromProtocolInfo(protocolInfo);
 
-        size_t pos = mimeType.find(";");
+        size_t pos = mimeType.find(';');
         if (pos != std::string::npos) {
             mimeType = mimeType.substr(0, pos);
         }


### PR DESCRIPTION
Found with performance-faster-string-find

Signed-off-by: Rosen Penev <rosenp@gmail.com>