### PR TITLE
[clang-tidy] remove unused using declarations

### DIFF
--- a/src/autoscan_inotify.cc
+++ b/src/autoscan_inotify.cc
@@ -36,7 +36,6 @@
 #include <filesystem>
 #include <sys/stat.h>
 #include <utility>
-namespace fs = std::filesystem;
 
 #include "autoscan_inotify.h"
 #include "content_manager.h"

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -39,7 +39,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <filesystem>
-namespace fs = std::filesystem;
 
 #if defined(HAVE_NL_LANGINFO) && defined(HAVE_SETLOCALE)
 #include <clocale>

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -37,7 +37,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <utility>
-namespace fs = std::filesystem;
 
 #include "config/config_manager.h"
 #include "storage/storage.h"

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -32,7 +32,6 @@
 #include <filesystem>
 #include <sys/stat.h>
 #include <utility>
-namespace fs = std::filesystem;
 
 #include "iohandler/file_io_handler.h"
 #include "file_request_handler.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -39,7 +39,6 @@
 #include <spdlog/spdlog.h>
 #include <spdlog/sinks/basic_file_sink.h>
 #include <filesystem>
-namespace fs = std::filesystem;
 
 #ifdef SOLARIS
 #include <iso/limits_iso.h>

--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -32,7 +32,6 @@
 
 #include <filesystem>
 #include <utility>
-namespace fs = std::filesystem;
 
 #include "metadata_handler.h"
 #include "config/config_manager.h"

--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -36,7 +36,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-namespace fs = std::filesystem;
 
 #include "sql_storage.h"
 #include "config/config_manager.h"

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -40,7 +40,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <utility>
-namespace fs = std::filesystem;
 
 #include "transcode_ext_handler.h"
 #include "cds_objects.h"

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -44,7 +44,6 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <utility>
-namespace fs = std::filesystem;
 
 #include <ifaddrs.h>
 #include <net/if.h>

--- a/src/web/add_object.cc
+++ b/src/web/add_object.cc
@@ -32,7 +32,6 @@
 #include <cstdio>
 #include <filesystem>
 #include <utility>
-namespace fs = std::filesystem;
 
 #include "cds_objects.h"
 #include "common.h"


### PR DESCRIPTION
Found with misc-unused-alias-decls

Signed-off-by: Rosen Penev <rosenp@gmail.com>