### PR TITLE
[clang-tidy] add explicit to single argument constructors

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -59,7 +59,7 @@ private:
     FILE* file;
 
 public:
-    file_io_callback(const char* path)
+    explicit file_io_callback(const char* path)
     {
         file = fopen(path, "rb");
         if (file == nullptr) {


### PR DESCRIPTION
Found with hicpp-explicit-conversions

Signed-off-by: Rosen Penev <rosenp@gmail.com>