### PR TITLE
[clang-tidy] add parentheses to macro

### DIFF
--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -81,7 +81,7 @@ enum {
 };
 
 /* table quote */
-#define TQ(data) QTB << data << QTE
+#define TQ(data) QTB << (data) << QTE
 /* table quote with dot */
 #define TQD(data1, data2) TQ(data1) << '.' << TQ(data2)
 


### PR DESCRIPTION
Found with bugprone-macro-parentheses

Signed-off-by: Rosen Penev <rosenp@gmail.com>