### PR TITLE
fix std::string with nullptr in MySQL code

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -254,7 +254,7 @@ void ConfigManager::load(const fs::path& filename, const fs::path& userHome)
         SET_INT_OPTION(CFG_SERVER_STORAGE_MYSQL_PORT);
 
         if (getElement("/server/storage/mysql/socket") == nullptr) {
-            NEW_OPTION(nullptr);
+            NEW_OPTION("");
         } else {
             NEW_OPTION(getOption("/server/storage/mysql/socket"));
         }
@@ -262,7 +262,7 @@ void ConfigManager::load(const fs::path& filename, const fs::path& userHome)
         SET_OPTION(CFG_SERVER_STORAGE_MYSQL_SOCKET);
 
         if (getElement("/server/storage/mysql/password") == nullptr) {
-            NEW_OPTION(nullptr);
+            NEW_OPTION("");
         } else {
             NEW_OPTION(getOption("/server/storage/mysql/password"));
         }


### PR DESCRIPTION
While booting this project for the first time, I ran into the following error:

```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
```

It appears this has been addressed before (8ac412a) but that commit did not discover these two areas in the configuration code where the same error arises.