### PR TITLE
Call to getnameinfo needs to use the size of the actual address struct

### DIFF
--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -1303,8 +1303,9 @@ std::string sockAddrGetNameInfo(const struct sockaddr* sa)
 {
     char hoststr[NI_MAXHOST];
     char portstr[NI_MAXSERV];
-
-    int ret = getnameinfo(sa, sizeof(struct sockaddr), hoststr, sizeof(hoststr), portstr, sizeof(portstr), NI_NUMERICHOST | NI_NUMERICSERV);
+    int len = sa->sa_family == AF_INET6 ? sizeof(struct sockaddr_in6) :
+      sizeof(struct sockaddr_in);
+    int ret = getnameinfo(sa, len, hoststr, sizeof(hoststr), portstr, sizeof(portstr), NI_NUMERICHOST | NI_NUMERICSERV);
     if (ret != 0) {
         throw_std_runtime_error("could not determine getnameinfo (" + mt_strerror(errno) + ")");
     }


### PR DESCRIPTION
 sizeof(struct sockaddr_in6) > sizeof(struct sockaddr)