### PR TITLE
 [clang-tidy] use range based loops

### DIFF
--- a/src/autoscan.cc
+++ b/src/autoscan.cc
@@ -96,8 +96,8 @@ int AutoscanList::_add(std::shared_ptr<AutoscanDirectory> dir)
 {
     std::string loc = dir->getLocation();
 
-    for (size_t i = 0; i < list.size(); i++) {
-        if (loc == list[i]->getLocation()) {
+    for (const auto& i : list) {
+        if (loc == i->getLocation()) {
             throw std::runtime_error("Attempted to add same autoscan path twice");
         }
     }
@@ -112,8 +112,8 @@ void AutoscanList::addList(std::shared_ptr<AutoscanList> list)
 {
     AutoLock lock(mutex);
 
-    for (size_t i = 0; i < list->list.size(); i++) {
-        _add(list->list[i]);
+    for (const auto& i : list->list) {
+        _add(i);
     }
 }
 
@@ -138,9 +138,9 @@ std::shared_ptr<AutoscanDirectory> AutoscanList::getByObjectID(int objectID)
 {
     AutoLock lock(mutex);
 
-    for (size_t i = 0; i < list.size(); i++) {
-        if (objectID == list[i]->getObjectID())
-            return list[i];
+    for (const auto& i : list) {
+        if (objectID == i->getObjectID())
+            return i;
     }
     return nullptr;
 }
@@ -148,9 +148,9 @@ std::shared_ptr<AutoscanDirectory> AutoscanList::getByObjectID(int objectID)
 std::shared_ptr<AutoscanDirectory> AutoscanList::get(std::string location)
 {
     AutoLock lock(mutex);
-    for (size_t i = 0; i < list.size(); i++) {
-        if (location == list[i]->getLocation())
-            return list[i];
+    for (const auto& i : list) {
+        if (location == i->getLocation())
+            return i;
     }
     return nullptr;
 }
@@ -237,8 +237,8 @@ void AutoscanList::notifyAll(Timer::Subscriber* sub)
         return;
     AutoLock lock(mutex);
 
-    for (size_t i = 0; i < list.size(); i++) {
-        sub->timerNotify(list[i]->getTimerParameter());
+    for (const auto& i : list) {
+        sub->timerNotify(i->getTimerParameter());
     }
 }
 

--- a/src/autoscan_inotify.cc
+++ b/src/autoscan_inotify.cc
@@ -397,8 +397,7 @@ void AutoscanInotify::checkMoveWatches(int wd, std::shared_ptr<Wd> wdObj)
 void AutoscanInotify::recheckNonexistingMonitors(int wd, std::shared_ptr<Wd> wdObj)
 {
     auto wdWatches = wdObj->getWdWatches();
-    for (auto it = wdWatches->begin(); it != wdWatches->end(); ++it) {
-        auto& watch = *it;
+    for (const auto& watch : *wdWatches) {
         if (watch->getType() == WatchType::Autoscan) {
             auto watchAs = std::static_pointer_cast<WatchAutoscan>(watch);
             auto pathAr = watchAs->getNonexistingPathArray();
@@ -552,8 +551,7 @@ void AutoscanInotify::unmonitorDirectory(fs::path path, std::shared_ptr<Autoscan
 std::shared_ptr<AutoscanInotify::WatchAutoscan> AutoscanInotify::getAppropriateAutoscan(std::shared_ptr<Wd> wdObj, std::shared_ptr<AutoscanDirectory> adir)
 {
     auto  wdWatches = wdObj->getWdWatches();
-    for (auto it = wdWatches->begin(); it != wdWatches->end(); ++it) {
-        auto& watch = *it;
+    for (const auto& watch : *wdWatches) {
         if (watch->getType() == WatchType::Autoscan) {
             auto watchAs = std::static_pointer_cast<WatchAutoscan>(watch);
             if (watchAs->getNonexistingPathArray().empty()) {
@@ -571,8 +569,7 @@ std::shared_ptr<AutoscanInotify::WatchAutoscan> AutoscanInotify::getAppropriateA
     fs::path pathBestMatch;
     std::shared_ptr<WatchAutoscan> bestMatch = nullptr;
     auto wdWatches = wdObj->getWdWatches();
-    for (auto it = wdWatches->begin(); it != wdWatches->end(); ++it) {
-        auto& watch = *it;
+    for (const auto& watch : *wdWatches) {
         if (watch->getType() == WatchType::Autoscan) {
             auto watchAs = std::static_pointer_cast<WatchAutoscan>(watch);
             if (watchAs->getNonexistingPathArray().empty()) {
@@ -654,8 +651,7 @@ bool AutoscanInotify::removeFromWdObj(std::shared_ptr<Wd> wdObj, std::shared_ptr
 std::shared_ptr<AutoscanInotify::WatchAutoscan> AutoscanInotify::getStartPoint(std::shared_ptr<Wd> wdObj)
 {
     auto wdWatches = wdObj->getWdWatches();
-    for (auto it = wdWatches->begin(); it != wdWatches->end(); ++it) {
-        auto& watch = *it;
+    for (const auto& watch : *wdWatches) {
         if (watch->getType() == WatchType::Autoscan) {
             auto watchAs = std::static_pointer_cast<WatchAutoscan>(watch);
             if (watchAs->isStartPoint())
@@ -696,8 +692,7 @@ void AutoscanInotify::removeDescendants(int wd)
     }
 
     auto wdWatches = wdObj->getWdWatches();
-    for (auto it = wdWatches->begin(); it != wdWatches->end(); ++it) {
-        auto& watch = *it;
+    for (const auto& watch : *wdWatches) {
         if (watch->getType() == WatchType::Autoscan) {
             auto watchAs = std::static_pointer_cast<WatchAutoscan>(watch);
             for (int descWd : watchAs->getDescendants()) {

--- a/src/cds_objects.cc
+++ b/src/cds_objects.cc
@@ -63,8 +63,8 @@ void CdsObject::copyTo(std::shared_ptr<CdsObject> obj)
     obj->setAuxData(auxdata);
     obj->setFlags(objectFlags);
     obj->setSortPriority(sortPriority);
-    for (size_t i = 0; i < resources.size(); i++)
-        obj->addResource(resources[i]->clone());
+    for (auto& resource : resources)
+        obj->addResource(resource->clone());
 }
 int CdsObject::equals(std::shared_ptr<CdsObject> obj, bool exactly)
 {

--- a/src/cds_resource.cc
+++ b/src/cds_resource.cc
@@ -63,8 +63,8 @@ void CdsResource::removeAttribute(std::string name)
 
 void CdsResource::mergeAttributes(const std::map<std::string,std::string>& additional)
 {
-    for (auto it = additional.begin(); it != additional.end(); it++) {
-        attributes[it->first] = it->second;
+    for (const auto& it : additional) {
+        attributes[it.first] = it.second;
     }
 }
 

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -1705,9 +1705,9 @@ std::shared_ptr<TranscodingProfileList> ConfigManager::createTranscodingProfileL
             }
 
             bool set = false;
-            for (auto it = mt_mappings.begin(); it != mt_mappings.end(); it++) {
-                if (it->second == prof->getName()) {
-                    list->add(it->first, prof);
+            for (const auto& mt_mapping : mt_mappings) {
+                if (mt_mapping.second == prof->getName()) {
+                    list->add(mt_mapping.first, prof);
                     set = true;
                 }
             }

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -358,8 +358,7 @@ void ContentManager::shutdown()
 
     shutdownFlag = true;
 
-    for (size_t i = 0; i < process_list.size(); i++) {
-        auto exec = process_list[i];
+    for (const auto& exec : process_list) {
         if (exec != nullptr)
             exec->kill();
     }
@@ -409,14 +408,12 @@ std::deque<std::shared_ptr<GenericTask>> ContentManager::getTasklist()
     if (t != nullptr)
         taskList.push_back(t);
 
-    for (size_t i = 0; i < taskQueue1.size(); i++) {
-        auto t = taskQueue1[i];
+    for (const auto &t : taskQueue1) {
         if (t->isValid())
             taskList.push_back(t);
     }
 
-    for (size_t i = 0; i < taskQueue2.size(); i++) {
-        auto t = taskQueue2[i];
+    for (const auto &t : taskQueue2) {
         if (t->isValid())
             taskList.clear();
     }
@@ -1357,15 +1354,13 @@ void ContentManager::invalidateTask(unsigned int taskID, task_owner_t taskOwner)
             }
         }
 
-        for (size_t i = 0; i < taskQueue1.size(); i++) {
-            auto t = taskQueue1[i];
+        for (const auto &t : taskQueue1) {
             if ((t->getID() == taskID) || (t->getParentID() == taskID)) {
                 t->invalidate();
             }
         }
 
-        for (size_t i = 0; i < taskQueue2.size(); i++) {
-            auto t = taskQueue2[i];
+        for (const auto &t : taskQueue2) {
             if ((t->getID() == taskID) || (t->getParentID() == taskID)) {
                 t->invalidate();
             }
@@ -1426,13 +1421,11 @@ void ContentManager::removeObject(int objectID, bool async, bool all)
 
             // we have to make sure that a currently running autoscan task will not
             // launch add tasks for directories that anyway are going to be deleted
-            for (size_t i = 0; i < taskQueue1.size(); i++) {
-                auto t = taskQueue1[i];
+            for (const auto& t : taskQueue1) {
                 invalidateAddTask(t, path);
             }
 
-            for (size_t i = 0; i < taskQueue2.size(); i++) {
-                auto t = taskQueue2[i];
+            for (const auto& t : taskQueue2) {
                 invalidateAddTask(t, path);
             }
 
@@ -1505,8 +1498,8 @@ std::vector<std::shared_ptr<AutoscanDirectory>> ContentManager::getAutoscanDirec
 
 #if HAVE_INOTIFY
     auto ino = autoscan_inotify->getArrayCopy();
-    for (size_t i = 0; i < ino.size(); i++)
-        all.push_back(ino[i]);
+    for (const auto& i : ino)
+        all.push_back(i);
 #endif
     return all;
 }
@@ -1727,8 +1720,8 @@ void ContentManager::triggerPlayHook(std::shared_ptr<CdsObject> obj)
 
     if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_ENABLED) && !obj->getFlag(OBJECT_FLAG_PLAYED)) {
         std::vector<std::string>  mark_list = config->getStringArrayOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_CONTENT_LIST);
-        for (size_t i = 0; i < mark_list.size(); i++) {
-            if (startswith(std::static_pointer_cast<CdsItem>(obj)->getMimeType(), mark_list[i])) {
+        for (const auto& i : mark_list) {
+            if (startswith(std::static_pointer_cast<CdsItem>(obj)->getMimeType(), i)) {
                 obj->setFlag(OBJECT_FLAG_PLAYED);
 
                 bool supress = config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_SUPPRESS_CDS_UPDATES);

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -408,12 +408,12 @@ std::deque<std::shared_ptr<GenericTask>> ContentManager::getTasklist()
     if (t != nullptr)
         taskList.push_back(t);
 
-    for (const auto &t : taskQueue1) {
+    for (const auto& t : taskQueue1) {
         if (t->isValid())
             taskList.push_back(t);
     }
 
-    for (const auto &t : taskQueue2) {
+    for (const auto& t : taskQueue2) {
         if (t->isValid())
             taskList.clear();
     }
@@ -1354,13 +1354,13 @@ void ContentManager::invalidateTask(unsigned int taskID, task_owner_t taskOwner)
             }
         }
 
-        for (const auto &t : taskQueue1) {
+        for (const auto& t : taskQueue1) {
             if ((t->getID() == taskID) || (t->getParentID() == taskID)) {
                 t->invalidate();
             }
         }
 
-        for (const auto &t : taskQueue2) {
+        for (const auto& t : taskQueue2) {
             if ((t->getID() == taskID) || (t->getParentID() == taskID)) {
                 t->invalidate();
             }

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -232,9 +232,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
                 std::string pathNoExt = path.parent_path() / path.stem();
 
                 std::string validext;
-                for (size_t i = 0; i < subexts.size(); i++) {
-                    std::string ext = subexts[i];
-
+                for (const auto& ext : subexts) {
                     std::string fpath = pathNoExt + ext;
                     if (access(fpath.c_str(), R_OK) == 0) {
                         validext = ext;

--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -68,10 +68,10 @@ bool ProcessIOHandler::abort()
     if (procList.empty())
         return abort;
 
-    for (size_t i = 0; i < procList.size(); i++) {
-        auto exec = procList[i]->getExecutor();
+    for (const auto& i : procList) {
+        auto exec = i->getExecutor();
         if ((exec != nullptr) && (!exec->isAlive())) {
-            if (procList[i]->abortOnDeath())
+            if (i->abortOnDeath())
                 abort = true;
             break;
         }
@@ -82,7 +82,7 @@ bool ProcessIOHandler::abort()
 
 void ProcessIOHandler::killAll()
 {
-    for (auto & i : procList) {
+    for (const auto& i : procList) {
         auto exec = i->getExecutor();
         if (exec != nullptr)
             exec->kill();
@@ -94,8 +94,8 @@ void ProcessIOHandler::registerAll()
     if (mainProc != nullptr)
         content->registerExecutor(mainProc);
 
-    for (size_t i = 0; i < procList.size(); i++) {
-        auto exec = procList[i]->getExecutor();
+    for (const auto& i : procList) {
+        auto exec = i->getExecutor();
         if (exec != nullptr)
             content->registerExecutor(exec);
     }
@@ -106,8 +106,8 @@ void ProcessIOHandler::unregisterAll()
     if (mainProc != nullptr)
         content->unregisterExecutor(mainProc);
 
-    for (size_t i = 0; i < procList.size(); i++) {
-        auto exec = procList[i]->getExecutor();
+    for (const auto& i : procList) {
+        auto exec = i->getExecutor();
         if (exec != nullptr)
             content->unregisterExecutor(exec);
     }

--- a/src/metadata/fanart_handler.cc
+++ b/src/metadata/fanart_handler.cc
@@ -53,10 +53,10 @@ fs::path FanArtHandler::getFanArtPath(std::shared_ptr<CdsItem> item) const
     log_debug("Folder name: {}", folder.c_str());
 
     fs::path found;
-    for (size_t i = 0; i < sizeof(names)/sizeof(names[0]); i++) {
-        auto found = folder / names[i];
+    for (const auto& name : names) {
+        auto found = folder / name;
         bool exists = fs::is_regular_file(found);
-        log_debug("{}: {}", names[i], exists ? "found" : "missing");
+        log_debug("{}: {}", name, exists ? "found" : "missing");
         if (!exists)
             continue;
         return found;

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -317,8 +317,7 @@ void LibExifHandler::process_ifd(ExifContent* content, std::shared_ptr<CdsItem> 
         }
 
         // if there are any auxilary tags that the user wants - add them
-        for (size_t j = 0; j < auxtags.size(); j++) {
-            std::string tmp = auxtags[j];
+        for (const auto& tmp : auxtags) {
             if (string_ok(tmp)) {
                 if (e->tag == getTagFromString(tmp)) {
                     value = (char*)exif_egv(e);
@@ -349,9 +348,9 @@ void LibExifHandler::fillMetadata(std::shared_ptr<CdsItem> item)
     }
 
     std::vector<std::string> aux = config->getStringArrayOption(CFG_IMPORT_LIBOPTS_EXIF_AUXDATA_TAGS_LIST);
-    for (int i = 0; i < EXIF_IFD_COUNT; i++) {
-        if (ed->ifd[i])
-            process_ifd(ed->ifd[i], item, sc, aux);
+    for (const auto& i : ed->ifd) {
+        if (i)
+            process_ifd(i, item, sc, aux);
     }
 
     // we got the image resolution so we can add our resource

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -73,7 +73,7 @@ public:
         close();
     }
 
-    virtual uint32 read(void * buffer, size_t size)
+    virtual uint32 read(void* buffer, size_t size)
     {
         assert(file != nullptr);
         if (size <= 0)
@@ -90,7 +90,7 @@ public:
         }
     }
 
-    virtual size_t write(const void *p_buffer, size_t i_size)
+    virtual size_t write(const void* p_buffer, size_t i_size)
     {
         // not needed
         return 0;

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -400,9 +400,8 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, std::shared_ptr<CdsIt
     bool hasTXXXFrames = frameListMap.contains("TXXX");
 
     std::vector<std::string> aux_tags_list = config->getStringArrayOption(CFG_IMPORT_LIBOPTS_ID3_AUXDATA_TAGS_LIST);
-    for (size_t i = 0; i < aux_tags_list.size(); i++) {
+    for (const auto& desiredFrame : aux_tags_list) {
 
-        std::string desiredFrame = aux_tags_list[i];
         if (!string_ok(desiredFrame)) {
             continue;
         }
@@ -431,7 +430,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, std::shared_ptr<CdsIt
             if (!string_ok(desiredSubTag))
                 continue;
 
-            for (auto frame : frameList) {
+            for (const auto& frame : frameList) {
                 const auto textFrame = dynamic_cast<const TagLib::ID3v2::TextIdentificationFrame*>(frame);
                 const TagLib::String frameContents = textFrame->toString();
                 std::string value(frameContents.toCString(true));
@@ -540,9 +539,8 @@ void TagLibHandler::extractFLAC(TagLib::IOStream* roStream, std::shared_ptr<CdsI
     auto sc = StringConverter::i2i(config);
 
     std::vector<std::string> aux_tags_list = config->getStringArrayOption(CFG_IMPORT_LIBOPTS_ID3_AUXDATA_TAGS_LIST);
-    for (size_t j = 0; j < aux_tags_list.size(); j++) {
+    for (const auto& desiredTag : aux_tags_list) {
 
-        std::string desiredTag = aux_tags_list[j];
         if (!string_ok(desiredTag)) {
             continue;
         }

--- a/src/scripting/script.cc
+++ b/src/scripting/script.cc
@@ -601,8 +601,8 @@ void Script::cdsObject2dukObject(std::shared_ptr<CdsObject> obj)
         // stack: js meta_js
 
         auto meta = obj->getMetadata();
-        for (auto it = meta.begin(); it != meta.end(); it++) {
-            setProperty(it->first, it->second);
+        for (const auto& it : meta) {
+            setProperty(it.first, it.second);
         }
 
         if (std::static_pointer_cast<CdsItem>(obj)->getTrackNumber() > 0)
@@ -625,8 +625,8 @@ void Script::cdsObject2dukObject(std::shared_ptr<CdsObject> obj)
             aux[ATRAILERS_AUXDATA_POST_DATE] = tmp;
 #endif
 
-        for (auto it = aux.begin(); it != aux.end(); it++) {
-            setProperty(it->first, it->second);
+        for (const auto& it : aux) {
+            setProperty(it.first, it.second);
         }
 
         duk_put_prop_string(ctx, -2, "aux");
@@ -642,8 +642,8 @@ void Script::cdsObject2dukObject(std::shared_ptr<CdsObject> obj)
         if (obj->getResourceCount() > 0) {
             auto res = obj->getResource(0);
             auto attributes = res->getAttributes();
-            for (auto it = attributes.begin(); it != attributes.end(); it++) {
-                setProperty(it->first, it->second);
+            for (const auto& attribute : attributes) {
+                setProperty(attribute.first, attribute.second);
             }
         }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -158,8 +158,7 @@ void Server::run()
     log_debug("webroot: {}", web_root.c_str());
 
     std::vector<std::string> arr = config->getStringArrayOption(CFG_SERVER_CUSTOM_HTTP_HEADERS);
-    for (size_t i = 0; i < arr.size(); i++) {
-        std::string tmp = arr[i];
+    for (const auto& tmp : arr) {
         if (string_ok(tmp)) {
             log_info("(NOT) Adding HTTP header \"{}\"", tmp.c_str());
             // FIXME upstream upnp

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -603,7 +603,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLStorage::browse(const std::unique_ptr
     res = nullptr;
 
     // update childCount fields
-    for (auto obj : arr) {
+    for (const auto& obj : arr) {
         if (IS_CDS_CONTAINER(obj->getObjectType())) {
             auto cont = std::static_pointer_cast<CdsContainer>(obj);
             cont->setChildCount(getChildCount(cont->getID(), getContainers, getItems, hideFsRoot));

--- a/src/transcoding/transcoding.cc
+++ b/src/transcoding/transcoding.cc
@@ -126,8 +126,8 @@ std::shared_ptr<TranscodingProfileMap> TranscodingProfileList::get(std::string s
 
 std::shared_ptr<TranscodingProfile> TranscodingProfileList::getByName(std::string name)
 {
-    for (auto it = list.begin(); it != list.end(); ++it) {
-        auto inner = it->second;
+    for (const auto& it : list) {
+        auto inner = it.second;
         auto tp = inner->find(name);
         if (tp != inner->end())
             return tp->second;

--- a/src/transcoding/transcoding_process_executor.cc
+++ b/src/transcoding/transcoding_process_executor.cc
@@ -44,7 +44,7 @@ TranscodingProcessExecutor::~TranscodingProcessExecutor()
 {
     kill();
 
-    for (auto name : file_list) {
+    for (const auto& name : file_list) {
         unlink(name.c_str());
     }
 }

--- a/src/transcoding/transcoding_process_executor.cc
+++ b/src/transcoding/transcoding_process_executor.cc
@@ -44,8 +44,7 @@ TranscodingProcessExecutor::~TranscodingProcessExecutor()
 {
     kill();
 
-    for (size_t i = 0; i < file_list.size(); i++) {
-        std::string name = file_list[i];
+    for (auto name : file_list) {
         unlink(name.c_str());
     }
 }

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -111,7 +111,7 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
         didl_lite_root.append_attribute(XML_SEC_NAMESPACE_ATTR) = XML_SEC_NAMESPACE;
     }
 
-    for (auto obj : arr) {
+    for (const auto& obj : arr) {
         if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_ENABLED) && obj->getFlag(OBJECT_FLAG_PLAYED)) {
             std::string title = obj->getTitle();
             if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_STRING_MODE_PREPEND))
@@ -176,7 +176,7 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
         throw UpnpException(UPNP_E_NO_SUCH_ID, "no such object");
     }
 
-    for (auto cdsObject : results) {
+    for (const auto& cdsObject : results) {
         if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_ENABLED) && cdsObject->getFlag(OBJECT_FLAG_PLAYED)) {
             std::string title = cdsObject->getTitle();
             if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_STRING_MODE_PREPEND))

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -111,8 +111,7 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
         didl_lite_root.append_attribute(XML_SEC_NAMESPACE_ATTR) = XML_SEC_NAMESPACE;
     }
 
-    for (size_t i = 0; i < arr.size(); i++) {
-        auto obj = arr[i];
+    for (auto obj : arr) {
         if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_ENABLED) && obj->getFlag(OBJECT_FLAG_PLAYED)) {
             std::string title = obj->getTitle();
             if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_STRING_MODE_PREPEND))
@@ -177,8 +176,7 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
         throw UpnpException(UPNP_E_NO_SUCH_ID, "no such object");
     }
 
-    for (size_t i = 0; i < results.size(); i++) {
-        auto cdsObject = results[i];
+    for (auto cdsObject : results) {
         if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_ENABLED) && cdsObject->getFlag(OBJECT_FLAG_PLAYED)) {
             std::string title = cdsObject->getTitle();
             if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_STRING_MODE_PREPEND))

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -81,10 +81,10 @@ void UpnpXMLBuilder::renderObject(std::shared_ptr<CdsObject> obj, bool renderAct
         std::string key;
         std::string upnp_class = obj->getClass();
 
-        for (auto it = meta.begin(); it != meta.end(); it++) {
-            key = it->first;
+        for (const auto& it : meta) {
+            key = it.first;
             if (key == MetadataHandler::getMetaFieldName(M_DESCRIPTION)) {
-                tmp = it->second;
+                tmp = it.second;
                 if ((stringLimit > 0) && (tmp.length() > stringLimit)) {
                     tmp = tmp.substr(0, getValidUTF8CutPosition(tmp, stringLimit - 3));
                     tmp = tmp + "...";
@@ -92,9 +92,9 @@ void UpnpXMLBuilder::renderObject(std::shared_ptr<CdsObject> obj, bool renderAct
                 result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(tmp.c_str());
             } else if (key == MetadataHandler::getMetaFieldName(M_TRACKNUMBER)) {
                 if (upnp_class == UPNP_DEFAULT_CLASS_MUSIC_TRACK)
-                    result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(it->second.c_str());
+                    result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(it.second.c_str());
             } else if ((key != MetadataHandler::getMetaFieldName(M_TITLE)) || ((key == MetadataHandler::getMetaFieldName(M_TRACKNUMBER)) && (upnp_class == UPNP_DEFAULT_CLASS_MUSIC_TRACK)))
-                result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(it->second.c_str());
+                result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(it.second.c_str());
         }
 
         addResources(item, &result);
@@ -423,8 +423,8 @@ void UpnpXMLBuilder::renderResource(std::string URL, const std::map<std::string,
     auto res = parent->append_child("res");
     res.append_child(pugi::node_pcdata).set_value(URL.c_str());
 
-    for (auto it = attributes.begin(); it != attributes.end(); it++) {
-        res.append_attribute(it->first.c_str()) = it->second.c_str();
+    for (const auto& attribute : attributes) {
+        res.append_attribute(attribute.first.c_str()) = attribute.second.c_str();
     }
 }
 
@@ -613,8 +613,8 @@ void UpnpXMLBuilder::addResources(std::shared_ptr<CdsItem> item, pugi::xml_node*
     auto tlist = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST);
     auto tp_mt = tlist->get(item->getMimeType());
     if (tp_mt != nullptr) {
-        for (auto it = tp_mt->begin(); it != tp_mt->end(); ++it) {
-            auto tp = it->second;
+        for (const auto& it : *tp_mt) {
+            auto tp = it.second;
 
             if (tp == nullptr)
                 throw std::runtime_error("Invalid profile encountered!");
@@ -647,8 +647,8 @@ void UpnpXMLBuilder::addResources(std::shared_ptr<CdsItem> item, pugi::xml_node*
                     // let's have a look if it matches the list
                     else {
                         bool fcc_match = false;
-                        for (size_t f = 0; f < fcc_list.size(); f++) {
-                            if (current_fcc == fcc_list[f])
+                        for (const auto& f : fcc_list) {
+                            if (current_fcc == f)
                                 fcc_match = true;
                         }
 

--- a/src/util/process_executor.cc
+++ b/src/util/process_executor.cc
@@ -45,8 +45,8 @@ ProcessExecutor::ProcessExecutor(std::string command, std::vector<std::string> a
     argv[0] = command.c_str();
     int apos = 0;
 
-    for (size_t i = 0; i < arglist.size(); i++) {
-        argv[++apos] = arglist[i].c_str();
+    for (const auto& i : arglist) {
+        argv[++apos] = i.c_str();
         if (apos >= MAX_ARGS - 2)
             break;
     }

--- a/src/util/task_processor.cc
+++ b/src/util/task_processor.cc
@@ -114,7 +114,7 @@ void TaskProcessor::invalidateTask(unsigned int taskID)
         }
     }
 
-    for (auto t : taskQueue) {
+    for (const auto& t : taskQueue) {
         if ((t->getID() == taskID) || (t->getParentID() == taskID)) {
             t->invalidate();
         }
@@ -135,7 +135,7 @@ std::deque<std::shared_ptr<GenericTask>> TaskProcessor::getTasklist()
 
     taskList.push_back(t);
 
-    for (auto t : taskQueue) {
+    for (const auto& t : taskQueue) {
         if (t->isValid())
             taskList.push_back(t);
     }

--- a/src/util/task_processor.cc
+++ b/src/util/task_processor.cc
@@ -114,8 +114,7 @@ void TaskProcessor::invalidateTask(unsigned int taskID)
         }
     }
 
-    for (size_t i = 0; i < taskQueue.size(); i++) {
-        auto t = taskQueue[i];
+    for (auto t : taskQueue) {
         if ((t->getID() == taskID) || (t->getParentID() == taskID)) {
             t->invalidate();
         }
@@ -136,8 +135,7 @@ std::deque<std::shared_ptr<GenericTask>> TaskProcessor::getTasklist()
 
     taskList.push_back(t);
 
-    for (size_t i = 0; i < taskQueue.size(); i++) {
-        auto t = taskQueue[i];
+    for (auto t : taskQueue) {
         if (t->isValid())
             taskList.push_back(t);
     }

--- a/src/util/xml_to_json.cc
+++ b/src/util/xml_to_json.cc
@@ -135,13 +135,11 @@ std::string Xml2Json::getValue(const char* text)
 
 bool Xml2Json::isArray(pugi::xml_node& node, const Hints* hints, std::string* arrayName)
 {
-    for (auto it = hints->asArray.begin(); it != hints->asArray.end(); ++it) {
-        auto& hint = *it;
+    for (const auto& hint : hints->asArray) {
         if (hint.first == node) {
             if (arrayName != nullptr) *arrayName = hint.second;
             return true;
         }
-    
     }
 
     return false;

--- a/src/web/auth.cc
+++ b/src/web/auth.cc
@@ -92,8 +92,8 @@ void web::auth::process()
         ipp.append_attribute("default") = config->getIntOption(CFG_SERVER_UI_DEFAULT_ITEMS_PER_PAGE);
 
         auto menu_opts = config->getStringArrayOption(CFG_SERVER_UI_ITEMS_PER_PAGE_DROPDOWN);
-        for (size_t i = 0; i < menu_opts.size(); i++) {
-            ipp.append_child("option").append_child(pugi::node_pcdata).set_value(menu_opts[i].c_str());
+        for (const auto& menu_opt : menu_opts) {
+            ipp.append_child("option").append_child(pugi::node_pcdata).set_value(menu_opt.c_str());
         }
 
 #ifdef HAVE_INOTIFY

--- a/src/web/containers.cc
+++ b/src/web/containers.cc
@@ -61,8 +61,7 @@ void web::containers::process()
     auto param = std::make_unique<BrowseParam>(parentID, BROWSE_DIRECT_CHILDREN | BROWSE_CONTAINERS);
     auto arr = storage->browse(param);
 
-    for (size_t i = 0; i < arr.size(); i++) {
-        auto obj = arr[i];
+    for (auto obj : arr) {
         //if (IS_CDS_CONTAINER(obj->getObjectType()))
         //{
         auto cont = std::static_pointer_cast<CdsContainer>(obj);

--- a/src/web/containers.cc
+++ b/src/web/containers.cc
@@ -61,7 +61,7 @@ void web::containers::process()
     auto param = std::make_unique<BrowseParam>(parentID, BROWSE_DIRECT_CHILDREN | BROWSE_CONTAINERS);
     auto arr = storage->browse(param);
 
-    for (auto obj : arr) {
+    for (const auto& obj : arr) {
         //if (IS_CDS_CONTAINER(obj->getObjectType()))
         //{
         auto cont = std::static_pointer_cast<CdsContainer>(obj);

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -111,8 +111,7 @@ void web::items::process()
     items.append_attribute("protect_container") = protectContainer;
     items.append_attribute("protect_items") =  protectItems;
 
-    for (size_t i = 0; i < arr.size(); i++) {
-        auto obj = arr[i];
+    for (auto obj : arr) {
         //if (IS_CDS_ITEM(obj->getObjectType()))
         //{
         auto item = items.append_child("item");

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -111,7 +111,7 @@ void web::items::process()
     items.append_attribute("protect_container") = protectContainer;
     items.append_attribute("protect_items") =  protectItems;
 
-    for (auto obj : arr) {
+    for (const auto& obj : arr) {
         //if (IS_CDS_ITEM(obj->getObjectType()))
         //{
         auto item = items.append_child("item");

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -200,7 +200,7 @@ void SessionManager::containerChangedUI(int objectID)
     if (sessions.size() <= 0)
         return;
     AutoLock lock(mutex);
-    for (auto session : sessions) {
+    for (const auto& session : sessions) {
         if (session->isLoggedIn())
             session->containerChangedUI(objectID);
     }
@@ -211,7 +211,7 @@ void SessionManager::containerChangedUI(const std::vector<int>& objectIDs)
     if (sessions.size() <= 0)
         return;
     AutoLock lock(mutex);
-    for (auto session : sessions) {
+    for (const auto& session : sessions) {
         if (session->isLoggedIn())
             session->containerChangedUI(objectIDs);
     }

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -166,8 +166,7 @@ std::shared_ptr<Session> SessionManager::getSession(std::string sessionID, bool 
     unique_lock<decltype(mutex)> lock(mutex, std::defer_lock);
     if (doLock)
         lock.lock();
-    for (size_t i = 0; i < sessions.size(); i++) {
-        auto s = sessions[i];
+    for (const auto& s : sessions) {
         if (s->getID() == sessionID)
             return s;
     }
@@ -201,8 +200,7 @@ void SessionManager::containerChangedUI(int objectID)
     if (sessions.size() <= 0)
         return;
     AutoLock lock(mutex);
-    for (size_t i = 0; i < sessions.size(); i++) {
-        auto session = sessions[i];
+    for (auto session : sessions) {
         if (session->isLoggedIn())
             session->containerChangedUI(objectID);
     }
@@ -213,8 +211,7 @@ void SessionManager::containerChangedUI(const std::vector<int>& objectIDs)
     if (sessions.size() <= 0)
         return;
     AutoLock lock(mutex);
-    for (size_t i = 0; i < sessions.size(); i++) {
-        auto session = sessions[i];
+    for (auto session : sessions) {
         if (session->isLoggedIn())
             session->containerChangedUI(objectIDs);
     }

--- a/src/web/tasks.cc
+++ b/src/web/tasks.cc
@@ -52,8 +52,8 @@ void web::tasks::process()
         auto tasksEl = root.append_child("tasks");
         xml2JsonHints->setArrayName(tasksEl, "tasks");
         auto taskList = content->getTasklist();
-        for (size_t i = 0; i < taskList.size(); i++) {
-            appendTask(taskList[i], &tasksEl);
+        for (const auto& i : taskList) {
+            appendTask(i, &tasksEl);
         }
     } else if (action == "cancel") {
         int taskID = intParam("task_id");

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -136,7 +136,7 @@ void web::autoscan::process()
 
         auto autoscansEl = root.append_child("autoscans");
         xml2JsonHints->setArrayName(autoscansEl, "autoscan");
-        for (auto autoscanDir : autoscanList) {
+        for (const auto& autoscanDir : autoscanList) {
             auto autoscanEl = autoscansEl.append_child("autoscan");
             autoscanEl.append_attribute("objectID") = autoscanDir->getObjectID();
 

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -136,8 +136,7 @@ void web::autoscan::process()
 
         auto autoscansEl = root.append_child("autoscans");
         xml2JsonHints->setArrayName(autoscansEl, "autoscan");
-        for (size_t i = 0; i < autoscanList.size(); i++) {
-            auto autoscanDir = autoscanList[i];
+        for (auto autoscanDir : autoscanList) {
             auto autoscanEl = autoscansEl.append_child("autoscan");
             autoscanEl.append_attribute("objectID") = autoscanDir->getObjectID();
 


### PR DESCRIPTION
Found with modernize-loop-convert, performance-for-range-copy

Signed-off-by: Rosen Penev <rosenp@gmail.com>