### PR TITLE
Ensure all xml-namespaces are declared (fixes #819)

### DIFF
--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -166,7 +166,7 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     didl_lite_root.append_attribute(XML_NAMESPACE_ATTR) = XML_DIDL_LITE_NAMESPACE;
     didl_lite_root.append_attribute(XML_DC_NAMESPACE_ATTR) = XML_DC_NAMESPACE;
     didl_lite_root.append_attribute(XML_UPNP_NAMESPACE_ATTR) = XML_UPNP_NAMESPACE;
-    request->GetQuirks()->appendSpecialNamespace(&didl_lite_root);
+    didl_lite_root.append_attribute(XML_SEC_NAMESPACE_ATTR) = XML_SEC_NAMESPACE;
 
     auto searchParam = std::make_unique<SearchParam>(containerID, searchCriteria,
         std::stoi(startingIndex, nullptr), std::stoi(requestedCount, nullptr));

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -114,7 +114,6 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     didl_lite_root.append_attribute(XML_DC_NAMESPACE_ATTR) = XML_DC_NAMESPACE;
     didl_lite_root.append_attribute(XML_UPNP_NAMESPACE_ATTR) = XML_UPNP_NAMESPACE;
     didl_lite_root.append_attribute(XML_SEC_NAMESPACE_ATTR) = XML_SEC_NAMESPACE;
-    //request->GetQuirks()->appendSpecialNamespace(&didl_lite_root);
 
     for (const auto& obj : arr) {
         if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_ENABLED) && obj->getFlag(OBJECT_FLAG_PLAYED)) {

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -113,7 +113,8 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     didl_lite_root.append_attribute(XML_NAMESPACE_ATTR) = XML_DIDL_LITE_NAMESPACE;
     didl_lite_root.append_attribute(XML_DC_NAMESPACE_ATTR) = XML_DC_NAMESPACE;
     didl_lite_root.append_attribute(XML_UPNP_NAMESPACE_ATTR) = XML_UPNP_NAMESPACE;
-    request->GetQuirks()->appendSpecialNamespace(&didl_lite_root);
+    didl_lite_root.append_attribute(XML_SEC_NAMESPACE_ATTR) = XML_SEC_NAMESPACE;
+    //request->GetQuirks()->appendSpecialNamespace(&didl_lite_root);
 
     for (const auto& obj : arr) {
         if (config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_ENABLED) && obj->getFlag(OBJECT_FLAG_PLAYED)) {

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -72,11 +72,3 @@ void Quirks::addCaptionInfo(std::shared_ptr<CdsItem> item, std::unique_ptr<Heade
     std::string url = "http://" + Server::getIP() + ":" + Server::getPort() + pathNoExt + validext;
     headers->addHeader("CaptionInfo.sec:", url);
 }
-
-void Quirks::appendSpecialNamespace(pugi::xml_node* didlLiteRoot)
-{
-    if ((pClientInfo->flags & QUIRK_FLAG_SAMSUNG) == 0)
-        return;
-
-    didlLiteRoot->append_attribute(XML_SEC_NAMESPACE_ATTR) = XML_SEC_NAMESPACE;
-}

--- a/src/util/upnp_quirks.h
+++ b/src/util/upnp_quirks.h
@@ -50,10 +50,6 @@ public:
     // To be more compliant with original Samsung server we should check for getCaptionInfo.sec: 1 request header.
     void addCaptionInfo(std::shared_ptr<CdsItem> item, std::unique_ptr<Headers>& headers);
 
-    // add additional headers in DIDL-Lite when doing doBrowse or doSearch
-    // currentlly used for Samsung
-    void appendSpecialNamespace(pugi::xml_node* parent);
-
 private:
     std::shared_ptr<Config> config;
     const ClientInfo* pClientInfo;


### PR DESCRIPTION
Namespace is still used in UpnpXMLBuilder::renderCaptionInfo for videos.