### PR TITLE
[clang-tidy] convert member functions to static

### DIFF
--- a/src/autoscan_inotify.h
+++ b/src/autoscan_inotify.h
@@ -165,9 +165,9 @@ private:
     int monitorDirectory(const fs::path& path, const std::shared_ptr<AutoscanDirectory>& adir, bool startPoint, std::vector<std::string>* pathArray = nullptr);
     void unmonitorDirectory(const fs::path& path, const std::shared_ptr<AutoscanDirectory>& adir);
 
-    std::shared_ptr<WatchAutoscan> getAppropriateAutoscan(const std::shared_ptr<Wd>& wdObj, const std::shared_ptr<AutoscanDirectory>& adir);
-    std::shared_ptr<WatchAutoscan> getAppropriateAutoscan(const std::shared_ptr<Wd>& wdObj, const fs::path& path);
-    std::shared_ptr<WatchAutoscan> getStartPoint(const std::shared_ptr<Wd>& wdObj);
+    static std::shared_ptr<WatchAutoscan> getAppropriateAutoscan(const std::shared_ptr<Wd>& wdObj, const std::shared_ptr<AutoscanDirectory>& adir);
+    static std::shared_ptr<WatchAutoscan> getAppropriateAutoscan(const std::shared_ptr<Wd>& wdObj, const fs::path& path);
+    static std::shared_ptr<WatchAutoscan> getStartPoint(const std::shared_ptr<Wd>& wdObj);
 
     bool removeFromWdObj(const std::shared_ptr<Wd>& wdObj, const std::shared_ptr<Watch>& toRemove);
 

--- a/src/config/config_generator.h
+++ b/src/config/config_generator.h
@@ -35,21 +35,21 @@ public:
     ConfigGenerator();
     ~ConfigGenerator();
 
-    std::string generate(const fs::path& userHome, const fs::path& configDir, const fs::path& prefixDir, const fs::path& magicFile);
+    static std::string generate(const fs::path& userHome, const fs::path& configDir, const fs::path& prefixDir, const fs::path& magicFile);
 
-    void generateServer(const fs::path& userHome, const fs::path& configDir, const fs::path& prefixDir, pugi::xml_node* config);
-    void generateUi(pugi::xml_node* server);
-    void generateExtendedRuntime(pugi::xml_node* server);
-    void generateStorage(pugi::xml_node* server);
-    void generateImport(const fs::path& prefixDir, const fs::path& magicFile, pugi::xml_node* config);
-    void generateMappings(pugi::xml_node* import);
-    void generateOnlineContent(pugi::xml_node* import);
-    void generateTranscoding(pugi::xml_node* config);
-    void generateUdn(pugi::xml_node* server);
+    static void generateServer(const fs::path& userHome, const fs::path& configDir, const fs::path& prefixDir, pugi::xml_node* config);
+    static void generateUi(pugi::xml_node* server);
+    static void generateExtendedRuntime(pugi::xml_node* server);
+    static void generateStorage(pugi::xml_node* server);
+    static void generateImport(const fs::path& prefixDir, const fs::path& magicFile, pugi::xml_node* config);
+    static void generateMappings(pugi::xml_node* import);
+    static void generateOnlineContent(pugi::xml_node* import);
+    static void generateTranscoding(pugi::xml_node* config);
+    static void generateUdn(pugi::xml_node* server);
 
 protected:
-    void map_from_to(const std::string& from, const std::string& to, pugi::xml_node* parent);
-    void treat_as(const std::string& mimetype, const std::string& as, pugi::xml_node* parent);
+    static void map_from_to(const std::string& from, const std::string& to, pugi::xml_node* parent);
+    static void treat_as(const std::string& mimetype, const std::string& as, pugi::xml_node* parent);
 };
 
 #endif //GERBERA_CONFIG_GENERATOR_H

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -75,7 +75,7 @@ ConfigManager::ConfigManager(fs::path filename,
     , interface(std::move(interface))
     , port(port)
 {
-    this->debug_logging = debug_logging;
+    ConfigManager::debug_logging = debug_logging;
 
     xmlDoc = std::make_unique<pugi::xml_document>();
     options = std::make_unique<std::vector<std::shared_ptr<ConfigOption>>>();

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -293,7 +293,7 @@ protected:
     ///
     /// This function will create a dictionary with the following
     /// key:value paris: "1":"2", "3":"4"
-    std::map<std::string, std::string> createDictionaryFromNode(const pugi::xml_node& element,
+    static std::map<std::string, std::string> createDictionaryFromNode(const pugi::xml_node& element,
         const std::string& nodeName, const std::string& keyAttr, const std::string& valAttr, bool tolower = false);
 
     /// \brief Creates an array of AutoscanDirectory objects from a XML nodeset.
@@ -305,7 +305,7 @@ protected:
     /// \brief Creates ab aray of TranscodingProfile objects from an XML
     /// nodeset.
     /// \param element starting element of the nodeset.
-    std::shared_ptr<TranscodingProfileList> createTranscodingProfileListFromNode(const pugi::xml_node& element);
+    static std::shared_ptr<TranscodingProfileList> createTranscodingProfileListFromNode(const pugi::xml_node& element);
 
     /// \brief Creates an array of strings from an XML nodeset.
     /// \param element starting element of the nodeset.
@@ -320,7 +320,7 @@ protected:
     /// <some-section>
     ///
     /// This function will create an array like that: ["data", "otherdata"]
-    std::vector<std::string> createArrayFromNode(const pugi::xml_node& element, const std::string& nodeName, const std::string& attrName);
+    static std::vector<std::string> createArrayFromNode(const pugi::xml_node& element, const std::string& nodeName, const std::string& attrName);
 
     void dumpOptions();
 };

--- a/src/content_manager.h
+++ b/src/content_manager.h
@@ -365,7 +365,7 @@ protected:
     std::string extension2mimetype(std::string extension);
     std::string mimetype2upnpclass(const std::string& mimeType);
 
-    void invalidateAddTask(const std::shared_ptr<GenericTask>& t, const fs::path& path);
+    static void invalidateAddTask(const std::shared_ptr<GenericTask>& t, const fs::path& path);
 
     std::shared_ptr<Layout> layout;
 

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -356,7 +356,7 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename,
         auto clone = CdsObject::createObject(storage, objectType);
         aitem->copyTo(clone);
 
-        xmlBuilder->updateObject(clone, output);
+        UpnpXMLBuilder::updateObject(clone, output);
 
         if (!aitem->equals(clone, true)) // check for all differences
         {

--- a/src/layout/fallback_layout.h
+++ b/src/layout/fallback_layout.h
@@ -57,7 +57,7 @@ public:
 #endif
 protected:
     void add(const std::shared_ptr<CdsObject>& obj, int parentID, bool use_ref = true);
-    std::string esc(std::string str);
+    static std::string esc(std::string str);
     void addVideo(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath);
     void addImage(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath);
     void addAudio(const std::shared_ptr<CdsObject>& obj);

--- a/src/main.cc
+++ b/src/main.cc
@@ -263,7 +263,7 @@ int main(int argc, char** argv, char** envp)
         if (opts.count("create-config") > 0) {
             ConfigGenerator configGenerator;
 
-            std::string generated = configGenerator.generate(home.value_or(""), confdir.value_or(""), prefix.value_or(""), magic.value_or(""));
+            std::string generated = ConfigGenerator::generate(home.value_or(""), confdir.value_or(""), prefix.value_or(""), magic.value_or(""));
             std::cout << generated.c_str() << std::endl;
             exit(EXIT_SUCCESS);
         }

--- a/src/metadata/fanart_handler.cc
+++ b/src/metadata/fanart_handler.cc
@@ -49,7 +49,7 @@ FanArtHandler::FanArtHandler(std::shared_ptr<ConfigManager> config)
 {
 }
 
-fs::path FanArtHandler::getFanArtPath(const std::shared_ptr<CdsItem>& item) const
+fs::path FanArtHandler::getFanArtPath(const std::shared_ptr<CdsItem>& item)
 {
     auto folder = item->getLocation().parent_path();
     log_debug("Folder name: {}", folder.c_str());

--- a/src/metadata/fanart_handler.h
+++ b/src/metadata/fanart_handler.h
@@ -43,7 +43,7 @@ public:
     virtual std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsItem> item, int resNum);
 
 private:
-    fs::path getFanArtPath(const std::shared_ptr<CdsItem>& item) const;
+    static fs::path getFanArtPath(const std::shared_ptr<CdsItem>& item);
 };
 
 #endif // __METADATA_FANART_H__

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -237,7 +237,7 @@ void MatroskaHandler::parseAttachments(const std::shared_ptr<CdsItem>& item, Ebm
     }
 }
 
-std::string MatroskaHandler::getContentTypeFromByteVector(const KaxFileData* data) const
+std::string MatroskaHandler::getContentTypeFromByteVector(const KaxFileData* data)
 {
     std::string art_mimetype = MIMETYPE_DEFAULT;
 #ifdef HAVE_MAGIC

--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -48,9 +48,9 @@ private:
     void parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandler** p_io_handler);
     void parseLevel1Element(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlElement* el_l1, MemIOHandler** p_io_handler);
     void parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, LIBMATROSKA_NAMESPACE::KaxInfo* info);
-    void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBMATROSKA_NAMESPACE::KaxAttachments* attachments, MemIOHandler** io_handler);
-    std::string getContentTypeFromByteVector(const LIBMATROSKA_NAMESPACE::KaxFileData* data) const;
-    void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
+    static void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBMATROSKA_NAMESPACE::KaxAttachments* attachments, MemIOHandler** io_handler);
+    static std::string getContentTypeFromByteVector(const LIBMATROSKA_NAMESPACE::KaxFileData* data);
+    static void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
 };
 
 #endif

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -248,7 +248,7 @@ bool TagLibHandler::isValidArtworkContentType(const std::string& art_mimetype)
     return (string_ok(art_mimetype) && (art_mimetype.find('/') != std::string::npos));
 }
 
-std::string TagLibHandler::getContentTypeFromByteVector(const TagLib::ByteVector& data) const
+std::string TagLibHandler::getContentTypeFromByteVector(const TagLib::ByteVector& data)
 {
     std::string art_mimetype = MIMETYPE_DEFAULT;
 #ifdef HAVE_MAGIC

--- a/src/metadata/taglib_handler.h
+++ b/src/metadata/taglib_handler.h
@@ -54,9 +54,9 @@ private:
     void addField(metadata_fields_t field, const TagLib::File& file, const TagLib::Tag* tag, const std::shared_ptr<CdsItem>& item) const;
 
     void populateGenericTags(const std::shared_ptr<CdsItem>& item, const TagLib::File& file) const;
-    bool isValidArtworkContentType(const std::string& art_mimetype);
-    std::string getContentTypeFromByteVector(const TagLib::ByteVector& data) const;
-    void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
+    static bool isValidArtworkContentType(const std::string& art_mimetype);
+    static std::string getContentTypeFromByteVector(const TagLib::ByteVector& data);
+    static void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
     void extractMP3(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
     void extractOgg(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
     void extractASF(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);

--- a/src/onlineservice/online_service_helper.h
+++ b/src/onlineservice/online_service_helper.h
@@ -44,7 +44,7 @@ public:
 
     /// \brief this function will determine the final URL for services that
     /// need extra steps to do that
-    std::string resolveURL(const std::shared_ptr<CdsItemExternalURL>& item);
+    static std::string resolveURL(const std::shared_ptr<CdsItemExternalURL>& item);
 };
 
 #endif //__ONLINE_SERVICE_HELPER_H__

--- a/src/search_handler.h
+++ b/src/search_handler.h
@@ -93,7 +93,7 @@ public:
 
 protected:
     std::string nextStringToken(const std::string& input);
-    std::unique_ptr<SearchToken> makeToken(const std::string& tokenStr);
+    static std::unique_ptr<SearchToken> makeToken(const std::string& tokenStr);
     std::string getQuotedValue(const std::string& input);
 
     const std::string& input;

--- a/src/server.h
+++ b/src/server.h
@@ -228,7 +228,7 @@ protected:
     /// \b web_close Close file.
     ///
     /// \return UPNP_E_SUCCESS Callbacks registered successfully, else error code.
-    int registerVirtualDirCallbacks();
+    static int registerVirtualDirCallbacks();
 };
 
 #endif // __SERVER_H__

--- a/src/storage/sql_storage.h
+++ b/src/storage/sql_storage.h
@@ -218,7 +218,7 @@ private:
     /* helper for removeObject(s) */
     void _removeObjects(const std::vector<int32_t>& objectIDs);
 
-    std::string toCSV(const std::vector<int>& input);
+    static std::string toCSV(const std::vector<int>& input);
 
     std::unique_ptr<ChangedContainers> _recursiveRemove(
         const std::vector<int32_t>& items,
@@ -234,9 +234,9 @@ private:
     std::unique_ptr<std::vector<int>> _checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir);
 
     /* location helper: filesystem path or virtual path to db location*/
-    std::string addLocationPrefix(char prefix, const std::string& path);
+    static std::string addLocationPrefix(char prefix, const std::string& path);
     /* location helpers: db location to filesystem path */
-    fs::path stripLocationPrefix(std::string dbLocation, char* prefix = NULL);
+    static fs::path stripLocationPrefix(std::string dbLocation, char* prefix = NULL);
 
     std::shared_ptr<CdsObject> checkRefID(const std::shared_ptr<CdsObject>& obj);
     int createContainer(int parentID, std::string name, const std::string& virtualPath, bool isVirtual, const std::string& upnpClass, int refID, const std::map<std::string, std::string>& itemMetadata);

--- a/src/storage/sqlite3/sqlite3_storage.h
+++ b/src/storage/sqlite3/sqlite3_storage.h
@@ -175,7 +175,7 @@ private:
 
     std::string startupError;
 
-    std::string getError(const std::string& query, const std::string& error, sqlite3* db);
+    static std::string getError(const std::string& query, const std::string& error, sqlite3* db);
 
     static void* staticThreadProc(void* arg);
     void threadProc();

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -130,7 +130,7 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     didl_lite.print(buf, "", 0);
     std::string didl_lite_xml = buf.str();
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
     auto resp_root = response->document_element();
     resp_root.append_child("Result").append_child(pugi::node_pcdata).set_value(didl_lite_xml.c_str());
     resp_root.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(std::to_string(arr.size()).c_str());
@@ -195,7 +195,7 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     didl_lite.print(buf, "", 0);
     std::string didl_lite_xml = buf.str();
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
     auto resp_root = response->document_element();
     resp_root.append_child("Result").append_child(pugi::node_pcdata).set_value(didl_lite_xml.c_str());
     resp_root.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(std::to_string(results.size()).c_str());
@@ -234,7 +234,7 @@ void ContentDirectoryService::doGetSystemUpdateID(const std::unique_ptr<ActionRe
 {
     log_debug("start");
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Id").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());
     request->setResponse(response);
@@ -270,7 +270,7 @@ void ContentDirectoryService::processSubscriptionRequest(const std::unique_ptr<S
 {
     log_debug("start");
 
-    auto propset = xmlBuilder->createEventPropertySet();
+    auto propset = UpnpXMLBuilder::createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());
     auto obj = storage->loadObject(0);
@@ -301,7 +301,7 @@ void ContentDirectoryService::sendSubscriptionUpdate(const std::string& containe
 
     systemUpdateID++;
 
-    auto propset = xmlBuilder->createEventPropertySet();
+    auto propset = UpnpXMLBuilder::createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(containerUpdateIDs_CSV.c_str());
     property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -210,7 +210,7 @@ void ContentDirectoryService::doGetSearchCapabilities(const std::unique_ptr<Acti
 {
     log_debug("start");
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("SearchCaps").append_child(pugi::node_pcdata).set_value("dc:title,upnp:class,upnp:artist,upnp:album");
     request->setResponse(response);
@@ -222,7 +222,7 @@ void ContentDirectoryService::doGetSortCapabilities(const std::unique_ptr<Action
 {
     log_debug("start");
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("SortCaps").append_child(pugi::node_pcdata).set_value("");
     request->setResponse(response);

--- a/src/upnp_cds.h
+++ b/src/upnp_cds.h
@@ -81,13 +81,13 @@ protected:
     /// \param request Incoming ActionRequest.
     ///
     /// GetSearchCapabilities(string SearchCaps)
-    void doGetSearchCapabilities(const std::unique_ptr<ActionRequest>& request);
+    static void doGetSearchCapabilities(const std::unique_ptr<ActionRequest>& request);
 
     /// \brief UPnP standard defined action: GetSortCapabilities()
     /// \param request Incoming ActionRequest.
     ///
     /// GetSortCapabilities(string SortCaps)
-    void doGetSortCapabilities(const std::unique_ptr<ActionRequest>& request);
+    static void doGetSortCapabilities(const std::unique_ptr<ActionRequest>& request);
 
     /// \brief UPnP standard defined action: GetSystemUpdateID()
     /// \param request Incoming ActionRequest.

--- a/src/upnp_cm.cc
+++ b/src/upnp_cm.cc
@@ -76,7 +76,7 @@ void ConnectionManagerService::doGetProtocolInfo(const std::unique_ptr<ActionReq
 {
     log_debug("start");
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_CM_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_CM_SERVICE_TYPE);
 
     std::vector<std::string> mimeTypes = storage->getMimeTypes();
     std::string CSV = mime_types_to_CSV(mimeTypes);
@@ -116,7 +116,7 @@ void ConnectionManagerService::processSubscriptionRequest(const std::unique_ptr<
     std::vector<std::string> mimeTypes = storage->getMimeTypes();
     std::string CSV = mime_types_to_CSV(mimeTypes);
 
-    auto propset = xmlBuilder->createEventPropertySet();
+    auto propset = UpnpXMLBuilder::createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("CurrentConnectionIDs").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("SinkProtocolInfo").append_child(pugi::node_pcdata).set_value("");
@@ -141,7 +141,7 @@ void ConnectionManagerService::processSubscriptionRequest(const std::unique_ptr<
 
 void ConnectionManagerService::sendSubscriptionUpdate(const std::string& sourceProtocol_CSV)
 {
-    auto propset = xmlBuilder->createEventPropertySet();
+    auto propset = UpnpXMLBuilder::createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("SourceProtocolInfo").append_child(pugi::node_pcdata).set_value(sourceProtocol_CSV.c_str());
 

--- a/src/upnp_cm.cc
+++ b/src/upnp_cm.cc
@@ -53,7 +53,7 @@ void ConnectionManagerService::doGetCurrentConnectionIDs(const std::unique_ptr<A
 {
     log_debug("start");
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_CM_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_CM_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("ConnectionID").append_child(pugi::node_pcdata).set_value("0");
 

--- a/src/upnp_cm.h
+++ b/src/upnp_cm.h
@@ -55,7 +55,7 @@ protected:
     /// GetCurrentConnectionIDs(string ConnectionIDs)
     ///
     /// This is currently unsupported (returns empty string)
-    void doGetCurrentConnectionIDs(const std::unique_ptr<ActionRequest>& request);
+    static void doGetCurrentConnectionIDs(const std::unique_ptr<ActionRequest>& request);
 
     /// \brief UPnP standard defined action: GetCurrentConnectionInfo()
     /// \param request Incoming ActionRequest.
@@ -64,7 +64,7 @@ protected:
     /// string PeerConnectionManager, i4 PeerConnectionID, string Direction, string Status)
     ///
     /// This action is currently unsupported.
-    void doGetCurrentConnectionInfo(const std::unique_ptr<ActionRequest>& request);
+    static void doGetCurrentConnectionInfo(const std::unique_ptr<ActionRequest>& request);
 
     /// \brief UPnP standard defined action: GetProtocolInfo()
     /// \param request Incoming ActionRequest.

--- a/src/upnp_mrreg.cc
+++ b/src/upnp_mrreg.cc
@@ -53,7 +53,7 @@ void MRRegistrarService::doIsAuthorized(const std::unique_ptr<ActionRequest>& re
 {
     log_debug("start");
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_MRREG_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_MRREG_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 
@@ -76,7 +76,7 @@ void MRRegistrarService::doIsValidated(const std::unique_ptr<ActionRequest>& req
 {
     log_debug("start");
 
-    auto response = xmlBuilder->createResponse(request->getActionName(), DESC_MRREG_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), DESC_MRREG_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 

--- a/src/upnp_mrreg.cc
+++ b/src/upnp_mrreg.cc
@@ -108,7 +108,7 @@ void MRRegistrarService::processActionRequest(const std::unique_ptr<ActionReques
 
 void MRRegistrarService::processSubscriptionRequest(const std::unique_ptr<SubscriptionRequest>& request)
 {
-    auto propset = xmlBuilder->createEventPropertySet();
+    auto propset = UpnpXMLBuilder::createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("ValidationRevokedUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("ValidationSucceededUpdateID").append_child(pugi::node_pcdata).set_value("0");

--- a/src/upnp_mrreg.h
+++ b/src/upnp_mrreg.h
@@ -65,7 +65,7 @@ protected:
     /// IsAuthorized(string DeviceID, i4 Result)
     ///
     /// This is currently unsupported (always returns 1)
-    void doIsAuthorized(const std::unique_ptr<ActionRequest>& request);
+    static void doIsAuthorized(const std::unique_ptr<ActionRequest>& request);
 
     /// \brief Media Receiver Registrar service action: RegisterDevice()
     /// \param request Incoming ActionRequest.
@@ -73,13 +73,13 @@ protected:
     /// RegisterDevice(bin.base64 RegistrationReqMsg, bin.base64 RegistrationRespMsg)
     ///
     /// This action is currently unsupported.
-    void doRegisterDevice(const std::unique_ptr<ActionRequest>& request);
+    static void doRegisterDevice(const std::unique_ptr<ActionRequest>& request);
 
     /// \brief Media Receiver Registrar service action: IsValidated()
     /// \param request Incoming ActionRequest.
     ///
     /// IsValidated(string DeviceID, i4 Result)
-    void doIsValidated(const std::unique_ptr<ActionRequest>& request);
+    static void doIsValidated(const std::unique_ptr<ActionRequest>& request);
 
     std::shared_ptr<ConfigManager> config;
 
@@ -98,7 +98,7 @@ public:
     ///
     /// This function looks at the incoming ActionRequest and passes it on
     /// to the appropriate action for processing.
-    void processActionRequest(const std::unique_ptr<ActionRequest>& request);
+    static void processActionRequest(const std::unique_ptr<ActionRequest>& request);
 
     /// \brief Processes an incoming SubscriptionRequest.
     /// \param request Incoming SubscriptionRequest.

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -57,7 +57,7 @@ public:
     /// <u:actionNameResponse xmlns:u="serviceType"/>
     /// Further response information (various parameters, DIDL-Lite or
     /// whatever can then be adapted to it.
-    std::unique_ptr<pugi::xml_document> createResponse(const std::string& actionName, const std::string& serviceType);
+    static std::unique_ptr<pugi::xml_document> createResponse(const std::string& actionName, const std::string& serviceType);
 
     /// \brief Renders the DIDL-Lite representation of an object in the content directory.
     /// \param obj Object to be rendered as XML.
@@ -70,11 +70,11 @@ public:
     void renderObject(const std::shared_ptr<CdsObject>& obj, bool renderActions, size_t stringLimit, pugi::xml_node* parent);
 
     /// \todo change the text string to element, parsing should be done outside
-    void updateObject(const std::shared_ptr<CdsObject>& obj, const std::string& text);
+    static void updateObject(const std::shared_ptr<CdsObject>& obj, const std::string& text);
 
     /// \brief Renders XML for the event property set.
     /// \return pugi::xml_document representing the newly created XML.
-    std::unique_ptr<pugi::xml_document> createEventPropertySet();
+    static std::unique_ptr<pugi::xml_document> createEventPropertySet();
 
     /// \brief Renders the device description XML.
     /// \return pugi::xml_document representing the newly created device description.
@@ -86,18 +86,18 @@ public:
     /// \brief Renders a resource tag (part of DIDL-Lite XML)
     /// \param URL download location of the item (will be child element of the <res> tag)
     /// \param attributes Dictionary containing the <res> tag attributes (like resolution, etc.)
-    void renderResource(const std::string& URL, const std::map<std::string, std::string>& attributes, pugi::xml_node* parent);
+    static void renderResource(const std::string& URL, const std::map<std::string, std::string>& attributes, pugi::xml_node* parent);
 
     /// \brief Renders a subtitle resource tag (Samsung proprietary extension)
     /// \param URL download location of the video item
-    void renderCaptionInfo(const std::string& URL, pugi::xml_node* parent);
+    static void renderCaptionInfo(const std::string& URL, pugi::xml_node* parent);
 
-    void renderCreator(const std::string& creator, pugi::xml_node* parent);
-    void renderAlbumArtURI(const std::string& uri, pugi::xml_node* parent);
-    void renderComposer(const std::string& composer, pugi::xml_node* parent);
-    void renderConductor(const std::string& conductor, pugi::xml_node* parent);
-    void renderOrchestra(const std::string& orchestra, pugi::xml_node* parent);
-    void renderAlbumDate(const std::string& date, pugi::xml_node* parent);
+    static void renderCreator(const std::string& creator, pugi::xml_node* parent);
+    static void renderAlbumArtURI(const std::string& uri, pugi::xml_node* parent);
+    static void renderComposer(const std::string& composer, pugi::xml_node* parent);
+    static void renderConductor(const std::string& conductor, pugi::xml_node* parent);
+    static void renderOrchestra(const std::string& orchestra, pugi::xml_node* parent);
+    static void renderAlbumDate(const std::string& date, pugi::xml_node* parent);
 
     void addResources(const std::shared_ptr<CdsItem>& item, pugi::xml_node* parent);
 
@@ -120,7 +120,7 @@ protected:
     };
 
     static std::unique_ptr<PathBase> getPathBase(const std::shared_ptr<CdsItem>& item, bool forceLocal = false);
-    std::string renderExtension(const std::string& contentType, const std::string& location);
+    static std::string renderExtension(const std::string& contentType, const std::string& location);
     std::string getArtworkUrl(const std::shared_ptr<CdsItem>& item);
 };
 #endif // __UPNP_XML_H__

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -143,7 +143,7 @@ public:
     virtual void process();
 
 protected:
-    void autoscan2XML(const std::shared_ptr<AutoscanDirectory>& adir, pugi::xml_node* element);
+    static void autoscan2XML(const std::shared_ptr<AutoscanDirectory>& adir, pugi::xml_node* element);
 };
 
 /// \brief nothing :)

--- a/src/web/web_request_handler.h
+++ b/src/web/web_request_handler.h
@@ -111,7 +111,7 @@ protected:
     /// \brief Helper function to create a generic XML document header.
     /// \param xsl_link If not nullptr, also adds header information that is required for the XSL processor.
     /// \return The header as a string... because our parser does not yet understand <? ?> stuff :)
-    std::string renderXMLHeader();
+    static std::string renderXMLHeader();
 
     /// \brief Prepares the output buffer and calls the process function.
     /// \return IOHandler
@@ -121,7 +121,7 @@ protected:
     /// \brief add the ui update ids from the given session as xml tags to the given root element
     /// \param session the session from which the ui update ids should be taken
     /// \param updateIDsEl the xml element to add the elements to
-    void addUpdateIDs(const std::shared_ptr<Session>& session, pugi::xml_node* updateIDsEl);
+    static void addUpdateIDs(const std::shared_ptr<Session>& session, pugi::xml_node* updateIDsEl);
 
     /// \brief check if ui update ids should be added to the response and add
     /// them in that case.
@@ -131,13 +131,13 @@ protected:
     /// \brief add the content manager task to the given xml element as xml elements
     /// \param task the task to add to the given xml element
     /// \param parent the xml element to add the elements to
-    void appendTask(const std::shared_ptr<GenericTask>& task, pugi::xml_node* parent);
+    static void appendTask(const std::shared_ptr<GenericTask>& task, pugi::xml_node* parent);
 
     /// \brief check if accounts are enabled in the config
     /// \return true if accounts are enabled, false if not
     bool accountsEnabled() { return config->getBoolOption(CFG_SERVER_UI_ACCOUNTS_ENABLED); }
 
-    std::string mapAutoscanType(int type);
+    static std::string mapAutoscanType(int type);
 
 public:
     /// \brief Constructor, currently empty.


### PR DESCRIPTION
Found with readability-convert-member-functions-to-static
Found with readability-static-accessed-through-instance
