### PR TITLE
improve util upnp headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,6 @@ set(libgerberaFILES
         src/util/executor.h
         src/util/generic_task.cc
         src/util/generic_task.h
-        src/util/headers.h
-        src/util/headers.cc
         src/util/jpeg_resolution.cc
         src/util/logger.h
         src/util/mt_inotify.cc
@@ -185,6 +183,8 @@ set(libgerberaFILES
         src/util/timer.h
         src/util/tools.cc
         src/util/tools.h
+        src/util/upnp_headers.h
+        src/util/upnp_headers.cc
         src/util/xml_to_json.cc
         src/util/xml_to_json.h
         src/web/action.cc

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -45,7 +45,7 @@
 #include "util/process.h"
 #include "web/session_manager.h"
 
-#include "util/headers.h"
+#include "util/upnp_headers.h"
 #include "util/tools.h"
 
 #include "transcoding/transcode_dispatcher.h"

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -45,8 +45,8 @@
 #include "util/process.h"
 #include "web/session_manager.h"
 
-#include "util/upnp_headers.h"
 #include "util/tools.h"
+#include "util/upnp_headers.h"
 
 #include "transcoding/transcode_dispatcher.h"
 

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -96,33 +96,35 @@ std::vector<std::string> split_string(const std::string& str, char sep, bool emp
     return ret;
 }
 
+void leftTrimStringInPlace(std::string& str)
+{
+    str.erase(str.begin(), std::find_if(str.begin(), str.end(), [](int ch) {
+        return !std::isspace(ch);
+    }));
+}
+
+void rightTrimStringInPlace(std::string& str)
+{
+    str.erase(std::find_if(str.rbegin(), str.rend(), [](int ch) {
+        return !std::isspace(ch);
+    }).base(),
+        str.end());
+}
+
+void trimStringInPlace(std::string& str)
+{
+    leftTrimStringInPlace(str);
+    rightTrimStringInPlace(str);
+}
+
 std::string trim_string(std::string str)
 {
     if (str.empty())
         return str;
 
-    int i;
-    int start = 0;
-    int end = 0;
-    int len = str.length();
-
-    const char* buf = str.c_str();
-
-    for (i = 0; i < len; i++) {
-        if (!strchr(WHITE_SPACE, buf[i])) {
-            start = i;
-            break;
-        }
-    }
-    if (i >= len)
-        return "";
-    for (i = len - 1; i >= start; i--) {
-        if (!strchr(WHITE_SPACE, buf[i])) {
-            end = i + 1;
-            break;
-        }
-    }
-    return str.substr(start, end - start);
+    leftTrimStringInPlace(str);
+    rightTrimStringInPlace(str);
+    return str;
 }
 
 bool startswith(const std::string& str, const std::string& check)

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -63,7 +63,16 @@ class IOHandler;
 /// \return array of strings
 std::vector<std::string> split_string(const std::string& str, char sep, bool empty = false);
 
-/// \brief returns str with leading and trailing whitespace removed
+/// \brief trim from start (in place)
+void leftTrimStringInPlace(std::string& str);
+
+/// \brief trim from end (in place)
+void rightTrimStringInPlace(std::string& str);
+
+/// \brief remove leading and trailing whitespace (in place)
+void trimStringInPlace(std::string& str);
+
+/// \brief returns str with leading and trailing whitespace removed (copy)
 std::string trim_string(std::string str);
 
 /// \brief returns true if str starts with check

--- a/src/util/upnp_headers.cc
+++ b/src/util/upnp_headers.cc
@@ -21,9 +21,9 @@
     $Id$
 */
 
-/// \file headers.cc
+/// \file upnp_headers.cc
 
-#include "headers.h" // API
+#include "upnp_headers.h" // API
 
 #include <string>
 

--- a/src/util/upnp_headers.h
+++ b/src/util/upnp_headers.h
@@ -21,7 +21,7 @@ Gerbera - https://gerbera.io/
     $Id$
 */
 
-/// \file headers.h
+/// \file upnp_headers.h
 
 #ifndef GERBERA_HEADERS_H
 #define GERBERA_HEADERS_H

--- a/src/util/upnp_headers.h
+++ b/src/util/upnp_headers.h
@@ -1,8 +1,8 @@
 /*GRB*
 
-Gerbera - https://gerbera.io/
+    Gerbera - https://gerbera.io/
 
-    http_protocol_helper.h - this file is part of Gerbera.
+    upnp_headers.h - this file is part of Gerbera.
 
     Copyright (C) 2016-2020 Gerbera Contributors
 
@@ -26,9 +26,10 @@ Gerbera - https://gerbera.io/
 #ifndef GERBERA_HEADERS_H
 #define GERBERA_HEADERS_H
 
-#include <action_request.h>
 #include <map>
 #include <memory>
+#include <upnp.h>
+#include <vector>
 #if defined(UPNP_HAS_EXTRA_HEADERS_LIST) || defined(UPNP_1_12_LIST)
 #include <ExtraHeaders.h>
 #endif
@@ -38,10 +39,14 @@ public:
     void addHeader(const std::string& header, const std::string& value);
     void writeHeaders(UpnpFileInfo* fileInfo) const;
 
+    static std::unique_ptr<std::map<std::string, std::string>> readHeaders(UpnpFileInfo* fileInfo);
+
 private:
-    std::unique_ptr<std::vector<std::pair<std::string, std::string>>> headers;
     static std::string formatHeader(const std::pair<std::string, std::string>& header, bool crlf);
+    static std::pair<std::string, std::string> parseHeader(const std::string& header);
     static std::string stripInvalid(const std::string& value);
+
+    std::unique_ptr<std::map<std::string, std::string>> headers;
 };
 
 #endif //GERBERA_HEADERS_H

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -32,13 +32,13 @@
 #include "web_request_handler.h" // API
 
 #include <ctime>
-#include <util/headers.h>
 #include <utility>
 
 #include "config/config_manager.h"
 #include "content_manager.h"
 #include "iohandler/mem_io_handler.h"
 #include "util/tools.h"
+#include "util/upnp_headers.h"
 #include "util/xml_to_json.h"
 #include "web/pages.h"
 

--- a/test/test_handler/test_http_protocol_helper.cc
+++ b/test/test_handler/test_http_protocol_helper.cc
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "util/headers.h"
+#include "util/upnp_headers.h"
 
 using namespace ::testing;
 

--- a/test/test_handler/test_http_protocol_helper.cc
+++ b/test/test_handler/test_http_protocol_helper.cc
@@ -23,197 +23,241 @@ public:
     Headers* subject;
 };
 
-#ifdef UPNP_1_12_LIST
-std::string headers_as_string(UpnpFileInfo* info)
-{
-    std::string out;
-
-    UpnpExtraHeaders* extra;
-    UpnpListIter pos;
-    auto head = const_cast<UpnpListHead*>(UpnpFileInfo_get_ExtraHeadersList(info));
-    for (pos = UpnpListBegin(head); pos != UpnpListEnd(head); pos = UpnpListNext(head, pos)) {
-        extra = (UpnpExtraHeaders*)pos;
-        out += UpnpExtraHeaders_get_resp(extra);
-        out += "\r\n";
-    }
-    return out;
-}
-#define GET_HEADERS(x) headers_as_string(x).c_str()
-#elif UPNP_HAS_EXTRA_HEADERS_LIST
-std::string headers_as_string(UpnpFileInfo* info)
-{
-    std::string out;
-
-    UpnpExtraHeaders* extra;
-    list_head* pos;
-    auto head = const_cast<list_head*>(UpnpFileInfo_get_ExtraHeadersList(info));
-    list_for_each(pos, head)
-    {
-        extra = (UpnpExtraHeaders*)pos;
-        out.insert(0, std::string { UpnpExtraHeaders_get_resp(extra) } + "\r\n");
-    }
-    return out;
-}
-#define GET_HEADERS(x) headers_as_string(x).c_str()
-#else
-#define GET_HEADERS UpnpFileInfo_get_ExtraHeaders_cstr
-#endif
-
 TEST_F(HeadersHelperTest, TerminatesTheHeaderWithCarriageNewLine)
 {
-    std::string header = "Content-Disposition";
+    // arrange
+    std::string key = "Content-Disposition";
     std::string value = "attachment; filename=\"file.mp3\"";
+    std::map<std::string, std::string> expected;
+    expected[key] = value;
 
-    subject->addHeader(header, value);
+    // act
+    subject->addHeader(key, value);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, DoesNotAddTerminationCarriageNewLineWhenAlreadyExists)
 {
-    std::string header = "Content-Disposition";
+    // arrange
+    std::string key = "Content-Disposition";
     std::string value = "attachment; filename=\"file.mp3\"\r\n";
+    std::map<std::string, std::string> expected;
+    expected[key] = "attachment; filename=\"file.mp3\"";
 
-    subject->addHeader(header, value);
+    // act
+    subject->addHeader(key, value);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, MultipleHeaders)
 {
-    std::string header = "Content-Disposition";
-    std::string value = "attachment; filename=\"file.mp3\"";
-    std::string header2 = "Accept-Ranges";
-    std::string value2 = "bytes";
+    // arrange
+    std::map<std::string, std::string> expected;
+    expected["Content-Disposition"] = "attachment; filename=\"file.mp3\"";
+    expected["Accept-Ranges"] = "bytes";
 
-    subject->addHeader(header, value);
-    subject->addHeader(header2, value2);
+    // act
+    for (const auto& add : expected) {
+        subject->addHeader(add.first, add.second);
+    }
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\nAccept-Ranges: bytes\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, MultipleHeadersSingleCarriageNewLine)
 {
-    std::string header = "Content-Disposition";
+    // arrange
+    std::string key = "Content-Disposition";
     std::string value = "attachment; filename=\"file.mp3\"";
-    std::string header2 = "Accept-Ranges";
+    std::string key2 = "Accept-Ranges";
     std::string value2 = "bytes\r\n";
+    std::map<std::string, std::string> expected;
+    expected[key] = value;
+    expected[key2] = "bytes";
 
-    subject->addHeader(header, value);
-    subject->addHeader(header2, value2);
+    // act
+    subject->addHeader(key, value);
+    subject->addHeader(key2, value2);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\nAccept-Ranges: bytes\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, MultiBothCarriageNewLine)
 {
-    std::string header = "Content-Disposition";
+    // arrange
+    std::string key = "Content-Disposition";
     std::string value = "attachment; filename=\"file.mp3\"\r\n";
-    std::string header2 = "Accept-Ranges";
+    std::string key2 = "Accept-Ranges";
     std::string value2 = "bytes\r\n";
+    std::map<std::string, std::string> expected;
+    expected[key] = "attachment; filename=\"file.mp3\"";
+    expected[key2] = "bytes";
 
-    subject->addHeader(header, value);
-    subject->addHeader(header2, value2);
+    // act
+    subject->addHeader(key, value);
+    subject->addHeader(key2, value2);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\nAccept-Ranges: bytes\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, IgnoresDataAfterFirstCarriageNewLine)
 {
-    std::string header = "Content-Disposition";
+    // arrange
+    std::string key = "Content-Disposition";
     std::string value = "attachment; filename=\"file.mp3\"\r\nAccept-Ranges: bytes";
+    std::map<std::string, std::string> expected;
+    expected[key] = "attachment; filename=\"file.mp3\"";
 
-    subject->addHeader(header, value);
+    // act
+    subject->addHeader(key, value);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, HeaderIsOnlyLinebreakReturnsEmpty)
 {
+    // arrange
     std::string header = "\r\n";
+    std::map<std::string, std::string> expected;
 
+    // act
     subject->addHeader(header, header);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, HeaderIsEmptyReturnsEmpty)
 {
+    // arrange
     std::string header = "";
+    std::map<std::string, std::string> expected;
 
+    // act
     subject->addHeader(header, header);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, HandlesSingleCarriageReturn)
 {
-    std::string header = "Content-Disposition";
+    // arrange
+    std::string key = "Content-Disposition";
     std::string value = "attachment; filename=\"file.mp3\"\r";
+    std::map<std::string, std::string> expected;
+    expected[key] = "attachment; filename=\"file.mp3\"";
 
-    subject->addHeader(header, value);
+    // act
+    subject->addHeader(key, value);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, HandlesSingleNewLine)
 {
-    std::string header = "Content-Disposition";
+    // arrange
+    std::string key = "Content-Disposition";
     std::string value = "attachment; filename=\"file.mp3\"\n";
+    std::map<std::string, std::string> expected;
+    expected[key] = "attachment; filename=\"file.mp3\"";
 
-    subject->addHeader(header, value);
+    // act
+    subject->addHeader(key, value);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "Content-Disposition: attachment; filename=\"file.mp3\"\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, EmptyValueNotAdded)
 {
-    std::string header = "a";
+    // arrange
+    std::string key = "a";
+    std::map<std::string, std::string> expected;
 
-    subject->addHeader(header, "");
+    // act
+    subject->addHeader(key, "");
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, HandlesEmptyString)
 {
+    // arrange
     std::string header;
+    std::map<std::string, std::string> expected;
 
+    // act
     subject->addHeader(header, header);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, HandlesExtraContent)
 {
-    std::string header = "foo";
+    // arrange
+    std::string key = "foo";
     std::string value = "bar\r\nzoo: wombat\r\n";
+    std::map<std::string, std::string> expected;
+    expected[key] = "bar";
 
-    subject->addHeader(header, value);
+    // act
+    subject->addHeader(key, value);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "foo: bar\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }
 
 TEST_F(HeadersHelperTest, HandlesExtraContentTwo)
 {
-    std::string header = "foo";
+    // arrange
+    std::string key = "foo";
     std::string value = "bar\r\nzoo: wombat\r\nwhere: somewhere";
+    std::map<std::string, std::string> expected;
+    expected[key] = "bar";
 
-    subject->addHeader(header, value);
+    // act
+    subject->addHeader(key, value);
     subject->writeHeaders(info);
 
-    EXPECT_STREQ(GET_HEADERS(info), "foo: bar\r\n");
+    // assert
+    auto actual = Headers::readHeaders(info);
+    EXPECT_EQ(*actual, expected);
 }


### PR DESCRIPTION
- use dictionary for headers (uniqueness of key)
- simplify unit-test (sequence does no longer matter)
- readHeaders function can later be reused
