### PR TITLE
 [clang-tidy] use dynamic_cast instead of static_cast

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -162,9 +162,9 @@ void MatroskaHandler::parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandle
 void MatroskaHandler::parseLevel1Element(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, EbmlElement* el_l1, MemIOHandler** p_io_handler)
 {
     if (EbmlId(*el_l1) == KaxInfo::ClassInfos.GlobalId) {
-        parseInfo(item, ebml_stream, static_cast<KaxInfo*>(el_l1));
+        parseInfo(item, ebml_stream, dynamic_cast<KaxInfo*>(el_l1));
     } else if (EbmlId(*el_l1) == KaxAttachments::ClassInfos.GlobalId) {
-        parseAttachments(item, ebml_stream, static_cast<KaxAttachments*>(el_l1), p_io_handler);
+        parseAttachments(item, ebml_stream, dynamic_cast<KaxAttachments*>(el_l1), p_io_handler);
     }
 }
 
@@ -184,11 +184,11 @@ void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream
         EbmlElement* el = (*m)[i];
 
         if (EbmlId(*el) == KaxTitle::ClassInfos.GlobalId) {
-            std::string title(UTFstring(*static_cast<KaxTitle*>(el)).GetUTF8());
+            std::string title(UTFstring(*dynamic_cast<KaxTitle*>(el)).GetUTF8());
             // printf("KaxTitle = %s\n", title.c_str());
             item->setMetadata(MT_KEYS[M_TITLE].upnp, sc->convert(title));
         } else if (EbmlId(*el) == KaxDateUTC::ClassInfos.GlobalId) {
-            KaxDateUTC& date = *static_cast<KaxDateUTC*>(el);
+            KaxDateUTC& date = *dynamic_cast<KaxDateUTC*>(el);
             time_t i_date;
             struct tm tmres;
             char buffer[25];

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -297,7 +297,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
         if (list.isEmpty())
             throw std::runtime_error("TagLibHandler: resource has no album information");
 
-        auto* art = static_cast<TagLib::ID3v2::AttachedPictureFrame*>(list.front());
+        auto art = dynamic_cast<TagLib::ID3v2::AttachedPictureFrame*>(list.front());
 
         auto h = std::make_unique<MemIOHandler>((void*)art->picture().data(), art->picture().size());
         return h;
@@ -455,7 +455,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
 
     const TagLib::ID3v2::FrameList apicFrameList = mp3.ID3v2Tag()->frameList("APIC");
     if (!apicFrameList.isEmpty()) {
-        auto art = static_cast<const TagLib::ID3v2::AttachedPictureFrame*>(apicFrameList.front());
+        auto art = dynamic_cast<const TagLib::ID3v2::AttachedPictureFrame*>(apicFrameList.front());
 
         const TagLib::ByteVector pic = art->picture();
         std::string art_mimetype = sc->convert(art->mimeType().toCString(true));

--- a/src/scripting/playlist_parser_script.cc
+++ b/src/scripting/playlist_parser_script.cc
@@ -46,7 +46,7 @@ extern "C" {
 static duk_ret_t
 js_readln(duk_context* ctx)
 {
-    auto* self = (PlaylistParserScript*)Script::getContextScript(ctx);
+    auto self = dynamic_cast<PlaylistParserScript*>(Script::getContextScript(ctx));
 
     std::string line;
 
@@ -67,7 +67,7 @@ js_readln(duk_context* ctx)
 static duk_ret_t
 js_getCdsObject(duk_context* ctx)
 {
-    auto* self = (PlaylistParserScript*)Script::getContextScript(ctx);
+    auto self = dynamic_cast<PlaylistParserScript*>(Script::getContextScript(ctx));
 
     if (!duk_is_string(ctx, 0))
         return 0;


### PR DESCRIPTION
 [clang-tidy] use dynamic_cast instead of static_cast

Found with cppcoreguidelines-pro-type-cstyle-cast
Found with cppcoreguidelines-pro-type-static-cast-downcast

Signed-off-by: Rosen Penev <rosenp@gmail.com>