### PR TITLE
[clang-tidy] replace C casts with C++ ones

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -1833,19 +1833,19 @@ void ConfigManager::dumpOptions()
 {
 #ifdef TOMBDEBUG
     log_debug("Dumping options!");
-    for (int i = 0; i < (int)CFG_MAX; i++) {
+    for (int i = 0; i < static_cast<int>(CFG_MAX); i++) {
         try {
-            std::string opt = getOption((config_option_t)i);
+            std::string opt = getOption(static_cast<config_option_t>(i));
             log_debug("    Option {:02d} {}", i, opt.c_str());
         } catch (const std::runtime_error& e) {
         }
         try {
-            int opt = getIntOption((config_option_t)i);
+            int opt = getIntOption(static_cast<config_option_t>(i));
             log_debug(" IntOption {:02d} {}", i, opt);
         } catch (const std::runtime_error& e) {
         }
         try {
-            bool opt = getBoolOption((config_option_t)i);
+            bool opt = getBoolOption(static_cast<config_option_t>(i));
             log_debug("BoolOption {:02d} {}", i, opt ? "true" : "false");
         } catch (const std::runtime_error& e) {
         }

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -319,7 +319,7 @@ void ContentManager::timerNotify(std::shared_ptr<Timer::Parameter> parameter)
     }
 #ifdef ONLINE_SERVICES
     else if (parameter->whoami() == Timer::Parameter::IDOnlineContent) {
-        fetchOnlineContent((service_type_t)(parameter->getID()));
+        fetchOnlineContent(static_cast<service_type_t>(parameter->getID()));
     }
 #endif // ONLINE_SERVICES
 }
@@ -1232,7 +1232,7 @@ void ContentManager::threadProc()
 
 void* ContentManager::staticThreadProc(void* arg)
 {
-    auto* inst = (ContentManager*)arg;
+    auto inst = static_cast<ContentManager*>(arg);
     inst->threadProc();
     pthread_exit(nullptr);
     return nullptr;

--- a/src/iohandler/buffered_io_handler.cc
+++ b/src/iohandler/buffered_io_handler.cc
@@ -87,7 +87,7 @@ void BufferedIOHandler::threadProc()
                 int currentFillSize = b - a;
                 if (currentFillSize <= 0)
                     currentFillSize += bufSize;
-                percentFillLevel = ((float)currentFillSize / (float)bufSize) * 100;
+                percentFillLevel = (static_cast<float>(currentFillSize) / static_cast<float>(bufSize)) * 100;
             }
             log_debug("buffer fill level: {:03.2f}%  (bufSize: {}; a: {}; b: {})", percentFillLevel, bufSize, a, b);
         }
@@ -161,7 +161,7 @@ void BufferedIOHandler::threadProc()
                     int currentFillSize = b - a;
                     if (currentFillSize <= 0)
                         currentFillSize += bufSize;
-                    if ((size_t)currentFillSize >= initialFillSize) {
+                    if (static_cast<size_t>(currentFillSize) >= initialFillSize) {
                         log_debug("buffer: initial fillsize reached");
                         waitForInitialFillSize = false;
                         cond.notify_one();

--- a/src/iohandler/curl_io_handler.cc
+++ b/src/iohandler/curl_io_handler.cc
@@ -143,7 +143,7 @@ void CurlIOHandler::threadProc()
 
 size_t CurlIOHandler::curlCallback(void* ptr, size_t size, size_t nmemb, void* data)
 {
-    auto* ego = (CurlIOHandler*)data;
+    auto ego = static_cast<CurlIOHandler*>(data);
     size_t wantWrite = size * nmemb;
 
     assert(wantWrite <= ego->bufSize);
@@ -209,7 +209,7 @@ size_t CurlIOHandler::curlCallback(void* ptr, size_t size, size_t nmemb, void* d
             if (bufFree < 0)
                 bufFree += ego->bufSize;
         }
-    } while ((size_t)bufFree < wantWrite);
+    } while (static_cast<size_t>(bufFree) < wantWrite);
 
     size_t maxWrite = (ego->empty ? ego->bufSize : (ego->a < ego->b ? ego->bufSize - ego->b : ego->a - ego->b));
     size_t write1 = (wantWrite > maxWrite ? maxWrite : wantWrite);
@@ -221,7 +221,7 @@ size_t CurlIOHandler::curlCallback(void* ptr, size_t size, size_t nmemb, void* d
 
     memcpy(ego->buffer + bLocal, ptr, write1);
     if (write2)
-        memcpy(ego->buffer, (char*)ptr + maxWrite, write2);
+        memcpy(ego->buffer, static_cast<char*>(ptr) + maxWrite, write2);
 
     lock.lock();
 
@@ -237,7 +237,7 @@ size_t CurlIOHandler::curlCallback(void* ptr, size_t size, size_t nmemb, void* d
         int currentFillSize = ego->b - ego->a;
         if (currentFillSize <= 0)
             currentFillSize += ego->bufSize;
-        if ((size_t)currentFillSize >= ego->initialFillSize) {
+        if (static_cast<size_t>(currentFillSize) >= ego->initialFillSize) {
             log_debug("buffer: initial fillsize reached");
             ego->waitForInitialFillSize = false;
             ego->cond.notify_one();

--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -62,7 +62,7 @@ void IOHandlerBufferHelper::open(enum UpnpOpenFileMode mode)
 {
     if (isOpen)
         throw std::runtime_error("tried to reopen an open IOHandlerBufferHelper");
-    buffer = (char*)MALLOC(bufSize);
+    buffer = static_cast<char*>(MALLOC(bufSize));
     if (buffer == nullptr)
         throw std::runtime_error("Failed to allocate memory for transcoding buffer!");
 
@@ -210,7 +210,7 @@ void IOHandlerBufferHelper::stopBufferThread()
 void* IOHandlerBufferHelper::staticThreadProc(void* arg)
 {
     log_debug("starting buffer thread... thread: {}", pthread_self());
-    auto* inst = (IOHandlerBufferHelper*)arg;
+    auto inst = static_cast<IOHandlerBufferHelper*>(arg);
     inst->threadProc();
     log_debug("buffer thread shut down. thread: {}", pthread_self());
     pthread_exit(nullptr);

--- a/src/iohandler/io_handler_chainer.cc
+++ b/src/iohandler/io_handler_chainer.cc
@@ -43,7 +43,7 @@ IOHandlerChainer::IOHandlerChainer(std::unique_ptr<IOHandler>& readFrom, std::un
     this->readFrom = std::move(readFrom);
     this->writeTo = std::move(writeTo);
     readFrom->open(UPNP_READ);
-    buf = (char*)MALLOC(chunkSize);
+    buf = static_cast<char*>(MALLOC(chunkSize));
     startThread();
 }
 

--- a/src/iohandler/mem_io_handler.cc
+++ b/src/iohandler/mem_io_handler.cc
@@ -44,7 +44,7 @@
 #include <unistd.h>
 
 MemIOHandler::MemIOHandler(const void* buffer, int length)
-    : buffer((char*)MALLOC(length))
+    : buffer(static_cast<char*>(MALLOC(length)))
     , length(length)
     , pos(-1)
 {
@@ -52,7 +52,7 @@ MemIOHandler::MemIOHandler(const void* buffer, int length)
 }
 
 MemIOHandler::MemIOHandler(const std::string& str)
-    : buffer((char*)MALLOC(str.length()))
+    : buffer(static_cast<char*>(MALLOC(str.length())))
     , length(str.length())
     , pos(-1)
 {
@@ -79,12 +79,12 @@ size_t MemIOHandler::read(char* buf, size_t length)
     }
 
     off_t rest = this->length - pos;
-    if (length > (size_t)rest)
+    if (length > static_cast<size_t>(rest))
         length = rest;
 
     memcpy(buf, buffer + pos, length);
     pos = pos + length;
-    ret = (int)length;
+    ret = static_cast<int>(length);
 
     if (pos >= this->length) {
         pos = -1;

--- a/src/layout/fallback_layout.cc
+++ b/src/layout/fallback_layout.cc
@@ -417,7 +417,7 @@ void FallbackLayout::processCdsObject(std::shared_ptr<CdsObject> obj, fs::path r
 
 #ifdef ONLINE_SERVICES
     if (clone->getFlag(OBJECT_FLAG_ONLINE_SERVICE)) {
-        service_type_t service = (service_type_t)std::stoi(clone->getAuxData(ONLINE_SERVICE_AUX_ID));
+        auto service = static_cast<service_type_t>(std::stoi(clone->getAuxData(ONLINE_SERVICE_AUX_ID)));
 
         switch (service) {
 #ifdef SOPCAST

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -274,7 +274,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
 
         switch (e->tag) {
         case EXIF_TAG_DATE_TIME_ORIGINAL:
-            value = (char*)exif_egv(e);
+            value = const_cast<char*>(exif_egv(e));
             value = trim_string(value);
             if (string_ok(value)) {
                 value = sc->convert(value);
@@ -289,7 +289,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
             break;
 
         case EXIF_TAG_USER_COMMENT:
-            value = (char*)exif_egv(e);
+            value = const_cast<char*>(exif_egv(e));
             value = trim_string(value);
             if (string_ok(value)) {
                 value = sc->convert(value);
@@ -298,7 +298,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
             break;
 
         case EXIF_TAG_PIXEL_X_DIMENSION:
-            value = (char*)exif_egv(e);
+            value = const_cast<char*>(exif_egv(e));
             value = trim_string(value);
             if (string_ok(value)) {
                 value = sc->convert(value);
@@ -307,7 +307,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
             break;
 
         case EXIF_TAG_PIXEL_Y_DIMENSION:
-            value = (char*)exif_egv(e);
+            value = const_cast<char*>(exif_egv(e));
             value = trim_string(value);
             if (string_ok(value)) {
                 value = sc->convert(value);
@@ -322,7 +322,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
         for (const auto& tmp : auxtags) {
             if (string_ok(tmp)) {
                 if (e->tag == getTagFromString(tmp)) {
-                    value = (char*)exif_egv(e);
+                    value = const_cast<char*>(exif_egv(e));
                     value = trim_string(value);
                     if (string_ok(value)) {
                         value = sc->convert(value);

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -116,7 +116,7 @@ void TagLibHandler::addField(metadata_fields_t field, const TagLib::File& file, 
         i = tag->track();
         if (i > 0) {
             value = std::to_string(i);
-            item->setTrackNumber((int)i);
+            item->setTrackNumber(static_cast<int>(i));
         } else
             return;
         break;
@@ -174,7 +174,7 @@ void TagLibHandler::populateGenericTags(const std::shared_ptr<CdsItem>& item, co
     const TagLib::Tag* tag = file.tag();
 
     for (int i = 0; i < M_MAX; i++)
-        addField((metadata_fields_t)i, file, tag, item);
+        addField(static_cast<metadata_fields_t>(i), file, tag, item);
 
     int temp;
 
@@ -297,7 +297,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
         if (list.isEmpty())
             throw std::runtime_error("TagLibHandler: resource has no album information");
 
-        auto* art = static_cast<TagLib::ID3v2::AttachedPictureFrame*>(list.front());
+        auto art = static_cast<TagLib::ID3v2::AttachedPictureFrame*>(list.front());
 
         auto h = std::make_unique<MemIOHandler>((void*)art->picture().data(), art->picture().size());
         return h;

--- a/src/onlineservice/online_service_helper.cc
+++ b/src/onlineservice/online_service_helper.cc
@@ -43,7 +43,7 @@ std::string OnlineServiceHelper::resolveURL(const std::shared_ptr<CdsItemExterna
     if (!item->getFlag(OBJECT_FLAG_ONLINE_SERVICE))
         throw std::runtime_error("The given item does not belong to an online service");
 
-    service_type_t service = (service_type_t)std::stoi(item->getAuxData(ONLINE_SERVICE_AUX_ID));
+    auto service = static_cast<service_type_t>(std::stoi(item->getAuxData(ONLINE_SERVICE_AUX_ID)));
     if (service > OS_Max)
         throw std::runtime_error("Invalid service id!");
 

--- a/src/scripting/playlist_parser_script.cc
+++ b/src/scripting/playlist_parser_script.cc
@@ -145,7 +145,7 @@ void PlaylistParserScript::processPlaylistObject(const std::shared_ptr<CdsObject
 
     currentTask = std::move(task);
     currentObjectID = obj->getID();
-    currentLine = (char*)MALLOC(ONE_TEXTLINE_BYTES);
+    currentLine = static_cast<char*>(MALLOC(ONE_TEXTLINE_BYTES));
     if (!currentLine) {
         currentObjectID = INVALID_OBJECT_ID;
         currentTask = nullptr;

--- a/src/scripting/script.cc
+++ b/src/scripting/script.cc
@@ -159,13 +159,13 @@ Script::Script(const std::shared_ptr<ConfigManager>& config,
     duk_push_int(ctx, OBJECT_TYPE_ITEM_INTERNAL_URL);
     duk_put_global_string(ctx, "OBJECT_TYPE_ITEM_INTERNAL_URL");
 #ifdef ONLINE_SERVICES
-    duk_push_int(ctx, (int)OS_None);
+    duk_push_int(ctx, static_cast<int>(OS_None));
     duk_put_global_string(ctx, "ONLINE_SERVICE_NONE");
     duk_push_int(ctx, -1);
     duk_put_global_string(ctx, "ONLINE_SERVICE_YOUTUBE");
 
 #ifdef ATRAILERS
-    duk_push_int(ctx, (int)OS_ATrailers);
+    duk_push_int(ctx, static_cast<int>(OS_ATrailers));
     duk_put_global_string(ctx, "ONLINE_SERVICE_APPLE_TRAILERS");
     duk_push_string(ctx, ATRAILERS_AUXDATA_POST_DATE);
     duk_put_global_string(ctx, "APPLE_TRAILERS_AUXDATA_POST_DATE");
@@ -175,7 +175,7 @@ Script::Script(const std::shared_ptr<ConfigManager>& config,
 #endif //ATRAILERS
 
 #ifdef SOPCAST
-    duk_push_int(ctx, (int)OS_SopCast);
+    duk_push_int(ctx, static_cast<int>(OS_SopCast));
     duk_put_global_string(ctx, "ONLINE_SERVICE_SOPCAST");
 #else
     duk_push_int(ctx, -1);
@@ -254,7 +254,7 @@ Script* Script::getContextScript(duk_context* ctx)
 {
     duk_push_thread_stash(ctx, ctx);
     duk_get_prop_string(ctx, -1, "this");
-    auto* self = (Script*)duk_get_pointer(ctx, -1);
+    auto self = static_cast<Script*>(duk_get_pointer(ctx, -1));
     duk_pop_2(ctx);
     if (self == nullptr) {
         log_debug("Could not retrieve class instance from global object");
@@ -554,8 +554,8 @@ void Script::cdsObject2dukObject(const std::shared_ptr<CdsObject>& obj)
     if (!val.empty())
         setProperty("location", val);
 
-    setIntProperty("mtime", (int)obj->getMTime());
-    setIntProperty("sizeOnDisk", (int)obj->getSizeOnDisk());
+    setIntProperty("mtime", static_cast<int>(obj->getMTime()));
+    setIntProperty("sizeOnDisk", static_cast<int>(obj->getSizeOnDisk()));
 
     // TODO: boolean type
     i = obj->isRestricted();
@@ -568,8 +568,8 @@ void Script::cdsObject2dukObject(const std::shared_ptr<CdsObject>& obj)
 
 #ifdef ONLINE_SERVICES
     if (obj->getFlag(OBJECT_FLAG_ONLINE_SERVICE)) {
-        service_type_t service = (service_type_t)std::stoi(obj->getAuxData(ONLINE_SERVICE_AUX_ID));
-        setIntProperty("onlineservice", (int)service);
+        auto service = static_cast<service_type_t>(std::stoi(obj->getAuxData(ONLINE_SERVICE_AUX_ID)));
+        setIntProperty("onlineservice", static_cast<int>(service));
     } else
 #endif
         setIntProperty("onlineservice", 0);

--- a/src/server.cc
+++ b/src/server.cc
@@ -208,7 +208,7 @@ void Server::run()
     log_debug("Registering with UPnP...");
     ret = UpnpRegisterRootDevice2(UPNPREG_BUF_DESC,
         deviceDescription.c_str(),
-        (size_t)deviceDescription.length() + 1,
+        static_cast<size_t>(deviceDescription.length()) + 1,
         true,
         static_upnp_callback,
         this,
@@ -525,7 +525,7 @@ int Server::registerVirtualDirCallbacks()
         if (static_cast<const Server*>(cookie)->getShutdownStatus())
             return -1;
 
-        auto* handler = static_cast<IOHandler*>(f);
+        auto handler = static_cast<IOHandler*>(f);
         return handler->read(buf, length);
     });
     if (ret != UPNP_E_SUCCESS)
@@ -551,7 +551,7 @@ int Server::registerVirtualDirCallbacks()
 #endif
         //log_debug("%p seek({}, {})", f, offset, whence);
         try {
-            auto* handler = static_cast<IOHandler*>(f);
+            auto handler = static_cast<IOHandler*>(f);
             handler->seek(offset, whence);
         } catch (const std::runtime_error& e) {
             log_error("Exception during seek: {}", e.what());
@@ -571,7 +571,7 @@ int Server::registerVirtualDirCallbacks()
 #endif
         int ret_close = 0;
         //log_debug("%p close()", f);
-        auto* handler = static_cast<IOHandler*>(f);
+        auto handler = static_cast<IOHandler*>(f);
         try {
             handler->close();
         } catch (const std::runtime_error& e) {

--- a/src/storage/mysql/mysql_storage.cc
+++ b/src/storage/mysql/mysql_storage.cc
@@ -199,8 +199,8 @@ void MysqlStorage::init()
             throw std::runtime_error("Error while uncompressing mysql create sql. returned: " + std::to_string(ret));
         buf[MS_CREATE_SQL_INFLATED_SIZE] = '\0';
 
-        auto* sql_start = (char*)buf;
-        char* sql_end = strchr(sql_start, ';');
+        auto sql_start = (char*)buf;
+        auto sql_end = strchr(sql_start, ';');
         if (sql_end == nullptr) {
             throw std::runtime_error("';' not found in mysql create sql");
         }
@@ -289,7 +289,7 @@ std::string MysqlStorage::quote(std::string value)
      * the \0; then the string won't be null-terminated, but that doesn't matter,
      * because we give the correct length to std::string()
      */
-    auto* q = (char*)MALLOC(value.length() * 2 + 2);
+    auto q = (char*)MALLOC(value.length() * 2 + 2);
     *q = '\'';
     long size = mysql_real_escape_string(&db, q + 1, value.c_str(), value.length());
     q[size + 1] = '\'';

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -113,7 +113,7 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::open(std::shared_ptr<Transc
 #ifdef SOPCAST
     service_type_t service = OS_None;
     if (obj->getFlag(OBJECT_FLAG_ONLINE_SERVICE)) {
-        service = (service_type_t)std::stoi(obj->getAuxData(ONLINE_SERVICE_AUX_ID));
+        service = static_cast<service_type_t>(std::stoi(obj->getAuxData(ONLINE_SERVICE_AUX_ID)));
     }
 
     if (service == OS_SopCast) {

--- a/src/update_manager.cc
+++ b/src/update_manager.cc
@@ -247,7 +247,7 @@ void UpdateManager::threadProc()
 void* UpdateManager::staticThreadProc(void* arg)
 {
     log_debug("starting update thread... thread: {}", pthread_self());
-    auto* inst = (UpdateManager*)arg;
+    auto inst = static_cast<UpdateManager*>(arg);
     inst->threadProc();
 
     log_debug("update thread shut down. thread: {}", pthread_self());

--- a/src/url.cc
+++ b/src/url.cc
@@ -176,7 +176,7 @@ std::unique_ptr<URL::Stat> URL::getInfo(const std::string& URL, CURL* curl_handl
     else
         used_url = c_url;
 
-    auto st = std::make_unique<Stat>(used_url, (off_t)cl, mt);
+    auto st = std::make_unique<Stat>(used_url, static_cast<off_t>(cl), mt);
 
     if (cleanup)
         curl_easy_cleanup(curl_handle);

--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -76,10 +76,10 @@ static int Get16m(const void* Short)
 static int ioh_fgetc(const std::unique_ptr<IOHandler>& ioh)
 {
     uchar c[1] = { 0 };
-    int ret = ioh->read((char*)c, sizeof(char));
+    int ret = ioh->read(reinterpret_cast<char*>(c), sizeof(char));
     if (ret < 0)
         return ret;
-    return (int)c[0];
+    return static_cast<int>(c[0]);
 }
 
 static void get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh, int* w, int* h)
@@ -127,10 +127,10 @@ static void get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh, int* w, i
         }
 
         // Store first two pre-read bytes.
-        Data[0] = (uchar)lh;
-        Data[1] = (uchar)ll;
+        Data[0] = static_cast<uchar>(lh);
+        Data[1] = static_cast<uchar>(ll);
 
-        got = ioh->read((char*)(Data + 2), itemlen - 2);
+        got = ioh->read(reinterpret_cast<char*>(Data + 2), itemlen - 2);
         if (got != itemlen - 2)
             throw std::runtime_error("get_jpeg_resolution: Premature end of file?");
 

--- a/src/util/mt_inotify.cc
+++ b/src/util/mt_inotify.cc
@@ -114,9 +114,9 @@ struct inotify_event* Inotify::nextEvent()
 
     // first_byte is index into event buffer
     if (first_byte != 0
-        && first_byte <= (int)(bytes - sizeof(struct inotify_event))) {
+        && first_byte <= static_cast<int>(bytes - sizeof(struct inotify_event))) {
 
-        ret = (struct inotify_event*)((char*)&event[0] + first_byte);
+        ret = reinterpret_cast<struct inotify_event*>(reinterpret_cast<char*>(&event[0]) + first_byte);
         first_byte += sizeof(struct inotify_event) + ret->len;
 
         // if the pointer to the next event exactly hits end of bytes read,
@@ -133,7 +133,7 @@ struct inotify_event* Inotify::nextEvent()
             assert((long)((char*)&event[0] + sizeof(struct inotify_event) + event[0].len) <= (long)ret);
 
             // how much of the event do we have?
-            bytes = (char*)&event[0] + bytes - (char*)ret;
+            bytes = reinterpret_cast<char*>(&event[0]) + bytes - reinterpret_cast<char*>(ret);
             memcpy(&event[0], ret, bytes);
             return nextEvent();
         }

--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -65,7 +65,7 @@ std::string StringConverter::convert(std::string str, bool validate)
             break;
 
         ret = ret + "?";
-        if ((stoppedAt + 1) < (size_t)str.length())
+        if ((stoppedAt + 1) < static_cast<size_t>(str.length()))
             str = str.substr(stoppedAt + 1);
         else
             break;
@@ -93,8 +93,8 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
 
     int buf_size = str.length() * 4;
 
-    const char* input = str.c_str();
-    auto* output = (char*)MALLOC(buf_size);
+    auto input = str.c_str();
+    auto output = static_cast<char*>(MALLOC(buf_size));
     if (!output) {
         log_debug("Could not allocate memory for string conversion!");
         throw std::runtime_error("Could not allocate memory for string conversion!");
@@ -106,8 +106,8 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
     const char** input_ptr = &input_copy;
     char** output_ptr = &output_copy;
 
-    auto input_bytes = (size_t)str.length();
-    auto output_bytes = (size_t)buf_size;
+    auto input_bytes = static_cast<size_t>(str.length());
+    auto output_bytes = static_cast<size_t>(buf_size);
 
     int ret;
 
@@ -123,7 +123,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
     ret = iconv(cd, input_ptr, &input_bytes,
         output_ptr, &output_bytes);
 #else
-    ret = iconv(cd, (char**)input_ptr, &input_bytes,
+    ret = iconv(cd, const_cast<char**>(input_ptr), &input_bytes,
         output_ptr, &output_bytes);
 #endif
 
@@ -143,7 +143,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
             }
 
             if (stoppedAt)
-                *stoppedAt = (size_t)str.length() - input_bytes;
+                *stoppedAt = static_cast<size_t>(str.length()) - input_bytes;
             ret_str = std::string(output, output_copy - output);
             dirty = true;
             *output_copy = 0;

--- a/src/util/task_processor.cc
+++ b/src/util/task_processor.cc
@@ -42,7 +42,7 @@ void TaskProcessor::shutdown()
 
 void* TaskProcessor::staticThreadProc(void* arg)
 {
-    auto* inst = (TaskProcessor*)arg;
+    auto inst = static_cast<TaskProcessor*>(arg);
     inst->threadProc();
     pthread_exit(nullptr);
     return nullptr;

--- a/src/util/thread_executor.cc
+++ b/src/util/thread_executor.cc
@@ -73,7 +73,7 @@ bool ThreadExecutor::kill()
 
 void* ThreadExecutor::staticThreadProc(void* arg)
 {
-    auto* inst = (ThreadExecutor*)arg;
+    auto inst = static_cast<ThreadExecutor*>(arg);
     inst->threadProc();
     pthread_exit(nullptr);
     return nullptr;

--- a/src/util/timer.cc
+++ b/src/util/timer.cc
@@ -57,7 +57,7 @@ void Timer::init()
 void* Timer::staticThreadProc(void* arg)
 {
     log_debug("Started Timer thread.");
-    auto* inst = (Timer*)arg;
+    auto inst = static_cast<Timer*>(arg);
     inst->threadProc();
     log_debug("Exiting Timer thread...");
     return nullptr;


### PR DESCRIPTION
Found with google-readability-casting

Signed-off-by: Rosen Penev <rosenp@gmail.com>