### PR TITLE
Add title param to external transcoder

### DIFF
--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -118,7 +118,7 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::open(std::shared_ptr<Transc
         std::vector<std::string> sop_args;
         int p1 = find_local_port(45000, 65500);
         int p2 = find_local_port(45000, 65500);
-        sop_args = populateCommandLine(location + " " + std::to_string(p1) + " " + std::to_string(p2), nullptr, nullptr, nullptr);
+        sop_args = populateCommandLine(location + " " + std::to_string(p1) + " " + std::to_string(p2));
         auto spsc = std::make_shared<ProcessExecutor>("sp-sc-auth", sop_args);
         auto pr_item = std::make_shared<ProcListItem>(spsc);
         proc_list.push_back(pr_item);
@@ -189,7 +189,7 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::open(std::shared_ptr<Transc
 
     chmod(fifo_name.c_str(), S_IWUSR | S_IRUSR);
 
-    arglist = populateCommandLine(profile->getArguments(), location, fifo_name, range);
+    arglist = populateCommandLine(profile->getArguments(), location, fifo_name, range, obj->getTitle());
 
     log_debug("Command: {}", profile->getCommand().c_str());
     log_debug("Arguments: {}", profile->getArguments().c_str());

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -998,9 +998,13 @@ bool validateYesNo(const std::string& value)
     return !((value != "yes") && (value != "no"));
 }
 
-std::vector<std::string> populateCommandLine(const std::string& line, const std::string& in, const std::string& out, const std::string& range)
+std::vector<std::string> populateCommandLine(const std::string& line,
+    const std::string& in,
+    const std::string& out,
+    const std::string& range,
+    const std::string& title)
 {
-    log_debug("Template: '{}', in: '{}', out: '{}', range: '{}'", line, in, out, range);
+    log_debug("Template: '{}', in: '{}', out: '{}', range: '{}', title: '{}'", line, in, out, range, title);
     std::vector<std::string> params = split_string(line, ' ');
     if (in.empty() && out.empty())
         return params;
@@ -1018,7 +1022,12 @@ std::vector<std::string> populateCommandLine(const std::string& line, const std:
 
         size_t rangePos = param.find("%range");
         if (rangePos != std::string::npos) {
-            std::string newParam = param.replace(rangePos, 5, range);
+            std::string newParam = param.replace(rangePos, 6, range);
+        }
+
+        size_t titlePos = param.find("%title");
+        if (titlePos != std::string::npos) {
+            std::string newParam = param.replace(titlePos, 6, title);
         }
     }
 

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -303,9 +303,10 @@ bool validateYesNo(const std::string& value);
 /// strings.
 /// \todo add escaping
 std::vector<std::string> populateCommandLine(const std::string& line,
-    const std::string& in,
-    const std::string& out,
-    const std::string& range);
+    const std::string& in = "",
+    const std::string& out = "",
+    const std::string& range = "",
+    const std::string& title = "");
 
 /// \brief this is the mkstemp routine from glibc, the only difference is that
 /// it does not return an fd but just the name that we could use.


### PR DESCRIPTION
This allows us to pass metadata from the import script to the transcoder via the object title.  It's not much, but it's enough to e.g. signal a resume offset for otherwise non-seekable content.

Also, fix a string length bug that was corrupting the range parameter