### PR TITLE
[clang-tidy] use raw string literals

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -99,7 +99,7 @@ void ConfigGenerator::generateServer(fs::path userHome, fs::path configDir, fs::
   generateStorage(&server);
 
   auto ps3protinfo = server.append_child(pugi::node_comment);
-  ps3protinfo.set_value(" For PS3 support change \"extend\" to \"yes\" ");
+  ps3protinfo.set_value(R"( For PS3 support change "extend" to "yes" )");
 
   auto protocolinfo = server.append_child("protocolInfo");
   protocolinfo.append_attribute("extend") = DEFAULT_EXTEND_PROTOCOLINFO;
@@ -265,10 +265,10 @@ void ConfigGenerator::generateMappings(pugi::xml_node* import) {
   map_from_to("wv", "audio/x-wavpack", &ext2mt);
 
   ext2mt.append_child(pugi::node_comment).set_value(" Uncomment the line below for PS3 divx support ");
-  ext2mt.append_child(pugi::node_comment).set_value(" <map from=\"avi\" to=\"video/divx\" /> ");
+  ext2mt.append_child(pugi::node_comment).set_value(R"( <map from="avi" to="video/divx" /> )");
 
   ext2mt.append_child(pugi::node_comment).set_value(" Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 ");
-  ext2mt.append_child(pugi::node_comment).set_value(" <map from=\"avi\" to=\"video/avi\" /> ");
+  ext2mt.append_child(pugi::node_comment).set_value(R"( <map from="avi" to="video/avi" /> )");
 
   auto mtupnp = mappings.append_child("mimetype-upnpclass");
   map_from_to("audio/*", UPNP_DEFAULT_CLASS_MUSIC_TRACK, &mtupnp);

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -1112,7 +1112,7 @@ void ConfigManager::load(fs::path filename, fs::path userHome)
                 throw std::runtime_error("error in configuration, <mark-played-items>, empty <content> parameter!");
 
             if ((mark_content != DEFAULT_MARK_PLAYED_CONTENT_VIDEO) && (mark_content != DEFAULT_MARK_PLAYED_CONTENT_AUDIO) && (mark_content != DEFAULT_MARK_PLAYED_CONTENT_IMAGE))
-                throw std::runtime_error("error in configuration, <mark-played-items>, invalid <content> parameter! Allowed values are \"video\", \"audio\", \"image\"");
+                throw std::runtime_error(R"(error in configuration, <mark-played-items>, invalid <content> parameter! Allowed values are "video", "audio", "image")");
 
             mark_content_list.push_back(mark_content);
             NEW_STRARR_OPTION(mark_content_list);

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -233,7 +233,7 @@ void string_ok_ex(std::string str)
 
 std::string http_redirect_to(std::string ip, std::string port, std::string page)
 {
-    return "<html><head><meta http-equiv=\"Refresh\" content=\"0;URL=http://" + ip + ":" + port + "/" + page + "\"></head><body bgcolor=\"#dddddd\"></body></html>";
+    return R"(<html><head><meta http-equiv="Refresh" content="0;URL=http://)" + ip + ":" + port + "/" + page + R"("></head><body bgcolor="#dddddd"></body></html>)";
 }
 
 std::string hex_encode(const void* data, int len)

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -90,7 +90,7 @@ void WebRequestHandler::check_request(bool checkLogin)
 
 std::string WebRequestHandler::renderXMLHeader()
 {
-    return std::string("<?xml version=\"1.0\" encoding=\"") + DEFAULT_INTERNAL_CHARSET + "\"?>\n";
+    return std::string(R"(<?xml version="1.0" encoding=")") + DEFAULT_INTERNAL_CHARSET + "\"?>\n";
 }
 
 void WebRequestHandler::getInfo(const char *filename, UpnpFileInfo *info)


### PR DESCRIPTION
Found with modernize-use-raw-string-literal

Signed-off-by: Rosen Penev <rosenp@gmail.com>