### PR TITLE
Always scan inotify autoscan locations after startup

### DIFF
--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -260,6 +260,10 @@ void ContentManager::run()
             std::shared_ptr<AutoscanDirectory> dir = autoscan_inotify->get(i);
             if (dir != nullptr)
                 inotify->monitor(dir);
+
+            auto param = std::make_shared<Timer::Parameter>(Timer::Parameter::timer_param_t::IDAutoscan, dir->getScanID());
+            log_debug("Adding one-shot inotify scan");
+            timer->addTimerSubscriber(this, 60, param, true);
         }
     }
 #endif


### PR DESCRIPTION
This avoids gaps and handles the initial state as well.  Fixes https://github.com/gerbera/gerbera/issues/763