### PR TITLE
spdlog build path improvement, fanart semantic and exception fix, and spdlog flushing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,8 +322,16 @@ endif()
 find_package(fmt REQUIRED)
 target_link_libraries(gerbera fmt::fmt)
 
-find_package(spdlog REQUIRED)
-target_link_libraries(gerbera spdlog::spdlog)
+# See if it's just installed as a library first, as not all installs have .cmake files
+find_library(SPDLOG_LIBRARY spdlog)
+if(SPDLOG_LIBRARY)
+    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${SPDLOG_LIBRARY})
+    target_link_libraries(gerbera ${SPDLOG_LIBRARY})
+else()
+    # Didn't find it, so try the .cmake file, fail if not found
+    find_package(spdlog REQUIRED)
+    target_link_libraries(gerbera spdlog::spdlog)
+endif()
 add_compile_definitions("SPDLOG_FMT_EXTERNAL")
 
 find_package (Pugixml REQUIRED)

--- a/src/main.cc
+++ b/src/main.cc
@@ -191,6 +191,7 @@ int main(int argc, char** argv, char** envp)
         if (opts.count("logfile") > 0) {
             auto file_logger = spdlog::basic_logger_mt("basic_logger", opts["logfile"].as<std::string>());
             spdlog::set_default_logger(file_logger);
+            spdlog::flush_on(spdlog::level::trace); 
         }
 
         // Action starts here

--- a/src/metadata/fanart_handler.cc
+++ b/src/metadata/fanart_handler.cc
@@ -39,9 +39,11 @@
 #include "iohandler/file_io_handler.h"
 #include "util/tools.h"
 
+// These must not have a leading slash, or the "/" operator will produce
+// just this, not folder and this
 static const char* names[] = {
-    "/folder.jpg",
-    "/poster.jpg"
+    "folder.jpg",
+    "poster.jpg"
 };
 
 FanArtHandler::FanArtHandler(std::shared_ptr<ConfigManager> config)
@@ -57,7 +59,8 @@ fs::path FanArtHandler::getFanArtPath(const std::shared_ptr<CdsItem>& item)
     fs::path found;
     for (const auto& name : names) {
         auto found = folder / name;
-        bool exists = fs::is_regular_file(found);
+        std::error_code ec;
+        bool exists = fs::is_regular_file(found, ec);   // no error throwing, please
         log_debug("{}: {}", name, exists ? "found" : "missing");
         if (!exists)
             continue;


### PR DESCRIPTION
Greetings.  Lots has changed since last I peeked, fancy C++ idioms and long link times...
Three fixes in order of priority:

1.  This most recent master was completely broken for me, removing almost all my media.  I saw errors thrown, saying "/folder.jpg" was a filesystem exception.  The problem is twofold.  First, the check for fanart shouldn't throw an exception.  Second, the fanart path was bogus.  The `/` operator isn't just "+ for paths", it has semantics, and the leading "/" in the two `names` blows away the base path if it is rooted.  I've lost track of how "fanart" differs from associating images with albums; if this code is still important it could stand a more diverse set of names and some case-insensitive matching, but at least now it doesn't kill a scan.

2. The spdlog I'm using via Joyent is just a normal library, with a pkg-config file but no .cmake package definition.  This change allows that to work, only trying the hard-require .cmake config if spdlog isn't otherwise found.

3. While debugging, I noticed the logfile appeared empty, for long stretches of time.  Aggressive buffering made it unhelpful for diagnosing problems.  I've added a `flush_on` to ensure lines are written as they happen.

Finally, with a build of this current tree, I was observing
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Abort
```
which did _not_ get logged to the logfile

Running overnight, it also used up all system memory, populating a new database which should be about 1G.  So, there's some problems in master right now.