### PR TITLE
Warnings-free build with gcc 9.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@ We welcome pull requests from everyone!
 
 MediaTomb is an old project that we are working on modernising - there are a lot of cobwebs 🕸 .
 
-For new code please use modern C++ (up to 14) constructs where possible, and avoid the `zmm` namespace.
+For new code please use modern C++ (up to 17) constructs where possible, and avoid the `zmm` namespace.
 
 1. Fork this repo.
 
 2. Clone your fork:
 
-    `git clone git@github.com:your-username/mediatomb.git`
+    `git clone git@github.com:your-username/gerbera.git`
 
 2. Make your change.
 
@@ -22,3 +22,6 @@ Some things that will increase the chance that your pull request is accepted:
 
 * Stick to [Webkit style](https://webkit.org/code-style-guidelines/).
 * Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+It is also a good idea to run cmake with`-DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS="-Werror"`
+options for development.

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -149,11 +149,6 @@ static void addFfmpegResourceFields(std::shared_ptr<CdsItem> item, AVFormatConte
     int64_t hours, mins, secs, us;
     int audioch = 0, samplefreq = 0;
     bool audioset, videoset;
-    std::string resolution;
-    char duration[15];
-
-    // Initialize the buffers
-    duration[0] = 0;
 
     // duration
     secs = pFormatCtx->duration / AV_TIME_BASE;
@@ -163,9 +158,9 @@ static void addFfmpegResourceFields(std::shared_ptr<CdsItem> item, AVFormatConte
     hours = mins / 60;
     mins %= 60;
     if ((hours + mins + secs) > 0) {
-        sprintf(duration, "%02" PRId64 ":%02" PRId64 ":%02" PRId64 ".%01" PRId64, hours, mins, secs, (10 * us) / AV_TIME_BASE);
+        auto duration = fmt::format("{:02}:{:02}:{:02}.{:01}", hours, mins, secs, (10 * us) / AV_TIME_BASE);
         log_debug("Added duration: {}", duration);
-        item->getResource(0)->addAttribute(MetadataHandler::getResAttrName(R_DURATION), duration);
+        item->getResource(0)->addAttribute(MetadataHandler::getResAttrName(R_DURATION), std::move(duration));
     }
 
     // bitrate
@@ -198,10 +193,10 @@ static void addFfmpegResourceFields(std::shared_ptr<CdsItem> item, AVFormatConte
             }
 
             if ((as_codecpar(st)->width > 0) && (as_codecpar(st)->height > 0)) {
-                resolution = std::to_string(as_codecpar(st)->width) + "x" + std::to_string(as_codecpar(st)->height);
+                auto resolution = fmt::format("{}x{}", as_codecpar(st)->width, as_codecpar(st)->height);
 
-                log_debug("Added resolution: {} pixel", resolution.c_str());
-                item->getResource(0)->addAttribute(MetadataHandler::getResAttrName(R_RESOLUTION), resolution);
+                log_debug("Added resolution: {} pixel", resolution);
+                item->getResource(0)->addAttribute(MetadataHandler::getResAttrName(R_RESOLUTION), std::move(resolution));
                 videoset = true;
             }
         }

--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -51,8 +51,8 @@ public:
 private:
     void parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandler** p_io_handler);
     void parseLevel1Element(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlElement* el_l1, MemIOHandler** p_io_handler);
-    void parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, LIBMATROSKA_NAMESPACE::KaxInfo* info);
-    static void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBMATROSKA_NAMESPACE::KaxAttachments* attachments, MemIOHandler** io_handler);
+    void parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlMaster* info);
+    static void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlMaster* attachments, MemIOHandler** io_handler);
     static std::string getContentTypeFromByteVector(const LIBMATROSKA_NAMESPACE::KaxFileData* data);
     static void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
 };


### PR DESCRIPTION
Minor refactoring to build without warnings with Gcc 9 and latest
libraries.

Fixed undefined behavior in matroska_handler and taglib_handler.