### PR TITLE
[clang-tidy] fix function defenitions

### DIFF
--- a/src/storage/sqlite3/sqlite3_storage.h
+++ b/src/storage/sqlite3/sqlite3_storage.h
@@ -150,7 +150,7 @@ protected:
 /// \brief The Storage class for using SQLite3
 class Sqlite3Storage : public Timer::Subscriber, public SQLStorage, public std::enable_shared_from_this<SQLStorage> {
 public:
-    virtual void timerNotify(std::shared_ptr<Timer::Parameter> sqlite3storage) override;
+    virtual void timerNotify(std::shared_ptr<Timer::Parameter> param) override;
     Sqlite3Storage(std::shared_ptr<ConfigManager> config, std::shared_ptr<Timer> timer);
 
 private:


### PR DESCRIPTION
Found with readability-inconsistent-declaration-parameter-name

Signed-off-by: Rosen Penev <rosenp@gmail.com>