### PR TITLE
Return full URL of the subtitle (#744)

### DIFF
--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -391,13 +391,11 @@ void UpnpXMLBuilder::renderCaptionInfo(const std::string& URL, pugi::xml_node* p
 
     // Samsung DLNA clients don't follow this URL and
     // obtain subtitle location from video HTTP headers.
-    // We don't need to know here what the subtitle type
-    // is and even if there is a subtitle.
-    // This tag seems to be only a hint for Samsung devices,
-    // though it's necessary.
+    // However other software players (like VLC) use
+    // it to add a subtitle track.
 
     size_t endp = URL.rfind('.');
-    cap.append_child(pugi::node_pcdata).set_value((URL.substr(0, endp) + ".srt").c_str());
+    cap.append_child(pugi::node_pcdata).set_value((virtualURL + URL.substr(0, endp) + ".srt").c_str());
     cap.append_attribute("sec:type") = "srt";
 }
 
@@ -831,10 +829,8 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
             protocolInfo = protocolInfo.substr(0, protocolInfo.rfind(':') + 1).append(extend);
             res_attrs[MetadataHandler::getResAttrName(R_PROTOCOLINFO)] = protocolInfo;
 
-            if (config->getBoolOption(CFG_SERVER_EXTEND_PROTOCOLINFO_SM_HACK)) {
-                if (startswith(mimeType, "video")) {
-                    renderCaptionInfo(url, parent);
-                }
+            if (startswith(mimeType, "video")) {
+                renderCaptionInfo(url, parent);
             }
 
             log_debug("extended protocolInfo: {}", protocolInfo.c_str());

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -88,9 +88,9 @@ public:
     /// \param attributes Dictionary containing the <res> tag attributes (like resolution, etc.)
     static void renderResource(const std::string& URL, const std::map<std::string, std::string>& attributes, pugi::xml_node* parent);
 
-    /// \brief Renders a subtitle resource tag (Samsung proprietary extension)
+    /// \brief Renders a subtitle resource tag
     /// \param URL download location of the video item
-    static void renderCaptionInfo(const std::string& URL, pugi::xml_node* parent);
+    void renderCaptionInfo(const std::string& URL, pugi::xml_node* parent);
 
     static void renderCreator(const std::string& creator, pugi::xml_node* parent);
     static void renderAlbumArtURI(const std::string& uri, pugi::xml_node* parent);

--- a/test/test_upnp/test_upnp_xml.cc
+++ b/test/test_upnp/test_upnp_xml.cc
@@ -13,7 +13,7 @@ public:
 
     virtual void SetUp()
     {
-        std::string virtualDir = "/dir/virtual";
+        std::string virtualDir = "http://server/content";
         std::string presentationURl = "http://someurl/";
         subject = new UpnpXMLBuilder(nullptr, nullptr, virtualDir, presentationURl);
     }
@@ -90,11 +90,11 @@ TEST_F(UpnpXmlTest, CreatesSecCaptionInfoElement)
 {
     pugi::xml_document doc;
     auto container = doc.append_child("container");
-    subject->renderCaptionInfo("file.srt", &container);
+    subject->renderCaptionInfo("/media/object_id/1/file.mp4", &container);
     auto result = container.first_child();
 
     EXPECT_NE(result, nullptr);
-    EXPECT_STREQ(result.text().as_string(), "file.srt");
+    EXPECT_STREQ(result.text().as_string(), "http://server/content/media/object_id/1/file.srt");
     EXPECT_STREQ(result.name(), "sec:CaptionInfoEx");
     EXPECT_STREQ(result.attribute("sec:type").as_string(), "srt");
 }


### PR DESCRIPTION
Apparently VLC requires a full URL to load subtitle properly
(treating as local path otherwise).

Add sec:CaptionInfoEx tag unconditionally as other UPNP servers do.