### PR TITLE
[clang-tidy] fix function defenitions

### DIFF
--- a/src/autoscan_inotify.h
+++ b/src/autoscan_inotify.h
@@ -172,7 +172,7 @@ private:
     bool removeFromWdObj(const std::shared_ptr<Wd>& wdObj, const std::shared_ptr<Watch>& toRemove);
 
     void monitorNonexisting(const fs::path& path, const std::shared_ptr<AutoscanDirectory>& adir);
-    void recheckNonexistingMonitor(int curWd, std::vector<std::string> nonexistingPathArray, const std::shared_ptr<AutoscanDirectory>& adir);
+    void recheckNonexistingMonitor(int curWd, std::vector<std::string> pathAr, const std::shared_ptr<AutoscanDirectory>& adir);
     void recheckNonexistingMonitors(int wd, const std::shared_ptr<Wd>& wdObj);
     void removeNonexistingMonitor(int wd, const std::shared_ptr<Wd>& wdObj, const std::vector<std::string>& pathAr);
 

--- a/src/content_manager.h
+++ b/src/content_manager.h
@@ -256,7 +256,7 @@ public:
     /// Note: no actions should be performed on the object given as the parameter.
     /// Only the returned object should be processed. This method does not save
     /// the returned object in the database. To do so updateObject must be called
-    std::shared_ptr<CdsObject> convertObject(std::shared_ptr<CdsObject> obj, int objectType);
+    std::shared_ptr<CdsObject> convertObject(std::shared_ptr<CdsObject> obj, int newType);
 
     /// \brief Gets an AutocsanDirectrory from the watch list.
     std::shared_ptr<AutoscanDirectory> getAutoscanDirectory(int scanID, ScanMode scanMode);

--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -54,7 +54,7 @@ public:
     explicit FileRequestHandler(std::shared_ptr<ConfigManager> config,
         std::shared_ptr<Storage> storage,
         std::shared_ptr<ContentManager> content,
-        std::shared_ptr<UpdateManager> update_manager, std::shared_ptr<web::SessionManager> session_manager,
+        std::shared_ptr<UpdateManager> updateManager, std::shared_ptr<web::SessionManager> sessionManager,
         UpnpXMLBuilder* xmlBuilder);
 
     virtual void getInfo(const char *filename, UpnpFileInfo *info);

--- a/src/iohandler/curl_io_handler.h
+++ b/src/iohandler/curl_io_handler.h
@@ -53,7 +53,7 @@ private:
     std::string URL;
     //off_t bytesCurl;
 
-    static size_t curlCallback(void* ptr, size_t size, size_t nmemb, void* stream);
+    static size_t curlCallback(void* ptr, size_t size, size_t nmemb, void* data);
     virtual void threadProc();
 };
 

--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -50,7 +50,7 @@ private:
     void parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, LIBMATROSKA_NAMESPACE::KaxInfo* info);
     void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBMATROSKA_NAMESPACE::KaxAttachments* attachments, MemIOHandler** io_handler);
     std::string getContentTypeFromByteVector(const LIBMATROSKA_NAMESPACE::KaxFileData* data) const;
-    void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& content_type);
+    void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
 };
 
 #endif

--- a/src/metadata/taglib_handler.h
+++ b/src/metadata/taglib_handler.h
@@ -54,9 +54,9 @@ private:
     void addField(metadata_fields_t field, const TagLib::File& file, const TagLib::Tag* tag, const std::shared_ptr<CdsItem>& item) const;
 
     void populateGenericTags(const std::shared_ptr<CdsItem>& item, const TagLib::File& file) const;
-    bool isValidArtworkContentType(const std::string& content_type);
+    bool isValidArtworkContentType(const std::string& art_mimetype);
     std::string getContentTypeFromByteVector(const TagLib::ByteVector& data) const;
-    void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& content_type);
+    void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
     void extractMP3(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
     void extractOgg(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
     void extractASF(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);

--- a/src/scripting/import_script.h
+++ b/src/scripting/import_script.h
@@ -46,7 +46,7 @@ public:
         std::shared_ptr<ContentManager> content,
         const std::shared_ptr<Runtime>& runtime);
     ~ImportScript();
-    void processCdsObject(const std::shared_ptr<CdsObject>& obj, const std::string& rootpath);
+    void processCdsObject(const std::shared_ptr<CdsObject>& obj, const std::string& scriptpath);
     virtual script_class_t whoami() override { return S_IMPORT; }
 };
 

--- a/src/storage/sql_storage.h
+++ b/src/storage/sql_storage.h
@@ -236,7 +236,7 @@ private:
     fs::path stripLocationPrefix(std::string dbLocation, char* prefix = NULL);
 
     std::shared_ptr<CdsObject> checkRefID(const std::shared_ptr<CdsObject>& obj);
-    int createContainer(int parentID, std::string name, const std::string& virtualPath, bool isVirtual, const std::string& upnpClass, int refID, const std::map<std::string, std::string>& lastMetadata);
+    int createContainer(int parentID, std::string name, const std::string& virtualPath, bool isVirtual, const std::string& upnpClass, int refID, const std::map<std::string, std::string>& itemMetadata);
 
     std::string mapBool(bool val) { return quote((val ? 1 : 0)); }
     bool remapBool(std::string field) { return (string_ok(field) && field == "1"); }

--- a/src/storage/sqlite3/sqlite3_storage.h
+++ b/src/storage/sqlite3/sqlite3_storage.h
@@ -158,7 +158,7 @@ private:
     void shutdownDriver() override;
     std::shared_ptr<Storage> getSelf();
 
-    std::string quote(std::string str) override;
+    std::string quote(std::string value) override;
     inline std::string quote(const char* str) override { return quote(std::string(str)); }
     inline std::string quote(int val) override { return std::to_string(val); }
     inline std::string quote(unsigned int val) override { return std::to_string(val); }

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -293,7 +293,7 @@ std::string interfaceToIP(const std::string& interface);
 /// \brief Finds the Interface with the specified IP address.
 /// \param ip i.e. 192.168.4.56.
 /// \return Interface name or nullptr if IP was not found.
-std::string ipToInterface(const std::string& interface);
+std::string ipToInterface(const std::string& ip);
 
 /// \brief Returns true if the given string is eitehr "yes" or "no", otherwise
 /// returns false.


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>