### PR TITLE
Replaced snprintf which caused a warning with fmt

### DIFF
--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -563,24 +563,13 @@ std::string getProtocol(const std::string& protocolInfo)
 
 std::string secondsToHMS(int seconds)
 {
-    int h, m, s;
-
-    s = seconds % 60;
+    auto s = seconds % 60;
     seconds /= 60;
 
-    m = seconds % 60;
-    h = seconds / 60;
+    auto m = seconds % 60;
+    auto h = std::min(seconds / 60, 999);
 
-    // XXX:XX:XX
-    // This fails if h goes over 999
-    if (h > 999)
-        h = 999;
-
-    char buf[10];
-    snprintf(buf, sizeof(buf), "%02d:%02d:%02d", h, m, s);
-    std::string res = buf;
-
-    return res;
+    return fmt::format("{:02}:{:02}:{:02}", h, m, s);
 }
 
 int HMSToSeconds(const std::string& time)

--- a/test/test_util/CMakeLists.txt
+++ b/test/test_util/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(Threads REQUIRED)
 
 add_executable(testutil
+        test_tools.cc
         test_upnp_headers.cc
 )
 

--- a/test/test_util/test_tools.cc
+++ b/test/test_util/test_tools.cc
@@ -1,0 +1,18 @@
+#include "util/tools.h"
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+TEST(ToolsTest, secondsToHMS)
+{
+    EXPECT_EQ(secondsToHMS(0), "00:00:00");
+    EXPECT_EQ(secondsToHMS(1), "00:00:01");
+    EXPECT_EQ(secondsToHMS(62), "00:01:02");
+    EXPECT_EQ(secondsToHMS(3662), "01:01:02");
+}
+
+TEST(ToolsTest, secondsToHMSOverflow)
+{
+    EXPECT_EQ(secondsToHMS(1000 * 3600 + 1), "999:00:01");
+}


### PR DESCRIPTION
Not sure whether limit should be 999 or just 99 for 2-digit formatting...