### PR TITLE
[clang-tidy] fix wrong strncmp usage

### DIFF
--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -337,7 +337,7 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename,
         std::string output;
 
         log_debug("Script input: {}", input.c_str());
-        if (strncmp(action.c_str(), "http://", 7)) {
+        if (strncmp(action.c_str(), "http://", 7) != 0) {
 #ifdef TOMBDEBUG
             struct timespec before;
             getTimespecNow(&before);

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -1072,7 +1072,7 @@ fs::path tempName(const fs::path& leadPath, char* tmpl)
     /* find the last occurrence of "XXXXXX" */
     XXXXXX = strstr(tmpl, "XXXXXX");
 
-    if (!XXXXXX || strncmp(XXXXXX, "XXXXXX", 6)) {
+    if (!XXXXXX || strncmp(XXXXXX, "XXXXXX", 6) != 0) {
         return "";
     }
 


### PR DESCRIPTION
Found with bugprone-suspicious-string-compare

Signed-off-by: Rosen Penev <rosenp@gmail.com>