### PR TITLE
[clang-tidy] remove pointless void argument

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -68,12 +68,12 @@ public:
         }
     }
 
-    virtual ~file_io_callback()
+    ~file_io_callback() override
     {
         close();
     }
 
-    virtual uint32 read(void* buffer, size_t size)
+    uint32 read(void* buffer, size_t size) override
     {
         assert(file != nullptr);
         if (size <= 0)
@@ -81,7 +81,7 @@ public:
         return fread(buffer, 1, size, file);
     }
 
-    virtual void setFilePointer(int64_t offset, seek_mode mode = seek_beginning)
+    void setFilePointer(int64_t offset, seek_mode mode = seek_beginning) override
     {
         assert(file != nullptr);
         assert(mode == SEEK_CUR || mode == SEEK_END || mode == SEEK_SET);
@@ -90,19 +90,19 @@ public:
         }
     }
 
-    virtual size_t write(const void* p_buffer, size_t i_size)
+    size_t write(const void* p_buffer, size_t i_size) override
     {
         // not needed
         return 0;
     }
 
-    virtual uint64 getFilePointer()
+    uint64 getFilePointer() override
     {
         assert(file != nullptr);
         return ftello(file);
     }
 
-    virtual void close()
+    void close() override
     {
         if (file == nullptr)
             return;

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -96,13 +96,13 @@ public:
         return 0;
     }
 
-    virtual uint64 getFilePointer(void)
+    virtual uint64 getFilePointer()
     {
         assert(file != nullptr);
         return ftello(file);
     }
 
-    virtual void close(void)
+    virtual void close()
     {
         if (file == nullptr)
             return;


### PR DESCRIPTION
Found with modernize-redundant-void-arg

Signed-off-by: Rosen Penev <rosenp@gmail.com>