### PR TITLE
Avoid server abort when tracknumber starts with non-digit character

### DIFF
--- a/src/scripting/script.cc
+++ b/src/scripting/script.cc
@@ -393,7 +393,7 @@ std::shared_ptr<CdsObject> Script::dukObject2cdsObject(const std::shared_ptr<Cds
             val = getProperty(MT_KEYS[i].upnp);
             if (!val.empty()) {
                 if (i == M_TRACKNUMBER) {
-                    int j = std::stoi(val);
+                    int j = stoi_string(val, 0);
                     if (j > 0) {
                         obj->setMetadata(MT_KEYS[i].upnp, val);
                         std::static_pointer_cast<CdsItem>(obj)->setTrackNumber(j);

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -140,7 +140,7 @@ std::string tolower_string(std::string str)
 
 int stoi_string(const std::string& str, int def)
 {
-    if (str.empty())
+    if (str.empty() || !std::isdigit(*str.c_str()))
         return def;
 
     return std::stoi(str);


### PR DESCRIPTION
If tracknumber starts with an non-digit character std::stoi throws an std::invalid_argument exception.

Moved the check to the existing tools function "stoi_string" making it available for other places with same issues.