### PR TITLE
Don't override interface flags for spdlog.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,19 +310,31 @@ if (NOT UPNP_HAS_REUSEADDR)
 endif()
 
 find_package(fmt REQUIRED)
-target_link_libraries(gerbera fmt::fmt)
+target_link_libraries(libgerbera fmt::fmt)
 
 # See if it's just installed as a library first, as not all installs have .cmake files
 find_library(SPDLOG_LIBRARY spdlog)
 if(SPDLOG_LIBRARY)
     set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${SPDLOG_LIBRARY})
-    target_link_libraries(gerbera ${SPDLOG_LIBRARY})
+    target_link_libraries(libgerbera ${SPDLOG_LIBRARY})
 else()
     # Didn't find it, so try the .cmake file, fail if not found
     find_package(spdlog REQUIRED)
-    target_link_libraries(gerbera spdlog::spdlog)
+    target_link_libraries(libgerbera spdlog::spdlog)
+
+    if(NOT SPDLOG_FMT_EXTERNAL)
+        message(WARNING [=[
+spdlog is built without SPDLOG_FMT_EXTERNAL.
+Since Gerbera uses fmt library internally the spdlog's bundled version wlll be in conflict
+It is strongly recommended to rebuild spdlog without bundled fmt]=])
+        if(spdlog_VERSION VERSION_GREATER_EQUAL "1.4.0" AND fmt_VERSION VERSION_LESS "6.0.0")
+            message(FATAL_ERROR [=[
+The version of spdlog >= 1.4 bundles fmt version 6, but an older version of fmt was found.
+The current combination won't link.
+Please upgrade fmt or build spdlog with SPDLOG_FMT_EXTERNAL=ON]=])
+        endif()
+    endif()
 endif()
-add_compile_definitions("SPDLOG_FMT_EXTERNAL")
 
 find_package (Pugixml REQUIRED)
 if (PUGIXML_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,14 +312,8 @@ endif()
 find_package(fmt REQUIRED)
 target_link_libraries(libgerbera fmt::fmt)
 
-# See if it's just installed as a library first, as not all installs have .cmake files
-find_library(SPDLOG_LIBRARY spdlog)
-if(SPDLOG_LIBRARY)
-    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${SPDLOG_LIBRARY})
-    target_link_libraries(libgerbera ${SPDLOG_LIBRARY})
-else()
-    # Didn't find it, so try the .cmake file, fail if not found
-    find_package(spdlog REQUIRED)
+find_package(spdlog)
+if(spdlog_FOUND)
     target_link_libraries(libgerbera spdlog::spdlog)
 
     if(NOT SPDLOG_FMT_EXTERNAL)
@@ -333,6 +327,14 @@ The version of spdlog >= 1.4 bundles fmt version 6, but an older version of fmt 
 The current combination won't link.
 Please upgrade fmt or build spdlog with SPDLOG_FMT_EXTERNAL=ON]=])
         endif()
+    endif()
+else()
+    # See if it's just installed as a library, as not all installs have .cmake files
+    find_library(SPDLOG_LIBRARY spdlog)
+    if(SPDLOG_LIBRARY)
+        target_link_libraries(libgerbera ${SPDLOG_LIBRARY})
+    else()
+        message(FATAL_ERROR "spdlog library is required")
     endif()
 endif()
 

--- a/scripts/install-spdlog.sh
+++ b/scripts/install-spdlog.sh
@@ -18,6 +18,6 @@ if [ -d build ]; then
 fi
 mkdir build
 cd build && \
-cmake .. && \
+cmake .. -DSPDLOG_FMT_EXTERNAL=ON && \
 make spdlog && \
 make install/fast


### PR DESCRIPTION
Finding fmt explicitly is not needed since it's handled by spdlog's
CMake files.

Fixes: #691.