### PR TITLE
Don't override interface flags for spdlog.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,20 +317,17 @@ else()
     add_definitions(-DUPNP_HAS_EXTRA_HEADERS_LIST)
 endif()
 
-find_package(fmt REQUIRED)
-target_link_libraries(gerbera fmt::fmt)
 
 # See if it's just installed as a library first, as not all installs have .cmake files
 find_library(SPDLOG_LIBRARY spdlog)
 if(SPDLOG_LIBRARY)
     set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${SPDLOG_LIBRARY})
-    target_link_libraries(gerbera ${SPDLOG_LIBRARY})
+    target_link_libraries(libgerbera ${SPDLOG_LIBRARY})
 else()
     # Didn't find it, so try the .cmake file, fail if not found
     find_package(spdlog REQUIRED)
-    target_link_libraries(gerbera spdlog::spdlog)
+    target_link_libraries(libgerbera spdlog::spdlog)
 endif()
-add_compile_definitions("SPDLOG_FMT_EXTERNAL")
 
 find_package (Pugixml REQUIRED)
 if (PUGIXML_FOUND)


### PR DESCRIPTION
Finding fmt explicitly is not needed since it's handled by spdlog's
CMake files.

Fixes: #691.

What I checked:
1. Built spdlog 1.5 without `SPDLOG_FMT_EXTERNAL`: Gerbera compiles as expected (all fmt stuff comes from `bundled/` folder of spdlog).
2. Built fmt and spdlog with `SPDLOG_FMT_EXTERNAL=ON`. Both were installed into different paths.
When configuring gerbera I (expectedly) got this:
```
CMake Error at /usr/share/cmake-3.13/Modules/CMakeFindDependencyMacro.cmake:48 (find_package):
  Could not find a package configuration file provided by "fmt" with any of
  the following names:

    fmtConfig.cmake
    fmt-config.cmake

  Add the installation prefix of "fmt" to CMAKE_PREFIX_PATH or set "fmt_DIR"
  to a directory containing one of the above files.  If "fmt" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  /home/dev/install-spdlog/usr/local/lib/cmake/spdlog/spdlogConfig.cmake:11 (find_dependency)
  CMakeLists.txt:328 (find_package)
```
to verify that spdlog indeed looks for fmt itself. After fixing search paths I've got Gerbera compiling with flags: `-isystem /home/dev/install-spdlog/usr/local/include -isystem /home/dev/install-fmt/usr/local/include`.

There are 2 things which a bit unclear:
1. Whether to add check for fmt >= 6. It is possible to check for version since both `SPDLOG_FMT_EXTERNAL` and `fmt_VERSION_MAJOR` CMake variables are available (given that both spdlog and fmt are found using Package Config mode), but I think this check should be a part of spdlog (to not violate encapsulation).
2. Gerbera searches for `SPDLOG_LIBRARY` using `find_library` and this will not bring fmt into the scope. However I don't know what is this use-case and it doesn't handle include paths at all and there is not way to check whether fmt was bundled or not. I think this use-case is already broken.