### PR TITLE
[clang-tidy] remove continue statement at end of loop

### DIFF
--- a/src/storage/sqlite3/sqlite3_storage.cc
+++ b/src/storage/sqlite3/sqlite3_storage.cc
@@ -335,7 +335,6 @@ void Sqlite3Storage::threadProc()
         while (taskQueue.empty()) {
             /* if nothing to do, sleep until awakened */
             cond.wait(lock);
-            continue;
         }
 
         auto task = taskQueue.front();


### PR DESCRIPTION
Found with readability-redundant-control-flow

Signed-off-by: Rosen Penev <rosenp@gmail.com>