### PR TITLE
[clang-tidy] fix namespace comments

### DIFF
--- a/src/web/pages.cc
+++ b/src/web/pages.cc
@@ -70,4 +70,4 @@ std::unique_ptr<WebRequestHandler> createWebRequestHandler(
     throw std::runtime_error("Unknown page: " + page);
 }
 
-} // namespace
+} // namespace web

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -250,4 +250,4 @@ void SessionManager::timerNotify(std::shared_ptr<Timer::Parameter> parameter)
     }
 }
 
-} // namespace
+} // namespace web

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -287,4 +287,4 @@ std::string WebRequestHandler::mapAutoscanType(int type)
         return "none";
 }
 
-} // namespace
+} // namespace web


### PR DESCRIPTION
Found with llvm-namespace-comment

Signed-off-by: Rosen Penev <rosenp@gmail.com>