### PR TITLE
[clang-tidy] replace assert with static_assert

### DIFF
--- a/src/iohandler/curl_io_handler.cc
+++ b/src/iohandler/curl_io_handler.cc
@@ -120,7 +120,7 @@ void CurlIOHandler::threadProc()
                 curl_easy_setopt(curl_handle, CURLOPT_RESUME_FROM_LARGE, posRead);
             } else {
                 log_error("CurlIOHandler currently does not support SEEK_END");
-                assert(1);
+                static_assert(1, "");
             }
 
             /// \todo should we do that?


### PR DESCRIPTION
Found with hicpp-static-assert

Signed-off-by: Rosen Penev <rosenp@gmail.com>