### PR TITLE
[clang-tidy] use = default

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -36,9 +36,9 @@ Gerbera - https://gerbera.io/
 #endif
 #include "config_generator.h"
 
-ConfigGenerator::ConfigGenerator() {}
+ConfigGenerator::ConfigGenerator() = default;
 
-ConfigGenerator::~ConfigGenerator() {}
+ConfigGenerator::~ConfigGenerator() = default;
 
 std::string ConfigGenerator::generate(fs::path userHome, fs::path configDir, fs::path prefixDir, fs::path magicFile) {
   pugi::xml_document doc;

--- a/src/iohandler/io_handler.cc
+++ b/src/iohandler/io_handler.cc
@@ -35,13 +35,9 @@
 
 #include "server.h"
 
-IOHandler::IOHandler()
-{
-}
+IOHandler::IOHandler() = default;
 
-IOHandler::~IOHandler()
-{
-}
+IOHandler::~IOHandler() = default;
 
 /// \fn static UpnpWebFileHandle web_open(const char *filename,
 ///                                       enum UpnpOpenFileMode mode)

--- a/src/layout/js_layout.cc
+++ b/src/layout/js_layout.cc
@@ -43,9 +43,7 @@ JSLayout::JSLayout(std::shared_ptr<ConfigManager> config,
     import_script = std::make_unique<ImportScript>(config, storage, content, runtime);
 }
 
-JSLayout::~JSLayout()
-{
-}
+JSLayout::~JSLayout() = default;
 
 void JSLayout::processCdsObject(std::shared_ptr<CdsObject> obj, fs::path rootpath)
 {

--- a/src/onlineservice/online_service_helper.cc
+++ b/src/onlineservice/online_service_helper.cc
@@ -36,9 +36,7 @@
 #include "config/config_manager.h"
 #include "online_service.h"
 
-OnlineServiceHelper::OnlineServiceHelper()
-{
-}
+OnlineServiceHelper::OnlineServiceHelper() = default;
 
 std::string OnlineServiceHelper::resolveURL(std::shared_ptr<CdsItemExternalURL> item)
 {

--- a/src/scripting/import_script.cc
+++ b/src/scripting/import_script.cc
@@ -87,8 +87,6 @@ void ImportScript::processCdsObject(std::shared_ptr<CdsObject> obj, std::string 
     }
 }
 
-ImportScript::~ImportScript()
-{
-}
+ImportScript::~ImportScript() = default;
 
 #endif // HAVE_JS

--- a/src/scripting/playlist_parser_script.cc
+++ b/src/scripting/playlist_parser_script.cc
@@ -222,7 +222,5 @@ void PlaylistParserScript::processPlaylistObject(std::shared_ptr<CdsObject> obj,
 
 }
 
-PlaylistParserScript::~PlaylistParserScript()
-{
-}
+PlaylistParserScript::~PlaylistParserScript() = default;
 #endif // HAVE_JS

--- a/src/transcoding/transcoding.cc
+++ b/src/transcoding/transcoding.cc
@@ -98,9 +98,7 @@ std::vector<std::string> TranscodingProfile::getAVIFourCCList()
 }
 
 
-TranscodingProfileList::TranscodingProfileList()
-{
-}
+TranscodingProfileList::TranscodingProfileList() = default;
 
 void TranscodingProfileList::add(std::string sourceMimeType, std::shared_ptr<TranscodingProfile> prof)
 {

--- a/src/util/task_processor.cc
+++ b/src/util/task_processor.cc
@@ -145,9 +145,7 @@ std::deque<std::shared_ptr<GenericTask>> TaskProcessor::getTasklist()
     return taskList;
 }
 
-TaskProcessor::~TaskProcessor()
-{
-}
+TaskProcessor::~TaskProcessor() = default;
 
 TPFetchOnlineContentTask::TPFetchOnlineContentTask(std::shared_ptr<ContentManager> content,
     std::shared_ptr<TaskProcessor> task_processor,


### PR DESCRIPTION
Found with modernize-use-equals-default

Signed-off-by: Rosen Penev <rosenp@gmail.com>