### PR TITLE
remove virtual from overriden functions

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -378,18 +378,18 @@ public:
     inline int getTrackNumber() { return trackNumber; }
     /// \brief Copies all object properties to another object.
     /// \param obj target object (clone)`
-    virtual void copyTo(const std::shared_ptr<CdsObject>& obj) override;
+    void copyTo(const std::shared_ptr<CdsObject>& obj) override;
 
     /// \brief Checks if current object is equal to obj.
     ///
     /// See description for CdsObject::equals() for details.
-    virtual int equals(const std::shared_ptr<CdsObject>& obj, bool exactly = false) override;
+    int equals(const std::shared_ptr<CdsObject>& obj, bool exactly = false) override;
 
     /// \brief Checks if the minimum required parameters for the object have been set and are valid.
-    virtual void validate() override;
+    void validate() override;
 
     /// \brief Returns the path to the object as it appears in the database tree.
-    virtual std::string getVirtualPath() override;
+    std::string getVirtualPath() override;
 
     /// \brief Set the unique service ID.
     inline void setServiceID(std::string serviceID) { this->serviceID = serviceID; }
@@ -451,15 +451,15 @@ public:
 
     /// \brief Copies all object properties to another object.
     /// \param obj target object (clone)
-    virtual void copyTo(const std::shared_ptr<CdsObject>& obj) override;
+    void copyTo(const std::shared_ptr<CdsObject>& obj) override;
 
     /// \brief Checks if current object is equal to obj.
     ///
     /// See description for CdsObject::equals() for details.
-    virtual int equals(const std::shared_ptr<CdsObject>& obj, bool exactly = false) override;
+    int equals(const std::shared_ptr<CdsObject>& obj, bool exactly = false) override;
 
     /// \brief Checks if the minimum required parameters for the object have been set and are valid.
-    virtual void validate() override;
+    void validate() override;
 };
 
 /// \brief An item that is accessible via a URL.
@@ -476,12 +476,12 @@ public:
     inline std::string getURL() { return location; }
     /// \brief Copies all object properties to another object.
     /// \param obj target object (clone)
-    //virtual void copyTo(std::shared_ptr<CdsObject> obj) override;
+    //void copyTo(std::shared_ptr<CdsObject> obj) override;
 
     /// \brief Checks if current object is equal to obj.
     ///
     /// See description for CdsObject::equals() for details.
-    //virtual int equals(std::shared_ptr<CdsObject> obj, bool exactly=false) override;
+    //int equals(std::shared_ptr<CdsObject> obj, bool exactly=false) override;
 
     /// \brief Checks if the minimum required parameters for the object have been set and are valid.
     void validate() override;
@@ -543,15 +543,15 @@ public:
 
     /// \brief Copies all object properties to another object.
     /// \param obj target object (clone)
-    virtual void copyTo(std::shared_ptr<CdsObject> obj) override;
+    void copyTo(std::shared_ptr<CdsObject> obj) override;
 
     /// \brief Checks if current object is equal to obj.
     ///
     /// See description for CdsObject::equals() for details.
-    virtual int equals(std::shared_ptr<CdsObject> obj, bool exactly=false) override;
+    int equals(std::shared_ptr<CdsObject> obj, bool exactly=false) override;
 
     /// \brief Checks if the minimum required parameters for the object have been set and are valid.
-    virtual void validate();
+    void validate();
 };
 
 */

--- a/src/config/config_options.h
+++ b/src/config/config_options.h
@@ -85,7 +85,7 @@ class Option : public ConfigOption {
 public:
     Option(std::string option) { this->option = option; }
 
-    virtual std::string getOption() override { return option; }
+    std::string getOption() override { return option; }
 
 protected:
     std::string option;
@@ -95,7 +95,7 @@ class IntOption : public ConfigOption {
 public:
     IntOption(int option) { this->option = option; }
 
-    virtual int getIntOption() override { return option; }
+    int getIntOption() override { return option; }
 
 protected:
     int option;
@@ -105,7 +105,7 @@ class BoolOption : public ConfigOption {
 public:
     BoolOption(bool option) { this->option = option; }
 
-    virtual bool getBoolOption() override { return option; }
+    bool getBoolOption() override { return option; }
 
 protected:
     BoolOption() = default;
@@ -116,7 +116,7 @@ class DictionaryOption : public ConfigOption {
 public:
     DictionaryOption(std::map<std::string, std::string> option) { this->option = option; }
 
-    virtual std::map<std::string, std::string> getDictionaryOption() override { return option; }
+    std::map<std::string, std::string> getDictionaryOption() override { return option; }
 
 protected:
     std::map<std::string, std::string> option;
@@ -129,7 +129,7 @@ public:
         this->option = option;
     }
 
-    virtual std::vector<std::string> getStringArrayOption() override
+    std::vector<std::string> getStringArrayOption() override
     {
         return option;
     }
@@ -145,7 +145,7 @@ public:
         this->option = option;
     }
 
-    virtual std::shared_ptr<AutoscanList> getAutoscanListOption() override { return option; }
+    std::shared_ptr<AutoscanList> getAutoscanListOption() override { return option; }
 
 protected:
     std::shared_ptr<AutoscanList> option;
@@ -158,7 +158,7 @@ public:
         this->option = option;
     }
 
-    virtual std::shared_ptr<TranscodingProfileList> getTranscodingProfileListOption() override
+    std::shared_ptr<TranscodingProfileList> getTranscodingProfileListOption() override
     {
         return option;
     }

--- a/src/content_manager.h
+++ b/src/content_manager.h
@@ -92,7 +92,7 @@ public:
         bool hidden = false, bool cancellable = true);
     fs::path getPath();
     fs::path getRootPath();
-    virtual void run() override;
+    void run() override;
 };
 
 class CMRemoveObjectTask : public GenericTask {
@@ -104,7 +104,7 @@ protected:
 public:
     CMRemoveObjectTask(std::shared_ptr<ContentManager> content,
         int objectID, bool all);
-    virtual void run() override;
+    void run() override;
 };
 
 class CMRescanDirectoryTask : public GenericTask, public std::enable_shared_from_this<CMRescanDirectoryTask> {
@@ -118,7 +118,7 @@ public:
     CMRescanDirectoryTask(std::shared_ptr<ContentManager> content,
         int objectID, int scanID, ScanMode scanMode,
         bool cancellable);
-    virtual void run() override;
+    void run() override;
 };
 
 #ifdef ONLINE_SERVICES
@@ -137,7 +137,7 @@ public:
         std::shared_ptr<Timer> timer,
         std::shared_ptr<OnlineService> service, std::shared_ptr<Layout> layout,
         bool cancellable, bool unscheduled_refresh);
-    virtual void run() override;
+    void run() override;
 };
 #endif
 
@@ -151,7 +151,7 @@ public:
     ~ContentManager() override;
     void shutdown();
 
-    virtual void timerNotify(std::shared_ptr<Timer::Parameter> parameter) override;
+    void timerNotify(std::shared_ptr<Timer::Parameter> parameter) override;
 
     bool isBusy() { return working; }
 

--- a/src/layout/fallback_layout.h
+++ b/src/layout/fallback_layout.h
@@ -51,7 +51,7 @@ public:
     FallbackLayout(std::shared_ptr<ConfigManager> config,
         std::shared_ptr<Storage> storage,
         std::shared_ptr<ContentManager> content);
-    virtual void processCdsObject(std::shared_ptr<CdsObject> obj, fs::path rootpath) override;
+    void processCdsObject(std::shared_ptr<CdsObject> obj, fs::path rootpath) override;
 #ifdef ENABLE_PROFILING
     virtual ~FallbackLayout();
 #endif

--- a/src/scripting/import_script.h
+++ b/src/scripting/import_script.h
@@ -46,7 +46,7 @@ public:
         const std::shared_ptr<Runtime>& runtime);
     ~ImportScript() override;
     void processCdsObject(const std::shared_ptr<CdsObject>& obj, const std::string& scriptpath);
-    virtual script_class_t whoami() override { return S_IMPORT; }
+    script_class_t whoami() override { return S_IMPORT; }
 };
 
 #endif // __SCRIPTING_IMPORT_SCRIPT_H__

--- a/src/storage/mysql/mysql_storage.h
+++ b/src/storage/mysql/mysql_storage.h
@@ -52,7 +52,7 @@ private:
     std::shared_ptr<Storage> getSelf();
 
     virtual std::string quote(std::string str);
-    virtual inline std::string quote(const char* str) override { return quote(std::string(str)); }
+    inline std::string quote(const char* str) override { return quote(std::string(str)); }
     virtual inline std::string quote(int val) { return std::to_string(val); }
     virtual inline std::string quote(unsigned int val) { return std::to_string(val); }
     virtual inline std::string quote(long val) { return std::to_string(val); }

--- a/src/storage/sql_storage.h
+++ b/src/storage/sql_storage.h
@@ -109,63 +109,63 @@ public:
         return exec(s.c_str(), s.length(), getLastInsertId);
     }
 
-    virtual void addObject(std::shared_ptr<CdsObject> object, int* changedContainer) override;
-    virtual void updateObject(std::shared_ptr<CdsObject> object, int* changedContainer) override;
+    void addObject(std::shared_ptr<CdsObject> object, int* changedContainer) override;
+    void updateObject(std::shared_ptr<CdsObject> object, int* changedContainer) override;
 
-    virtual std::shared_ptr<CdsObject> loadObject(int objectID) override;
-    virtual int getChildCount(int contId, bool containers, bool items, bool hideFsRoot) override;
+    std::shared_ptr<CdsObject> loadObject(int objectID) override;
+    int getChildCount(int contId, bool containers, bool items, bool hideFsRoot) override;
 
-    virtual std::unique_ptr<std::unordered_set<int>> getObjects(int parentID, bool withoutContainer) override;
+    std::unique_ptr<std::unordered_set<int>> getObjects(int parentID, bool withoutContainer) override;
 
-    virtual std::unique_ptr<ChangedContainers> removeObject(int objectID, bool all) override;
-    virtual std::unique_ptr<ChangedContainers> removeObjects(const std::unique_ptr<std::unordered_set<int>>& list, bool all = false) override;
+    std::unique_ptr<ChangedContainers> removeObject(int objectID, bool all) override;
+    std::unique_ptr<ChangedContainers> removeObjects(const std::unique_ptr<std::unordered_set<int>>& list, bool all = false) override;
 
-    virtual std::shared_ptr<CdsObject> loadObjectByServiceID(std::string serviceID) override;
-    virtual std::unique_ptr<std::vector<int>> getServiceObjectIDs(char servicePrefix) override;
+    std::shared_ptr<CdsObject> loadObjectByServiceID(std::string serviceID) override;
+    std::unique_ptr<std::vector<int>> getServiceObjectIDs(char servicePrefix) override;
 
-    virtual std::string findFolderImage(int id, std::string trackArtBase) override;
+    std::string findFolderImage(int id, std::string trackArtBase) override;
 
     /* accounting methods */
-    virtual int getTotalFiles() override;
+    int getTotalFiles() override;
 
-    virtual std::vector<std::shared_ptr<CdsObject>> browse(const std::unique_ptr<BrowseParam>& param) override;
-    virtual std::vector<std::shared_ptr<CdsObject>> search(const std::unique_ptr<SearchParam>& param, int* numMatches) override;
+    std::vector<std::shared_ptr<CdsObject>> browse(const std::unique_ptr<BrowseParam>& param) override;
+    std::vector<std::shared_ptr<CdsObject>> search(const std::unique_ptr<SearchParam>& param, int* numMatches) override;
 
-    virtual std::vector<std::string> getMimeTypes() override;
+    std::vector<std::string> getMimeTypes() override;
 
     //virtual std::shared_ptr<CdsObject> findObjectByTitle(std::string title, int parentID);
-    virtual std::shared_ptr<CdsObject> findObjectByPath(fs::path fullpath, bool wasRegularFile = false) override;
-    virtual int findObjectIDByPath(fs::path fullpath, bool wasRegularFile = false) override;
-    virtual std::string incrementUpdateIDs(const std::unique_ptr<std::unordered_set<int>>& ids) override;
+    std::shared_ptr<CdsObject> findObjectByPath(fs::path fullpath, bool wasRegularFile = false) override;
+    int findObjectIDByPath(fs::path fullpath, bool wasRegularFile = false) override;
+    std::string incrementUpdateIDs(const std::unique_ptr<std::unordered_set<int>>& ids) override;
 
-    virtual fs::path buildContainerPath(int parentID, std::string title) override;
-    virtual void addContainerChain(std::string path, std::string lastClass, int lastRefID, int* containerID, int* updateID, const std::map<std::string, std::string>& lastMetadata) override;
-    virtual std::string getInternalSetting(std::string key) override;
-    virtual void storeInternalSetting(std::string key, std::string value) override = 0;
+    fs::path buildContainerPath(int parentID, std::string title) override;
+    void addContainerChain(std::string path, std::string lastClass, int lastRefID, int* containerID, int* updateID, const std::map<std::string, std::string>& lastMetadata) override;
+    std::string getInternalSetting(std::string key) override;
+    void storeInternalSetting(std::string key, std::string value) override = 0;
 
-    virtual void updateAutoscanPersistentList(ScanMode scanmode, std::shared_ptr<AutoscanList> list) override;
-    virtual std::shared_ptr<AutoscanList> getAutoscanList(ScanMode scanmode) override;
-    virtual void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
-    virtual void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
-    virtual void removeAutoscanDirectoryByObjectID(int objectID) override;
-    virtual void removeAutoscanDirectory(int autoscanID) override;
-    virtual int getAutoscanDirectoryType(int objectId) override;
-    virtual int isAutoscanDirectoryRecursive(int objectId) override;
-    virtual void autoscanUpdateLM(std::shared_ptr<AutoscanDirectory> adir) override;
-    virtual std::shared_ptr<AutoscanDirectory> getAutoscanDirectory(int objectID) override;
-    virtual int isAutoscanChild(int objectID) override;
-    virtual void checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir) override;
+    void updateAutoscanPersistentList(ScanMode scanmode, std::shared_ptr<AutoscanList> list) override;
+    std::shared_ptr<AutoscanList> getAutoscanList(ScanMode scanmode) override;
+    void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
+    void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
+    void removeAutoscanDirectoryByObjectID(int objectID) override;
+    void removeAutoscanDirectory(int autoscanID) override;
+    int getAutoscanDirectoryType(int objectId) override;
+    int isAutoscanDirectoryRecursive(int objectId) override;
+    void autoscanUpdateLM(std::shared_ptr<AutoscanDirectory> adir) override;
+    std::shared_ptr<AutoscanDirectory> getAutoscanDirectory(int objectID) override;
+    int isAutoscanChild(int objectID) override;
+    void checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir) override;
 
-    virtual std::unique_ptr<std::vector<int>> getPathIDs(int objectID) override;
+    std::unique_ptr<std::vector<int>> getPathIDs(int objectID) override;
 
     void shutdown() override;
     virtual void shutdownDriver() = 0;
 
-    virtual int ensurePathExistence(fs::path path, int* changedContainer) override;
+    int ensurePathExistence(fs::path path, int* changedContainer) override;
 
-    virtual std::string getFsRootName() override;
+    std::string getFsRootName() override;
 
-    virtual void clearFlagInDB(int flag) override;
+    void clearFlagInDB(int flag) override;
 
 protected:
     SQLStorage(std::shared_ptr<ConfigManager> config);

--- a/src/storage/sqlite3/sqlite3_storage.h
+++ b/src/storage/sqlite3/sqlite3_storage.h
@@ -150,7 +150,7 @@ protected:
 /// \brief The Storage class for using SQLite3
 class Sqlite3Storage : public Timer::Subscriber, public SQLStorage, public std::enable_shared_from_this<SQLStorage> {
 public:
-    virtual void timerNotify(std::shared_ptr<Timer::Parameter> param) override;
+    void timerNotify(std::shared_ptr<Timer::Parameter> param) override;
     Sqlite3Storage(std::shared_ptr<ConfigManager> config, std::shared_ptr<Timer> timer);
 
 private:
@@ -197,8 +197,8 @@ private:
     std::queue<std::shared_ptr<SLTask>> taskQueue;
     bool taskQueueOpen;
 
-    virtual void threadCleanup() override {}
-    virtual bool threadCleanupRequired() override { return false; }
+    void threadCleanup() override {}
+    bool threadCleanupRequired() override { return false; }
 
     bool dirty;
 
@@ -215,8 +215,8 @@ public:
     virtual ~Sqlite3Result();
 
 private:
-    virtual std::unique_ptr<SQLRow> nextRow() override;
-    virtual unsigned long long getNumRows() override { return nrow; }
+    std::unique_ptr<SQLRow> nextRow() override;
+    unsigned long long getNumRows() override { return nrow; }
 
     char** table;
     char** row;

--- a/src/web/session_manager.h
+++ b/src/web/session_manager.h
@@ -141,7 +141,7 @@ protected:
 public:
     /// \brief Constructor, initializes the array.
     SessionManager(const std::shared_ptr<ConfigManager>& config, std::shared_ptr<Timer> timer);
-    virtual ~SessionManager() override { log_debug("SessionManager destroyed\n"); }
+    ~SessionManager() override { log_debug("SessionManager destroyed\n"); }
 
     /// \brief Creates a Session with a given timeout.
     /// \param timeout Session timeout in milliseconds.
@@ -165,7 +165,7 @@ public:
 
     void containerChangedUI(const std::vector<int>& objectIDs);
 
-    virtual void timerNotify(std::shared_ptr<Timer::Parameter> parameter) override;
+    void timerNotify(std::shared_ptr<Timer::Parameter> parameter) override;
 };
 
 } // namespace


### PR DESCRIPTION
It's redundant.

Signed-off-by: Rosen Penev <rosenp@gmail.com>