### PR TITLE
[clang-tidy] fix remaining cast issues

### DIFF
--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -299,7 +299,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
 
         auto art = dynamic_cast<TagLib::ID3v2::AttachedPictureFrame*>(list.front());
 
-        auto h = std::make_unique<MemIOHandler>((void*)art->picture().data(), art->picture().size());
+        auto h = std::make_unique<MemIOHandler>(art->picture().data(), art->picture().size());
         return h;
     }
     if (content_type == CONTENT_TYPE_FLAC) {

--- a/src/server.cc
+++ b/src/server.cc
@@ -315,13 +315,13 @@ int Server::handleUpnpEvent(Upnp_EventType eventtype, const void* event)
         // a CP is invoking an action
         log_debug("UPNP_CONTROL_ACTION_REQUEST");
         try {
-            auto request = std::make_unique<ActionRequest>((UpnpActionRequest*)event);
+            auto request = std::make_unique<ActionRequest>(static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
             routeActionRequest(request);
             request->update();
             // set in update() ((struct Upnp_Action_Request *)event)->ErrCode = ret;
         } catch (const UpnpException& upnp_e) {
             ret = upnp_e.getErrorCode();
-            UpnpActionRequest_set_ErrCode((UpnpActionRequest*)event, ret);
+            UpnpActionRequest_set_ErrCode(static_cast<UpnpActionRequest*>(const_cast<void*>(event)), ret);
         } catch (const std::runtime_error& e) {
             log_info("Exception: {}", e.what());
         }
@@ -331,7 +331,7 @@ int Server::handleUpnpEvent(Upnp_EventType eventtype, const void* event)
         // a cp wants a subscription
         log_debug("UPNP_EVENT_SUBSCRIPTION_REQUEST");
         try {
-            auto request = std::make_unique<SubscriptionRequest>((UpnpSubscriptionRequest*)event);
+            auto request = std::make_unique<SubscriptionRequest>(static_cast<UpnpSubscriptionRequest*>(const_cast<void*>(event)));
             routeSubscriptionRequest(request);
         } catch (const UpnpException& upnp_e) {
             log_warning("Subscription exception: {}", upnp_e.what());
@@ -499,7 +499,7 @@ int Server::registerVirtualDirCallbacks()
         try {
             auto reqHandler = static_cast<const Server*>(cookie)->createRequestHandler(filename);
             auto ioHandler = reqHandler->open(link.c_str(), mode, "");
-            auto ioPtr = (UpnpWebFileHandle)ioHandler.release();
+            auto ioPtr = static_cast<UpnpWebFileHandle>(ioHandler.release());
             //log_debug("%p open({})", ioPtr, filename);
             return ioPtr;
         } catch (const ServerShutdownException& se) {

--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -70,7 +70,7 @@ using uchar = unsigned char;
 #define ITEM_BUF_SIZE 16
 static int Get16m(const void* Short)
 {
-    return (((uchar*)Short)[0] << 8) | ((uchar*)Short)[1];
+    return (static_cast<uchar*>(const_cast<void*>(Short))[0] << 8) | static_cast<uchar*>(const_cast<void*>(Short))[1];
 }
 
 static int ioh_fgetc(const std::unique_ptr<IOHandler>& ioh)

--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -39,15 +39,15 @@ StringConverter::StringConverter(const std::string& from, const std::string& to)
     dirty = false;
 
     cd = iconv_open(to.c_str(), from.c_str());
-    if (cd == (iconv_t)(-1)) {
-        cd = (iconv_t) nullptr;
+    if (cd == reinterpret_cast<iconv_t>(-1)) {
+        cd = static_cast<iconv_t>(nullptr);
         throw std::runtime_error(std::string("iconv: ") + strerror(errno));
     }
 }
 
 StringConverter::~StringConverter()
 {
-    if (cd != (iconv_t) nullptr)
+    if (cd != static_cast<iconv_t>(nullptr))
         iconv_close(cd);
 }
 

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -238,7 +238,7 @@ std::string hex_encode(const void* data, int len)
 
     std::ostringstream buf;
 
-    chars = (unsigned char*)data;
+    chars = static_cast<unsigned char*>(const_cast<void*>(data));
     for (i = 0; i < len; i++) {
         unsigned char c = chars[i];
         hi = c >> 4;
@@ -280,7 +280,7 @@ std::string hex_md5(const void* data, int length)
 
     md5_state_t ctx;
     md5_init(&ctx);
-    md5_append(&ctx, (unsigned char*)data, length);
+    md5_append(&ctx, static_cast<unsigned char*>(const_cast<void*>(data)), length);
     md5_finish(&ctx, reinterpret_cast<unsigned char*>(md5buf));
 
     return hex_encode(md5buf, 16);
@@ -842,7 +842,7 @@ std::string fallbackString(std::string first, std::string fallback)
 unsigned int stringHash(const std::string& str)
 {
     unsigned int hash = 5381;
-    auto data = (unsigned char*)str.c_str();
+    auto data = str.c_str();
     int c;
     while ((c = *data++))
         hash = ((hash << 5) + hash) ^ c; /* (hash * 33) ^ c */


### PR DESCRIPTION
Found with google-readability-casting

Required manual editing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>