### PR TITLE
shortten virtual path to videos

### DIFF
--- a/src/layout/fallback_layout.cc
+++ b/src/layout/fallback_layout.cc
@@ -138,8 +138,8 @@ void FallbackLayout::addImage(const std::shared_ptr<CdsObject>& obj, const fs::p
 
     std::string dir;
     if (!rootpath.empty()) {
-        // make location relative to rootpath: "/home/.../Photos/Action/a.mkv" with rootpath "/home/.../Photos" -> "Photos/Action"
-        dir = fs::relative(obj->getLocation().parent_path(), rootpath.parent_path());
+        // make location relative to rootpath: "/home/.../Photos/Action/a.mkv" with rootpath "/home/.../Photos" -> "Action"
+        dir = fs::relative(obj->getLocation().parent_path(), rootpath);
         dir = f2i->convert(dir);
     } else
         dir = esc(f2i->convert(get_last_path(obj->getLocation())));

--- a/src/layout/fallback_layout.cc
+++ b/src/layout/fallback_layout.cc
@@ -83,8 +83,8 @@ void FallbackLayout::addVideo(const std::shared_ptr<CdsObject>& obj, const fs::p
 
     std::string dir;
     if (!rootpath.empty()) {
-        // make location relative to rootpath: "/home/.../Video/Action/a.mkv" with rootpath "/home/.../Video" -> "Video/Action"
-        dir = fs::relative(obj->getLocation().parent_path(), rootpath.parent_path());
+        // make location relative to rootpath: "/home/.../Videos/Action/a.mkv" with rootpath "/home/.../Videos" -> "Action"
+        dir = fs::relative(obj->getLocation().parent_path(), rootpath);
         dir = f2i->convert(dir);
     } else
         dir = esc(f2i->convert(get_last_path(obj->getLocation())));


### PR DESCRIPTION
saw this when fixing issue #692. I see no benefit of passing last subdir of added location to virtual path too.

**Example:**
config.xml:
```
...
    <autoscan use-inotify="auto">
        <directory location="/home/.../Videos" mode="inotify" level="full" recursive="yes" hidden-files="no"/>
    </autoscan>
...
```
Before virtual path: /Video/Directories/**Videos**/Action/...`
With change: /Video/Directories/Action/...