### PR TITLE
[clang-tidy] remove redundant c_str method

### DIFF
--- a/src/cds_resource.cc
+++ b/src/cds_resource.cc
@@ -138,7 +138,7 @@ std::string CdsResource::encode()
     buf << dict_encode(parameters);
     buf << RESOURCE_PART_SEP;
     buf << dict_encode(options);
-    return buf.str().c_str();
+    return buf.str();
 }
 
 std::shared_ptr<CdsResource> CdsResource::decode(std::string serial)

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -165,7 +165,7 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     }
 
     auto searchParam = std::make_unique<SearchParam>(containerID, searchCriteria,
-        std::stoi(startingIndex.c_str(), nullptr), std::stoi(requestedCount.c_str(), nullptr));
+        std::stoi(startingIndex, nullptr), std::stoi(requestedCount, nullptr));
 
     std::vector<std::shared_ptr<CdsObject>> results;
     int numMatches = 0;


### PR DESCRIPTION
Found with readability-redundant-string-cstr

Signed-off-by: Rosen Penev <rosenp@gmail.com>