### PR TITLE
Fix config parsing for <transcoding> parameters

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -1415,7 +1415,7 @@ std::shared_ptr<TranscodingProfileList> ConfigManager::createTranscodingProfileL
 
     auto mtype_profile = element.child("mimetype-profile-mappings");
     if (mtype_profile != nullptr) {
-        for (const pugi::xml_node& child : element.children()) {
+        for (const pugi::xml_node& child : mtype_profile.children()) {
             if (std::string(child.name()) == "transcode") {
                 std::string mt = child.attribute("mimetype").as_string();
                 std::string pname = child.attribute("using").as_string();
@@ -1433,7 +1433,7 @@ std::shared_ptr<TranscodingProfileList> ConfigManager::createTranscodingProfileL
     if (profiles == nullptr)
         return list;
 
-    for (const pugi::xml_node& child : element.children()) {
+    for (const pugi::xml_node& child : profiles.children()) {
         if (std::string(child.name()) != "profile")
             continue;
 


### PR DESCRIPTION
Child elements of the <transcoding> node in the .xml were not being parsed correctly (<transcode> and <profile> elements were parsed as direct descendents of <transcoding>, not as children of <mimetype-profile-mappings> and <profiles> respectively.

Prior to this, I noticed gerbera did not find any of my transcoding profiles; upon further investigation I discovered this was causing profiles to be ignored.