### PR TITLE
Enable editing mime-type for externalUrl (fixes #790)

### DIFF
--- a/gerbera-web/test/client/fixtures/external-url.json
+++ b/gerbera-web/test/client/fixtures/external-url.json
@@ -19,7 +19,7 @@
   },
   "mime-type": {
     "editable": true,
-    "value": "text/plain"
+    "value": "video/ts"
   },
   "protocol": {
     "editable": true,

--- a/gerbera-web/test/client/gerbera.items.spec.js
+++ b/gerbera-web/test/client/gerbera.items.spec.js
@@ -412,6 +412,7 @@ describe('Gerbera Items', () => {
         title: 'title',
         location: 'http://localhost',
         description: 'description',
+        'mime-type': 'video/ts',
         protocol: 'http-get',
         updates: 'check'
       });
@@ -678,6 +679,7 @@ describe('Gerbera Items', () => {
         title: '',
         location: '',
         description: '',
+        'mime-type': '',
         protocol: 'http-get',
         updates: 'check'
       });

--- a/gerbera-web/test/client/jquery.gerbera.editor.spec.js
+++ b/gerbera-web/test/client/jquery.gerbera.editor.spec.js
@@ -262,7 +262,7 @@ describe('The jQuery Gerbera Editor Overlay', () => {
       expect(editLocation.val()).toEqual('http://localhost');
       expect(editClass.val()).toEqual('object.item');
       expect(editDesc.val()).toEqual('description');
-      expect(editMime.val()).toEqual('text/plain');
+      expect(editMime.val()).toEqual('video/ts');
       expect(editActionScript.val()).toEqual('');
       expect(editState.val()).toEqual('');
       expect(editProtocol.val()).toEqual('http-get');
@@ -353,6 +353,7 @@ describe('The jQuery Gerbera Editor Overlay', () => {
         title: 'title',
         location: 'http://localhost',
         description: 'description',
+        'mime-type': 'video/ts',
         protocol: 'http-get'
       });
     });
@@ -441,6 +442,7 @@ describe('The jQuery Gerbera Editor Overlay', () => {
         title: '',
         location: '',
         description: '',
+        'mime-type': '',
         protocol: 'http-get'
       });
     });

--- a/web/js/jquery.gerbera.editor.js
+++ b/web/js/jquery.gerbera.editor.js
@@ -269,7 +269,7 @@
 
     modal.find('#editMime')
       .val(item['mime-type'].value)
-      .prop('disabled', true)
+      .prop('disabled', !item['mime-type'].editable)
       .closest('.form-group').show();
 
     modal.find('#editProtocol')
@@ -366,6 +366,7 @@
           title: editTitle.val(),
           description: editDesc.val(),
           location: editLocation.val(),
+          'mime-type': editMime.val(),
           protocol: editProtocol.val()
         };
         break;
@@ -440,6 +441,7 @@
           title: editTitle.val(),
           description: editDesc.val(),
           location: editLocation.val(),
+          'mime-type': editMime.val(),
           protocol: editProtocol.val()
         };
         break;


### PR DESCRIPTION
Seems a straightforward change in Javascript code. Server code seems capable of changing mime type.
Code is backward compatible with Gerbera 1.4.0