### PR TITLE
remove extra semicolon in statements

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -113,26 +113,26 @@ ConfigManager::~ConfigManager()
     log_debug("ConfigManager destroyed");
 }
 
-#define NEW_OPTION(optval) opt = std::make_shared<Option>(optval);
-#define SET_OPTION(opttype) options->at(opttype) = opt;
+#define NEW_OPTION(optval) opt = std::make_shared<Option>(optval)
+#define SET_OPTION(opttype) options->at(opttype) = opt
 
-#define NEW_INT_OPTION(optval) int_opt = std::make_shared<IntOption>(optval);
-#define SET_INT_OPTION(opttype) options->at(opttype) = int_opt;
+#define NEW_INT_OPTION(optval) int_opt = std::make_shared<IntOption>(optval)
+#define SET_INT_OPTION(opttype) options->at(opttype) = int_opt
 
-#define NEW_BOOL_OPTION(optval) bool_opt = std::make_shared<BoolOption>(optval);
-#define SET_BOOL_OPTION(opttype) options->at(opttype) = bool_opt;
+#define NEW_BOOL_OPTION(optval) bool_opt = std::make_shared<BoolOption>(optval)
+#define SET_BOOL_OPTION(opttype) options->at(opttype) = bool_opt
 
-#define NEW_DICT_OPTION(optval) dict_opt = std::make_shared<DictionaryOption>(optval);
-#define SET_DICT_OPTION(opttype) options->at(opttype) = dict_opt;
+#define NEW_DICT_OPTION(optval) dict_opt = std::make_shared<DictionaryOption>(optval)
+#define SET_DICT_OPTION(opttype) options->at(opttype) = dict_opt
 
-#define NEW_STRARR_OPTION(optval) str_array_opt = std::make_shared<StringArrayOption>(optval);
-#define SET_STRARR_OPTION(opttype) options->at(opttype) = str_array_opt;
+#define NEW_STRARR_OPTION(optval) str_array_opt = std::make_shared<StringArrayOption>(optval)
+#define SET_STRARR_OPTION(opttype) options->at(opttype) = str_array_opt
 
-#define NEW_AUTOSCANLIST_OPTION(optval) alist_opt = std::make_shared<AutoscanListOption>(optval);
-#define SET_AUTOSCANLIST_OPTION(opttype) options->at(opttype) = alist_opt;
+#define NEW_AUTOSCANLIST_OPTION(optval) alist_opt = std::make_shared<AutoscanListOption>(optval)
+#define SET_AUTOSCANLIST_OPTION(opttype) options->at(opttype) = alist_opt
 
-#define NEW_TRANSCODING_PROFILELIST_OPTION(optval) trlist_opt = std::make_shared<TranscodingProfileListOption>(optval);
-#define SET_TRANSCODING_PROFILELIST_OPTION(opttype) options->at(opttype) = trlist_opt;
+#define NEW_TRANSCODING_PROFILELIST_OPTION(optval) trlist_opt = std::make_shared<TranscodingProfileListOption>(optval)
+#define SET_TRANSCODING_PROFILELIST_OPTION(opttype) options->at(opttype) = trlist_opt
 
 void ConfigManager::load(const fs::path& filename, const fs::path& userHome)
 {
@@ -1376,7 +1376,6 @@ void ConfigManager::emptyBookmark()
     fs::path path = getOption(CFG_SERVER_BOOKMARK_FILE);
     log_debug("Clearing bookmark file at: {}", path.c_str());
     writeTextFile(path, data);
-    ;
 }
 
 std::map<std::string, std::string> ConfigManager::createDictionaryFromNode(const pugi::xml_node& element,

--- a/src/iohandler/file_io_handler.cc
+++ b/src/iohandler/file_io_handler.cc
@@ -49,7 +49,6 @@ void FileIOHandler::open(enum UpnpOpenFileMode mode)
         f = fopen(filename.c_str(), "rb");
     } else if (mode == UPNP_WRITE) {
         throw std::runtime_error("FileIOHandler::open: Write mode not supported");
-        ;
     } else {
         throw std::runtime_error("FileIOHandler::open: invalid UpnpOpenFileMode mode");
     }

--- a/src/storage/sqlite3/sqlite3_storage.cc
+++ b/src/storage/sqlite3/sqlite3_storage.cc
@@ -503,7 +503,6 @@ void SLSelectTask::run(sqlite3** db, Sqlite3Storage* sl)
     pres = std::make_shared<Sqlite3Result>();
 
     char* err = nullptr;
-    ;
     int ret = sqlite3_get_table(
         *db,
         query,


### PR DESCRIPTION
Found with clang's -Wextra-semi-stmt

Signed-off-by: Rosen Penev <rosenp@gmail.com>