### PR TITLE
[clang-tidy] remove redundant member initializations

### DIFF
--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -35,7 +35,6 @@
 using namespace std;
 
 IOHandlerBufferHelper::IOHandlerBufferHelper(size_t bufSize, size_t initialFillSize)
-    : IOHandler()
 {
     if (bufSize <= 0)
         throw std::runtime_error("bufSize must be positive");

--- a/src/iohandler/io_handler_chainer.cc
+++ b/src/iohandler/io_handler_chainer.cc
@@ -33,7 +33,6 @@
 #include "exceptions.h"
 
 IOHandlerChainer::IOHandlerChainer(std::unique_ptr<IOHandler>& readFrom, std::unique_ptr<IOHandler>& writeTo, int chunkSize)
-    : ThreadExecutor()
 {
     if (chunkSize <= 0)
         throw std::runtime_error("chunkSize must be positive");

--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -119,7 +119,6 @@ ProcessIOHandler::ProcessIOHandler(std::shared_ptr<ContentManager> content,
     const std::shared_ptr<Executor>& mainProc,
     std::vector<std::shared_ptr<ProcListItem>> procList,
     bool ignoreSeek)
-    : IOHandler()
 {
     this->content = std::move(content);
     this->filename = filename;

--- a/src/layout/fallback_layout.cc
+++ b/src/layout/fallback_layout.cc
@@ -426,8 +426,7 @@ void FallbackLayout::addATrailers(const std::shared_ptr<CdsObject>& obj)
 FallbackLayout::FallbackLayout(std::shared_ptr<ConfigManager> config,
     std::shared_ptr<Storage> storage,
     std::shared_ptr<ContentManager> content)
-    : Layout()
-    , config(std::move(config))
+    : config(std::move(config))
     , storage(std::move(storage))
     , content(std::move(content))
 {

--- a/src/layout/js_layout.cc
+++ b/src/layout/js_layout.cc
@@ -38,7 +38,6 @@ JSLayout::JSLayout(const std::shared_ptr<ConfigManager>& config,
     const std::shared_ptr<Storage>& storage,
     const std::shared_ptr<ContentManager>& content,
     const std::shared_ptr<Runtime>& runtime)
-    : Layout()
 {
     import_script = std::make_unique<ImportScript>(config, storage, content, runtime);
 }

--- a/src/storage/sqlite3/sqlite3_storage.cc
+++ b/src/storage/sqlite3/sqlite3_storage.cc
@@ -602,7 +602,6 @@ void SLBackupTask::run(sqlite3** db, Sqlite3Storage* sl)
 /* Sqlite3Result */
 
 Sqlite3Result::Sqlite3Result()
-    : SQLResult()
 {
     table = nullptr;
 }


### PR DESCRIPTION
Found with readability-redundant-member-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>