### PR TITLE
Change several other functions to const manually

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -130,7 +130,7 @@ std::unique_ptr<IOHandler> MatroskaHandler::serveContent(std::shared_ptr<CdsItem
     return h;
 }
 
-void MatroskaHandler::parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandler** p_io_handler)
+void MatroskaHandler::parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandler** p_io_handler) const
 {
     file_io_callback ebml_file(item->getLocation().c_str());
     EbmlStream ebml_stream(ebml_file);
@@ -157,7 +157,7 @@ void MatroskaHandler::parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandle
     ebml_file.close();
 }
 
-void MatroskaHandler::parseLevel1Element(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, EbmlElement* el_l1, MemIOHandler** p_io_handler)
+void MatroskaHandler::parseLevel1Element(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, EbmlElement* el_l1, MemIOHandler** p_io_handler) const
 {
     // Looking at just at EbmlId is not reliable since it can be a dummy element.
     if (!el_l1->IsMaster())
@@ -174,7 +174,7 @@ void MatroskaHandler::parseLevel1Element(const std::shared_ptr<CdsItem>& item, E
     }
 }
 
-void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, EbmlMaster* info)
+void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, EbmlMaster* info) const
 {
     EbmlElement* dummy_el;
     int i_upper_level = 0;

--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -48,9 +48,9 @@ public:
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsItem> item, int resNum) override;
 
 private:
-    void parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandler** p_io_handler);
-    void parseLevel1Element(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlElement* el_l1, MemIOHandler** p_io_handler);
-    void parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlMaster* info);
+    void parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandler** p_io_handler) const;
+    void parseLevel1Element(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlElement* el_l1, MemIOHandler** p_io_handler) const;
+    void parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlMaster* info) const;
     static void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebml_stream, LIBEBML_NAMESPACE::EbmlMaster* attachments, MemIOHandler** io_handler);
     static std::string getContentTypeFromByteVector(const LIBMATROSKA_NAMESPACE::KaxFileData* data);
     static void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -387,7 +387,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsItem> 
     throw_std_runtime_error("Unsupported content_type: " + content_type);
 }
 
-void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item)
+void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const
 {
     TagLib::MPEG::File mp3(roStream, TagLib::ID3v2::FrameFactory::instance());
 
@@ -468,7 +468,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
     }
 }
 
-void TagLibHandler::extractOgg(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item)
+void TagLibHandler::extractOgg(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const
 {
     TagLib::Ogg::Vorbis::File vorbis(item->getLocation().c_str());
 
@@ -500,7 +500,7 @@ void TagLibHandler::extractOgg(TagLib::IOStream* roStream, const std::shared_ptr
     addArtworkResource(item, art_mimetype);
 }
 
-void TagLibHandler::extractASF(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item)
+void TagLibHandler::extractASF(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const
 {
     TagLib::ASF::File asf(roStream);
 
@@ -530,7 +530,7 @@ void TagLibHandler::extractASF(TagLib::IOStream* roStream, const std::shared_ptr
     }
 }
 
-void TagLibHandler::extractFLAC(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item)
+void TagLibHandler::extractFLAC(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const
 {
     TagLib::FLAC::File flac(roStream, TagLib::ID3v2::FrameFactory::instance());
 

--- a/src/metadata/taglib_handler.h
+++ b/src/metadata/taglib_handler.h
@@ -57,10 +57,10 @@ private:
     static bool isValidArtworkContentType(const std::string& art_mimetype);
     static std::string getContentTypeFromByteVector(const TagLib::ByteVector& data);
     static void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& art_mimetype);
-    void extractMP3(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
-    void extractOgg(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
-    void extractASF(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
-    void extractFLAC(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item);
+    void extractMP3(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const;
+    void extractOgg(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const;
+    void extractASF(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const;
+    void extractFLAC(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const;
     void extractAPE(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const;
     void extractWavPack(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const;
     void extractMP4(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const;

--- a/src/onlineservice/atrailers_service.cc
+++ b/src/onlineservice/atrailers_service.cc
@@ -76,7 +76,7 @@ service_type_t ATrailersService::getServiceType()
     return OS_ATrailers;
 }
 
-std::string ATrailersService::getServiceName()
+std::string ATrailersService::getServiceName() const
 {
     return "Apple Trailers";
 }

--- a/src/onlineservice/atrailers_service.h
+++ b/src/onlineservice/atrailers_service.h
@@ -63,7 +63,7 @@ public:
     service_type_t getServiceType() override;
 
     /// \brief Get the human readable name for the service
-    std::string getServiceName() override;
+    std::string getServiceName() const override;
 
 protected:
     std::shared_ptr<ConfigManager> config;

--- a/src/onlineservice/online_service.h
+++ b/src/onlineservice/online_service.h
@@ -79,7 +79,7 @@ public:
     virtual service_type_t getServiceType() = 0;
 
     /// \brief Returns the service name
-    virtual std::string getServiceName() = 0;
+    virtual std::string getServiceName() const = 0;
 
     /// \brief Get the storage service prefix for a particular service
     char getStoragePrefix();

--- a/src/onlineservice/sopcast_service.cc
+++ b/src/onlineservice/sopcast_service.cc
@@ -68,7 +68,7 @@ service_type_t SopCastService::getServiceType()
     return OS_SopCast;
 }
 
-std::string SopCastService::getServiceName()
+std::string SopCastService::getServiceName() const
 {
     return "SopCast";
 }

--- a/src/onlineservice/sopcast_service.h
+++ b/src/onlineservice/sopcast_service.h
@@ -63,7 +63,7 @@ public:
     service_type_t getServiceType() override;
 
     /// \brief Get the human readable name for the service
-    std::string getServiceName() override;
+    std::string getServiceName() const override;
 
 protected:
     std::shared_ptr<ConfigManager> config;

--- a/src/storage/mysql/mysql_storage.h
+++ b/src/storage/mysql/mysql_storage.h
@@ -51,7 +51,7 @@ private:
     void shutdownDriver() override;
     std::shared_ptr<Storage> getSelf() override;
 
-    std::string quote(std::string str) const override;
+    std::string quote(std::string value) const override;
     inline std::string quote(const char* str) const override { return quote(std::string(str)); }
     inline std::string quote(int val) const override { return std::to_string(val); }
     inline std::string quote(unsigned int val) const override { return std::to_string(val); }
@@ -64,13 +64,13 @@ private:
     int exec(const char* query, int length, bool getLastInsertId = false) override;
     void storeInternalSetting(const std::string& key, const std::string& value) override;
 
-    void _exec(const char* query, int lenth = -1);
+    void _exec(const char* query, int length = -1);
 
     MYSQL db;
 
     bool mysql_connection;
 
-    std::string getError(MYSQL* db);
+    static std::string getError(MYSQL* db);
 
     std::recursive_mutex mysqlMutex;
     using AutoLock = std::lock_guard<decltype(mysqlMutex)>;

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -506,7 +506,7 @@ std::string UpnpXMLBuilder::renderExtension(const std::string& contentType, cons
         if (dot != std::string::npos) {
             std::string extension = location.substr(dot);
             // make sure that the extension does not contain the separator character
-            if ((extension.find(URL_PARAM_SEPARATOR) == std::string::npos) && (extension.find(URL_PARAM_SEPARATOR) == std::string::npos)) {
+            if (extension.find(URL_PARAM_SEPARATOR) == std::string::npos) {
                 ext = ext + extension;
                 return ext;
             }


### PR DESCRIPTION
const allows the compiler to optimize these functions better.

Signed-off-by: Rosen Penev <rosenp@gmail.com>