### PR TITLE
[clang-tidy] don't use else after return

### DIFF
--- a/src/autoscan.cc
+++ b/src/autoscan.cc
@@ -277,8 +277,8 @@ ScanMode AutoscanDirectory::remapScanmode(const std::string& scanmode)
         return ScanMode::Timed;
     if (scanmode == "inotify")
         return ScanMode::INotify;
-    else
-        throw std::runtime_error("illegal scanmode (" + scanmode + ") given to remapScanmode()");
+
+    throw std::runtime_error("illegal scanmode (" + scanmode + ") given to remapScanmode()");
 }
 
 std::string AutoscanDirectory::mapScanlevel(ScanLevel scanlevel)
@@ -301,10 +301,10 @@ ScanLevel AutoscanDirectory::remapScanlevel(const std::string& scanlevel)
 {
     if (scanlevel == "basic")
         return ScanLevel::Basic;
-    else if (scanlevel == "full")
+    if (scanlevel == "full")
         return ScanLevel::Full;
-    else
-        throw std::runtime_error("illegal scanlevel (" + scanlevel + ") given to remapScanlevel()");
+
+    throw std::runtime_error("illegal scanlevel (" + scanlevel + ") given to remapScanlevel()");
 }
 
 void AutoscanDirectory::copyTo(const std::shared_ptr<AutoscanDirectory>& copy)

--- a/src/autoscan_inotify.cc
+++ b/src/autoscan_inotify.cc
@@ -455,7 +455,7 @@ void AutoscanInotify::monitorUnmonitorRecursive(const fs::path& startPath, bool 
         if (name[0] == '.') {
             if (name[1] == 0)
                 continue;
-            else if (name[1] == '.' && name[2] == 0)
+            if (name[1] == '.' && name[2] == 0)
                 continue;
         }
 
@@ -643,8 +643,8 @@ bool AutoscanInotify::removeFromWdObj(const std::shared_ptr<Wd>& wdObj, const st
             } else
                 it = wdWatches->erase(it);
             return true;
-        } else
-            ++it;
+        }
+        ++it;
     }
     return false;
 }

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -573,12 +573,12 @@ void ContentManager::_rescanDirectory(int containerID, int scanID, ScanMode scan
             storage->updateAutoscanDirectory(adir);
             if (adir->persistent()) {
                 return;
-            } else {
-                adir->setTaskCount(-1);
-                removeAutoscanDirectory(scanID, scanMode);
-                storage->removeAutoscanDirectory(adir->getStorageID());
-                return;
             }
+
+            adir->setTaskCount(-1);
+            removeAutoscanDirectory(scanID, scanMode);
+            storage->removeAutoscanDirectory(adir->getStorageID());
+            return;
         }
 
         containerID = ensurePathExistence(adir->getLocation());
@@ -606,13 +606,12 @@ void ContentManager::_rescanDirectory(int containerID, int scanID, ScanMode scan
             adir->setObjectID(INVALID_OBJECT_ID);
             storage->updateAutoscanDirectory(adir);
             return;
-        } else {
+        }
             adir->setTaskCount(-1);
             removeObject(containerID, false);
             removeAutoscanDirectory(scanID, scanMode);
             storage->removeAutoscanDirectory(adir->getStorageID());
             return;
-        }
     }
 
     // request only items if non-recursive scan is wanted
@@ -629,9 +628,11 @@ void ContentManager::_rescanDirectory(int containerID, int scanID, ScanMode scan
         if (name[0] == '.') {
             if (name[1] == 0) {
                 continue;
-            } else if (name[1] == '.' && name[2] == 0) {
+            }
+            if (name[1] == '.' && name[2] == 0) {
                 continue;
-            } else if (!adir->getHidden()) {
+            }
+            if (!adir->getHidden()) {
                 continue;
             }
         }
@@ -752,9 +753,11 @@ void ContentManager::addRecursive(const fs::path& path, bool hidden, const std::
         if (name[0] == '.') {
             if (name[1] == 0) {
                 continue;
-            } else if (name[1] == '.' && name[2] == 0) {
+            }
+            if (name[1] == '.' && name[2] == 0) {
                 continue;
-            } else if (!hidden)
+            }
+            if (!hidden)
                 continue;
         }
         fs::path newPath = path / name;
@@ -1204,9 +1207,9 @@ void ContentManager::threadProc()
             cond.wait(lock);
             working = true;
             continue;
-        } else {
-            currentTask = task;
         }
+
+        currentTask = task;
         lock.unlock();
 
         // log_debug("content manager Async START {}", task->getDescription().c_str());
@@ -1272,9 +1275,8 @@ int ContentManager::addFileInternal(
         task->setParentID(parentTaskID);
         addTask(task, lowPriority);
         return INVALID_OBJECT_ID;
-    } else {
-        return _addFile(path, rootpath, recursive, hidden);
     }
+    return _addFile(path, rootpath, recursive, hidden);
 }
 
 #ifdef ONLINE_SERVICES
@@ -1472,7 +1474,7 @@ std::shared_ptr<AutoscanDirectory> ContentManager::getAutoscanDirectory(int scan
     }
 
 #if HAVE_INOTIFY
-    else if (scanMode == ScanMode::INotify) {
+    if (scanMode == ScanMode::INotify) {
         return autoscan_inotify->get(scanID);
     }
 #endif
@@ -1486,7 +1488,7 @@ std::vector<std::shared_ptr<AutoscanDirectory>> ContentManager::getAutoscanDirec
     }
 
 #if HAVE_INOTIFY
-    else if (scanMode == ScanMode::INotify) {
+    if (scanMode == ScanMode::INotify) {
         return autoscan_inotify->getArrayCopy();
     }
 #endif

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -131,8 +131,8 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     if (ret != 0) {
         if (is_srt)
             throw SubtitlesNotFoundException("Subtitle file " + path.string() + " is not available.");
-        else
-            throw std::runtime_error("Failed to open " + path.string() + " - " + strerror(errno));
+
+        throw std::runtime_error("Failed to open " + path.string() + " - " + strerror(errno));
     }
 
     if (access(path.c_str(), R_OK) == 0) {
@@ -405,8 +405,8 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename,
     if (ret != 0) {
         if (is_srt)
             throw SubtitlesNotFoundException("Subtitle file " + path.string() + " is not available.");
-        else
-            throw std::runtime_error("Failed to open " + path.string() + " - " + strerror(errno));
+
+        throw std::runtime_error("Failed to open " + path.string() + " - " + strerror(errno));
     }
 
     log_debug("fetching resource id {}", res_id);
@@ -462,47 +462,46 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename,
         io_handler->open(mode);
         log_debug("end");
         return io_handler;
-
-    } else {
-        if (!is_srt && string_ok(tr_profile)) {
-            std::string range = getValueOrDefault(params, "range");
-
-            auto tr_d = std::make_unique<TranscodeDispatcher>(config, content);
-            auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
-                            ->getByName(tr_profile);
-            return tr_d->open(tp, path, item, range);
-        } else {
-            if (mimeType.empty())
-                mimeType = item->getMimeType();
-
-            /* FIXME Upstream headers / DNLA
-            info->file_length = statbuf.st_size;
-            info->content_type = ixmlCloneDOMString(mimeType.c_str());
-
-            log_debug("Adding content disposition header: {}",
-                    header.c_str());
-            // if we are dealing with a regular file we should add the
-            // Accept-Ranges: bytes header, in order to indicate that we support
-            // seeking
-            if (S_ISREG(statbuf.st_mode))
-            {
-                if (string_ok(header))
-                    header = header + "\r\n";
-
-                header = header + "Accept-Ranges: bytes";
-            }
-
-            header = getDLNAtransferHeader(mimeType, header);
-
-            if (string_ok(header))
-                info->http_header = ixmlCloneDOMString(header.c_str());
-            */
-
-            auto io_handler = std::make_unique<FileIOHandler>(path);
-            io_handler->open(mode);
-            content->triggerPlayHook(obj);
-            log_debug("end");
-            return io_handler;
-        }
     }
+
+    if (!is_srt && string_ok(tr_profile)) {
+        std::string range = getValueOrDefault(params, "range");
+
+        auto tr_d = std::make_unique<TranscodeDispatcher>(config, content);
+        auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
+                      ->getByName(tr_profile);
+        return tr_d->open(tp, path, item, range);
+    }
+
+    if (mimeType.empty())
+        mimeType = item->getMimeType();
+
+    /* FIXME Upstream headers / DNLA
+    info->file_length = statbuf.st_size;
+    info->content_type = ixmlCloneDOMString(mimeType.c_str());
+
+    log_debug("Adding content disposition header: {}",
+              header.c_str());
+    // if we are dealing with a regular file we should add the
+    // Accept-Ranges: bytes header, in order to indicate that we support
+    // seeking
+    if (S_ISREG(statbuf.st_mode))
+    {
+        if (string_ok(header))
+            header = header + "\r\n";
+
+         header = header + "Accept-Ranges: bytes";
+    }
+
+    header = getDLNAtransferHeader(mimeType, header);
+
+    if (string_ok(header))
+        info->http_header = ixmlCloneDOMString(header.c_str());
+    */
+
+    auto io_handler = std::make_unique<FileIOHandler>(path);
+    io_handler->open(mode);
+    content->triggerPlayHook(obj);
+    log_debug("end");
+    return io_handler;
 }

--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -90,8 +90,8 @@ size_t IOHandlerBufferHelper::read(char* buf, size_t length)
         if (checkSocket) {
             checkSocket = false;
             return CHECK_SOCKET;
-        } else
-            cond.wait(lock);
+        }
+        cond.wait(lock);
     }
 
     if (readError || threadShutdown)

--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -205,15 +205,11 @@ size_t ProcessIOHandler::read(char* buf, size_t length)
                         exit_status = mainProc->getStatus();
                         log_debug("process exited with status {}", exit_status);
                         killAll();
-                        if (exit_status == EXIT_SUCCESS)
-                            return 0;
-                        else
-                            return -1;
-                    } else {
-                        mainProc->kill();
-                        killAll();
-                        return -1;
+                        return (exit_status == EXIT_SUCCESS) ? 0 : -1;
                     }
+                    mainProc->kill();
+                    killAll();
+                    return -1;
                 }
             } else {
                 killAll();
@@ -304,15 +300,12 @@ size_t ProcessIOHandler::write(char* buf, size_t length)
                         exit_status = mainProc->getStatus();
                         log_debug("process exited with status {}", exit_status);
                         killAll();
-                        if (exit_status == EXIT_SUCCESS)
-                            return 0;
-                        else
-                            return -1;
-                    } else {
-                        mainProc->kill();
-                        killAll();
-                        return -1;
+                        return (exit_status == EXIT_SUCCESS) ? 0 : -1;
                     }
+
+                    mainProc->kill();
+                    killAll();
+                    return -1;
                 }
             } else {
                 killAll();

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -301,8 +301,8 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
 
         auto h = std::make_unique<MemIOHandler>((void*)art->picture().data(), art->picture().size());
         return h;
-
-    } else if (content_type == CONTENT_TYPE_FLAC) {
+    }
+    if (content_type == CONTENT_TYPE_FLAC) {
         TagLib::FLAC::File f(&roStream, TagLib::ID3v2::FrameFactory::instance());
 
         if (!f.isValid())
@@ -316,8 +316,8 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
 
         auto h = std::make_unique<MemIOHandler>(data.data(), data.size());
         return h;
-
-    } else if (content_type == CONTENT_TYPE_MP4) {
+    }
+    if (content_type == CONTENT_TYPE_MP4) {
         TagLib::MP4::File f(&roStream);
 
         if (!f.isValid()) {
@@ -342,7 +342,8 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
 
         auto h = std::make_unique<MemIOHandler>(data.data(), data.size());
         return h;
-    } else if (content_type == CONTENT_TYPE_WMA) {
+    }
+    if (content_type == CONTENT_TYPE_WMA) {
         TagLib::ASF::File f(&roStream);
 
         if (!f.isValid())
@@ -364,7 +365,8 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
 
         auto h = std::make_unique<MemIOHandler>(data.data(), data.size());
         return h;
-    } else if (content_type == CONTENT_TYPE_OGG) {
+    }
+    if (content_type == CONTENT_TYPE_OGG) {
         TagLib::Ogg::Vorbis::File f(&roStream);
 
         if (!f.isValid() || !f.tag())

--- a/src/search_handler.cc
+++ b/src/search_handler.cc
@@ -163,9 +163,8 @@ std::unique_ptr<SearchToken> SearchLexer::makeToken(const std::string& tokenStr)
     auto itr = tokenTypes.find(aslowercase(tokenStr));
     if (itr != tokenTypes.end()) {
         return std::make_unique<SearchToken>(itr->second, tokenStr);
-    } else {
-        return std::make_unique<SearchToken>(TokenType::PROPERTY, tokenStr);
     }
+    return std::make_unique<SearchToken>(TokenType::PROPERTY, tokenStr);
 }
 
 void SearchParser::getNextToken()
@@ -178,8 +177,8 @@ std::shared_ptr<ASTNode> SearchParser::parse()
     getNextToken();
     if (currentToken->getType() == TokenType::ASTERISK)
         return std::make_shared<ASTAsterisk>(sqlEmitter, currentToken->getValue());
-    else
-        return parseSearchExpression();
+
+    return parseSearchExpression();
 }
 
 std::shared_ptr<ASTNode> SearchParser::parseSearchExpression()
@@ -452,8 +451,8 @@ std::string DefaultSQLEmitter::emitSQL(const ASTNode* node) const
             << "where "
             << predicates;
         return sql.str();
-    } else
-        throw std::runtime_error("No SQL generated from AST");
+    }
+    throw std::runtime_error("No SQL generated from AST");
 }
 
 std::string DefaultSQLEmitter::emit(const ASTParenthesis* node, const std::string& bracketedNode) const

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -1737,8 +1737,8 @@ std::shared_ptr<AutoscanDirectory> SQLStorage::getAutoscanDirectory(int objectID
     std::unique_ptr<SQLRow> row = res->nextRow();
     if (row == nullptr)
         return nullptr;
-    else
-        return _fillAutoscanDirectory(row);
+
+    return _fillAutoscanDirectory(row);
 }
 
 std::shared_ptr<AutoscanDirectory> SQLStorage::_fillAutoscanDirectory(const std::unique_ptr<SQLRow>& row)
@@ -1905,10 +1905,11 @@ int SQLStorage::_getAutoscanDirectoryInfo(int objectID, const std::string& field
     std::unique_ptr<SQLRow> row;
     if (res == nullptr || (row = res->nextRow()) == nullptr)
         return 0;
+
     if (!remapBool(row->col(0)))
         return 1;
-    else
-        return 2;
+
+    return 2;
 }
 
 int SQLStorage::_getAutoscanObjectID(int autoscanID)
@@ -2043,14 +2044,13 @@ std::unique_ptr<std::vector<int>> SQLStorage::_checkOverlappingAutoscans(const s
         throw std::runtime_error("SQL error");
     if ((row = res->nextRow()) == nullptr)
         return pathIDs;
-    else {
-        int objectID = std::stoi(row->col(0));
-        auto obj = loadObject(objectID);
-        if (obj == nullptr)
-            throw std::runtime_error("Referenced object (by Autoscan) not found.");
-        log_error("Overlapping Autoscans are not allowed. There is already a recursive Autoscan set on {}", obj->getLocation().c_str());
-        throw std::runtime_error("Overlapping Autoscans are not allowed. There is already a recursive Autoscan set on " + obj->getLocation().string());
-    }
+
+    int objectID = std::stoi(row->col(0));
+    auto obj = loadObject(objectID);
+    if (obj == nullptr)
+        throw std::runtime_error("Referenced object (by Autoscan) not found.");
+    log_error("Overlapping Autoscans are not allowed. There is already a recursive Autoscan set on {}", obj->getLocation().c_str());
+    throw std::runtime_error("Overlapping Autoscans are not allowed. There is already a recursive Autoscan set on " + obj->getLocation().string());
 }
 
 std::unique_ptr<std::vector<int>> SQLStorage::getPathIDs(int objectID)

--- a/src/storage/sqlite3/sqlite3_storage.cc
+++ b/src/storage/sqlite3/sqlite3_storage.cc
@@ -306,8 +306,8 @@ int Sqlite3Storage::exec(const char* query, int length, bool getLastInsertId)
     etask->waitForTask();
     if (getLastInsertId)
         return etask->getLastInsertId();
-    else
-        return -1;
+
+    return -1;
 }
 
 void* Sqlite3Storage::staticThreadProc(void* arg)
@@ -623,8 +623,8 @@ std::unique_ptr<SQLRow> Sqlite3Result::nextRow()
             auto p = std::make_unique<Sqlite3Row>(row, self);
             p->res = std::static_pointer_cast<Sqlite3Result>(self);
             return p;
-        } else
-            return nullptr;
+        }
+        return nullptr;
     }
     return nullptr;
 }

--- a/src/transcoding/transcode_dispatcher.cc
+++ b/src/transcoding/transcode_dispatcher.cc
@@ -55,6 +55,7 @@ std::unique_ptr<IOHandler> TranscodeDispatcher::open(std::shared_ptr<Transcoding
     if (profile->getType() == TR_External) {
         auto tr_ext = std::make_unique<TranscodeExternalHandler>(config, content);
         return tr_ext->open(profile, location, obj, range);
-    } else
-        throw std::runtime_error("Unknown transcoding type for profile " + profile->getName());
+    }
+
+    throw std::runtime_error("Unknown transcoding type for profile " + profile->getName());
 }

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -72,8 +72,8 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     int objectID;
     if (objID.empty())
         throw UpnpException(UPNP_E_NO_SUCH_ID, "empty object id");
-    else
-        objectID = std::stoi(objID);
+
+    objectID = std::stoi(objID);
 
     unsigned int flag = BROWSE_ITEMS | BROWSE_CONTAINERS | BROWSE_EXACT_CHILDCOUNT;
 

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -82,8 +82,8 @@ void URLRequestHandler::getInfo(const char *filename, UpnpFileInfo *info)
     if (objID.empty()) {
         //log_error("object_id not found in url");
         throw std::runtime_error("getInfo: object_id not found");
-    } else
-        objectID = std::stoi(objID);
+    }
+    objectID = std::stoi(objID);
 
     //log_debug("got ObjectID: [{}]", object_id.c_str());
 
@@ -179,8 +179,8 @@ std::unique_ptr<IOHandler> URLRequestHandler::open(const char* filename,
     std::string objID = getValueOrDefault(dict, "object_id");
     if (objID.empty()) {
         throw std::runtime_error("object_id not found");
-    } else
-        objectID = std::stoi(objID);
+    }
+    objectID = std::stoi(objID);
 
     auto obj = storage->loadObject(objectID);
 
@@ -219,20 +219,20 @@ std::unique_ptr<IOHandler> URLRequestHandler::open(const char* filename,
 
         auto tr_d = std::make_unique<TranscodeDispatcher>(config, content);
         return tr_d->open(tp, url, item, range);
-    } else {
-        auto u = std::make_unique<URL>();
-        try {
-            auto st = u->getInfo(url);
-            // info->file_length = st->getSize();
-            header = "Accept-Ranges: bytes";
-            log_debug("URL used for request: {}", st->getURL().c_str());
-        } catch (const std::runtime_error& ex) {
-            log_warning("{}", ex.what());
-            //info->file_length = -1;
-        }
-        mimeType = item->getMimeType();
-        // info->content_type = ixmlCloneDOMString(mimeType.c_str());
     }
+
+    auto u = std::make_unique<URL>();
+    try {
+        auto st = u->getInfo(url);
+        // info->file_length = st->getSize();
+        header = "Accept-Ranges: bytes";
+        log_debug("URL used for request: {}", st->getURL().c_str());
+    } catch (const std::runtime_error& ex) {
+        log_warning("{}", ex.what());
+        //info->file_length = -1;
+    }
+    mimeType = item->getMimeType();
+    // info->content_type = ixmlCloneDOMString(mimeType.c_str());
 
     /* FIXME headers
     if (string_ok(header))

--- a/src/util/mt_inotify.cc
+++ b/src/util/mt_inotify.cc
@@ -76,10 +76,9 @@ bool Inotify::supported()
     int test_fd = inotify_init();
     if (test_fd < 0)
         return false;
-    else {
-        close(test_fd);
-        return true;
-    }
+
+    close(test_fd);
+    return true;
 }
 
 int Inotify::addWatch(const fs::path& path, int events)
@@ -88,11 +87,11 @@ int Inotify::addWatch(const fs::path& path, int events)
     if (wd < 0 && errno != ENOENT) {
         if (errno == ENOSPC)
             throw std::runtime_error("The user limit on the total number of inotify watches was reached or the kernel failed to allocate a needed resource.");
-        else if (errno == EACCES) {
+        if (errno == EACCES) {
             log_warning("Cannot add inotify watch for {}: {}", path.c_str(), strerror(errno));
             return -1;
-        } else
-            throw std::runtime_error(mt_strerror(errno));
+        }
+        throw std::runtime_error(mt_strerror(errno));
     }
     return wd;
 }
@@ -142,7 +141,7 @@ struct inotify_event* Inotify::nextEvent()
 
     }
 
-    else if (first_byte == 0) {
+    if (first_byte == 0) {
         bytes = 0;
     }
 
@@ -166,7 +165,8 @@ struct inotify_event* Inotify::nextEvent()
         nullptr, nullptr, nullptr);
     if (rc < 0) {
         return nullptr;
-    } else if (rc == 0) {
+    }
+    if (rc == 0) {
         // timeout
         return nullptr;
     }

--- a/src/util/task_processor.cc
+++ b/src/util/task_processor.cc
@@ -68,9 +68,9 @@ void TaskProcessor::threadProc()
             cond.wait(lock);
             working = true;
             continue;
-        } else {
-            currentTask = task;
         }
+
+        currentTask = task;
         lock.unlock();
 
         try {

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -515,8 +515,8 @@ void writeTextFile(const fs::path& path, const std::string& contents)
         fclose(f);
         if (bytesWritten >= 0)
             throw std::runtime_error("writeTextFile: incomplete write to " + path.string() + " : ");
-        else
-            throw std::runtime_error("writeTextFile: error writing to " + path.string() + " : " + mt_strerror(errno));
+
+        throw std::runtime_error("writeTextFile: error writing to " + path.string() + " : " + mt_strerror(errno));
     }
     fclose(f);
 }
@@ -526,10 +526,10 @@ std::string renderProtocolInfo(const std::string& mimetype, const std::string& p
     if (string_ok(mimetype) && string_ok(protocol)) {
         if (string_ok(extend))
             return protocol + ":*:" + mimetype + ":" + extend;
-        else
-            return protocol + ":*:" + mimetype + ":*";
-    } else
-        return "http-get:*:*:*";
+        return protocol + ":*:" + mimetype + ":*";
+    }
+
+    return "http-get:*:*:*";
 }
 
 std::string getMTFromProtocolInfo(const std::string& protocol)
@@ -537,8 +537,8 @@ std::string getMTFromProtocolInfo(const std::string& protocol)
     std::vector<std::string> parts = split_string(protocol, ':');
     if (parts.size() > 2)
         return parts[2];
-    else
-        return "";
+
+    return "";
 }
 
 std::string getProtocol(const std::string& protocolInfo)
@@ -959,9 +959,9 @@ std::string ipToInterface(const std::string& ip)
 {
     if (!string_ok(ip)) {
         return "";
-    } else {
-        log_debug("Looking for '{}'", ip.c_str());
     }
+
+    log_debug("Looking for '{}'", ip.c_str());
 
     struct ifaddrs *ifaddr, *ifa;
     int family, s, n;
@@ -1102,8 +1102,8 @@ fs::path tempName(const fs::path& leadPath, char* tmpl)
         if (ret != 0) {
             if ((errno == ENOENT) || (errno == ENOTDIR))
                 return check;
-            else
-                return "";
+
+            return "";
         }
     }
 
@@ -1288,10 +1288,7 @@ std::string getAVIFourCC(const fs::path& avi_filename)
     std::string fourcc = std::string(buffer + FCC_OFFSET, 4);
     free(buffer);
 
-    if (string_ok(fourcc))
-        return fourcc;
-    else
-        return "";
+    return string_ok(fourcc) ? fourcc : "";
 }
 #endif
 

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -52,9 +52,8 @@ void web::edit_load::process()
     int objectID;
     if (objID.empty())
         throw std::runtime_error("invalid object id");
-    else
-        objectID = std::stoi(objID);
 
+    objectID = std::stoi(objID);
     auto obj = storage->loadObject(objectID);
 
     auto root = xmlDoc->document_element();

--- a/src/web/edit_save.cc
+++ b/src/web/edit_save.cc
@@ -50,8 +50,7 @@ void web::edit_save::process()
     int objectID;
     if (!string_ok(objID))
         throw std::runtime_error("invalid object id");
-    else
-        objectID = std::stoi(objID);
 
+    objectID = std::stoi(objID);
     content->updateObject(objectID, params);
 }

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -186,8 +186,7 @@ void SessionManager::removeSession(const std::string& sessionID)
             checkTimer();
             return;
         }
-        else
-            ++it;
+        ++it;
     }
 }
 

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -56,10 +56,7 @@ WebRequestHandler::WebRequestHandler(std::shared_ptr<ConfigManager> config,
 int WebRequestHandler::intParam(std::string name, int invalid)
 {
     std::string value = param(std::move(name));
-    if (!string_ok(value))
-        return invalid;
-    else
-        return std::stoi(value);
+    return string_ok(value) ? std::stoi(value) : invalid;
 }
 
 bool WebRequestHandler::boolParam(std::string name)
@@ -280,12 +277,14 @@ void WebRequestHandler::appendTask(const std::shared_ptr<GenericTask>& task, pug
 
 std::string WebRequestHandler::mapAutoscanType(int type)
 {
-    if (type == 1)
+    switch (type) {
+    case 1:
         return "ui";
-    else if (type == 2)
+    case 2:
         return "persistent";
-    else
+    default:
         return "none";
+    }
 }
 
 } // namespace web


### PR DESCRIPTION
Found with readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>