### PR TITLE
doc change: ffmpeg metadata extraction facilites

### DIFF
--- a/doc/config-import.rst
+++ b/doc/config-import.rst
@@ -431,11 +431,11 @@ Here is some information on the auxdata: UPnP defines certain tags to pass along
 (like title, artist, year, etc.), however some media provides more metadata and exceeds the scope of UPnP.
 This additional metadata can be used to fine tune the server layout, it allows the user to create a more
 complex container structure using a customized import script. The metadata that can be extracted depends on the
-library, currently we support libebexif which provides a default set of keys that can be passed in the options below.
-The data according to those keys will the be extracted from the media and imported into the database along with the item.
-When processing the item, the import script will have full access to the gathered metadata, thus allowing the
-user to organize the data with the use of the extracted information. A practical example would be: if have more
-than one digital camera in your family you could extract the camera model from the Exif tags and sort your photos
+library, currently we support **taglib** (or id3lib if absent), **ffmpeg and libexif** which provide a default set of keys 
+that can be passed in the options below. The data according to those keys will the be extracted from the media and imported 
+into the database along with the item. When processing the item, the import script will have full access to the gathered 
+metadata, thus allowing the user to organize the data with the use of the extracted information. A practical example would be: 
+having more than one digital camera in your family you could extract the camera model from the Exif tags and sort your photos
 in a structure of your choice, like:
 
 - Photos/MyCamera1/All Photos
@@ -521,22 +521,23 @@ These options apply to id3lib or taglib libraries.
 
 * Optional
 
-Currently only adding keywords to auxdata is supported. The keywords are those defined in the id3 specification,
-we do not perform any extra checking, so you could try to use any string as a keyword - if it does not exist in the tag nothing bad will happen.
+Currently only adding keywords to auxdata is supported. The keywords are those defined in the specifications, e.g. 
+`ID3v2.4 <https://id3.org/id3v2.4.0-frames>`_ or `Vorbis comments. <https://www.xiph.org/vorbis/doc/v-comment.htm>`_
+We do not perform any extra checking, so you could try to use any string as a keyword - if it does not exist in the tag 
+nothing bad will happen.
 
-Here is a list of some possible keywords:
+Here is a list of some extra keywords not beeing part of UPnP:
 
-* ID3v2 / MP3
+* ID3v2.4 / MP3
 
-TALB, TBPM, TCOM, TCON, TCOP, TDAT, TDLY, TENC, TEXT, TFLT, TIME, TIT1, TIT2, TIT3, TKEY, TLAN, TLEN, TMED, TOAL,
-TOFN, TOLY, TOPE, TORY, TOWN, TPE1, TPE2, TPE3, TPE4, TPOS, TPUB, TRCK, TRDA, TRSN, TRSO, TSIZ, TSRC, TSSE, TYER, 
-TXXX:CATALOGNUMBER, TXXX:MusicBrainz Album Type, ...
+TBPM, TCOP, TDLY, TENC, TEXT, TFLT, TIT1, TIT3, TKEY, TLAN, TLEN, TMCL, TMED, TOAL,
+TOFN, TOLY, TOPE, TOWN, TPE4, TPOS, TPUB, TRSN, TRSO, TSOA, TSRC, TSSE, TXXX:Artist, TXXX:Work, ...
 
 * Vorbis / FLAC
 
-ALBUMSORT, COMPOSER, ENCODEDBY, MUSICBRAINZ_ARTISTID, CATALOGNUMBER, RELEASETYPE, ...
+ALBUMSORT, ARTISTS, CATALOGNUMBER, COMPOSERSORT, ENCODEDBY, LYRICIST, ORIGINALDATE, PRODUCER, RELEASETYPE, REMIXER, TITLESORT, WORK, ...
 
-* any other user defined keyword, e.g. for APEv2 or iTunes MP4
+* any other user defined keyword, for APEv2 or iTunes MP4, see e.g. `table of mapping <https://picard.musicbrainz.org/docs/mappings>`_ between various tagging formats at MusicBrainz.
 
  **Child tags:**
 
@@ -545,10 +546,10 @@ ALBUMSORT, COMPOSER, ENCODEDBY, MUSICBRAINZ_ARTISTID, CATALOGNUMBER, RELEASETYPE
 
 .. code-block:: xml
 
-    <add-data tag="TCOM"/>
-    <add-data tag="COMPOSER"/>
-    <add-data tag="TENC"/>
-    <add-data tag="ENCODEDBY"/>
+    <add-data tag="TXXX:Work"/>
+    <add-data tag="WORK"/>
+    <add-data tag="TMCL"/>
+    <add-data tag="PERFORMER"/>
     ...
 
 * Optional
@@ -562,10 +563,67 @@ A sample configuration for the example described above would be:
 
   <id3>
       <auxdata>
-          <add-data tag="TCOM"/>
-          <add-data tag="COMPOSER"/>
-          <add-data tag="TENC"/>
-          <add-data tag="ENCODEDBY"/>
+          <add-data tag="TXXX:Work"/>
+          <add-data tag="WORK"/>
+          <add-data tag="TMCL"/>
+          <add-data tag="PERFORMER"/>
       </auxdata>
   </id3>
+
+
+``ffmpeg``
+----------
+
+.. code-block:: xml
+
+  <ffmpeg>
+
+* Optional
+
+These options apply to ffmpeg libraries.
+
+**Child tags:**
+
+``auxdata``
+-----------
+
+.. code-block:: xml
+
+     <auxdata>
+
+* Optional
+
+Currently only adding keywords to auxdata is supported. `This page <https://wiki.multimedia.cx/index.php?title=FFmpeg_Metadata>`_ 
+documents all of the metadata keys that FFmpeg honors, depending on the format being encoded.
+
+ **Child tags:**
+
+``add-data``
+------------
+
+.. code-block:: xml
+
+    <add-data tag="COLLECTION"/>
+    <add-data tag="SHOW"/>
+    <add-data tag="NETWORK"/>
+    <add-data tag="EPISODE-ID"/>
+    ...
+
+* Optional
+
+If the library was able to extract the data according to the given keyword, it will be added to auxdata.
+You can then use that data in your import scripts.
+
+A sample configuration for the example described above would be:
+
+.. code-block:: xml
+
+  <ffmpeg>
+      <auxdata>
+          <add-data tag="COLLECTION"/>
+          <add-data tag="SHOW"/>
+          <add-data tag="NETWORK"/>
+          <add-data tag="EPISODE-ID"/>
+      </auxdata>
+  </ffmpeg>
 

--- a/doc/scripting.rst
+++ b/doc/scripting.rst
@@ -150,7 +150,7 @@ object.
     **RW**
 
     This is the title of the original object, since the object represents an entry in the PC-Directory, the title will be
-    set to it's file name. This field corresponds to dc:title in the DIDL-Lite XML.
+    set to it's file name. This field corresponds to ``dc:title`` in the DIDL-Lite XML.
 
 .. js:attribute:: orig.id
 
@@ -238,7 +238,7 @@ object.
 
         **RW**
 
-        Date, must be in the format of **YYYY-MM-DD** (required by the UPnP spec), this corresponds to dc:date in the
+        Date, must be in the format of **YYYY-MM-DD** (required by the UPnP spec), this corresponds to ``dc:date`` in the
         DIDL-Lite XML.
 
 
@@ -282,36 +282,39 @@ object.
 
         **RW**
 
-        Director of the media, this corresponds to ``dc:publisher`` in the DIDL-Lite XML.
+        Publisher of the media, this corresponds to ``dc:publisher`` in the DIDL-Lite XML.
 
     .. js:attribute:: orig.meta[M_RATING]
 
         **RW**
     
-        Director of the media, this corresponds to ``upnp:rating`` in the DIDL-Lite XML.
+        Rating of the media, this corresponds to ``upnp:rating`` in the DIDL-Lite XML.
 
     .. js:attribute:: orig.meta[M_ACTOR]
 
         **RW**
     
-        Director of the media, this corresponds to ``upnp:actor`` in the DIDL-Lite XML.
+        Actor of the media, this corresponds to ``upnp:actor`` in the DIDL-Lite XML.
 
     .. js:attribute:: orig.meta[M_PRODUCER]
 
         **RW**
 
-        Director of the media, this corresponds to ``upnp:producer`` in the DIDL-Lite XML.
+        Producer of the media, this corresponds to ``upnp:producer`` in the DIDL-Lite XML.
 
 .. js:attribute:: orig.aux
 
     **RO**
 
-    Array holding the so called auxiliary data. Aux data is metadata that is not part of UPnP, for example -
-    this can be a camera model that was used to make a photo, or the information if the photo was taken with or without flash.
+    Array holding the so called auxiliary data. Aux data is metadata that is not part of UPnP, for example - this 
+    can be a musical work, its performing artists and their instruments, the name of a personal video collection 
+    and the episode-ID of a TV show, a camera model that was used to make a photo, or the information if the photo 
+    was taken with or without flash.
 
 
-    Currently aux data can be gathered from **libexif** (see the Import section in the main
-    documentation for more details). So, this array will hold the tags that you specified in your config.xml, allowing
+    Currently aux data can be gathered from **taglib** (or id3lib if absent), **ffmpeg and libexif** (see the 
+    `Import section <http://docs.gerbera.io/en/latest/config-import.html?#library-options>`_ in the main documentation for 
+    more details). So, this array will hold the tags that you specified in your config.xml, allowing
     you to create your virtual structure according to your liking.
 
 .. js:attribute:: orig.playlistOrder
@@ -401,7 +404,7 @@ within the import and/or the playlist script:
         All Music container in the server hierarchy. Make sure to properly escape the slash characters in container
         names. You will find more information on container chain escaping later in this chapter.
     :param string lastContainerClass:
-        A string, defining the upnp:class of the container that appears last in the chain. This parameter can be
+        A string, defining the ``upnp:class`` of the container that appears last in the chain. This parameter can be
         omitted, in this case the default value ``object.container`` will be taken. Setting specific upnp container classes
         is useful to define the special meaning of a particular container; for example, the server will always sort
         songs by track number if upnp class of a container is set to ``object.container.album.musicAlbum``.
@@ -563,7 +566,7 @@ Audio Content Handler
 :::::::::::::::::::::
 
 The biggest one is the function that handles audio - the reason
-is simple: mp3 files offer a lot of metadata like album,
+is simple: flac and mp3 files offer a lot of metadata like album,
 artist, genre, etc. information, this allows us to create a
 nice container layout.
 
@@ -571,6 +574,15 @@ nice container layout.
     :start-after: // doc-add-audio-begin
     :end-before: // doc-add-audio-end
     :language: js
+
+Most music file taggers can handle additional metadata that is not part of UPnP, so you could add code to present your music to the
+renderer by musical works, their different interpretations, and the performing artists.
+
+.. Note::
+
+    if you want to use those additional metadata you need to compile Gerbera with taglib support and also
+    specify the fields of interest in the import section of your configuration file
+    (See documentation about library-options).
 
 
 Image Content Handler
@@ -582,7 +594,7 @@ or anything Exif field you might be interested in.
 
 .. Note::
 
-    if you want to use those additional Exif fields you need to compile MediaTomb with libexif support and also
+    if you want to use those additional Exif fields you need to compile Gerbera with libexif support and also
     specify the fields of interest in the import section of your configuration file
     (See documentation about library-options).
 
@@ -601,6 +613,12 @@ Not much to say here... I think libextractor is capable of retrieving some infor
 encountered any video files populated with metadata. You could also try ffmpeg to get more information, however by default we
 keep it very simple - we just put everything into the 'All Video' container.
 
+.. Note::
+
+    if you want to use additional metadata fields you need to compile Gerbera with ffmpeg support and also
+    specify the fields of interest in the import section of your configuration file
+    (See documentation about library-options).
+
 .. literalinclude:: ../scripts/js/import.js
     :start-after: // doc-add-video-begin
     :end-before: // doc-add-video-end
@@ -610,7 +628,7 @@ keep it very simple - we just put everything into the 'All Video' container.
 Apple Trailers Content Handler
 ::::::::::::::::::::::::::::::
 
-This function processes items that are importent via the Apple Trailers feature. We will organize the trailers by genre, post
+This function processes items that are imported via the Apple Trailers feature. We will organize the trailers by genre, post
 date and release date, additionally we will also add a container holding all trailers.
 
 .. literalinclude:: ../scripts/js/import.js

--- a/doc/scripting.rst
+++ b/doc/scripting.rst
@@ -312,7 +312,7 @@ object.
     was taken with or without flash.
 
 
-    Currently aux data can be gathered from **taglib** (or id3lib if absent), **ffmpeg and libexif** (see the 
+    Currently aux data can be gathered from **taglib, ffmpeg and libexif** (see the 
     `Import section <http://docs.gerbera.io/en/latest/config-import.html?#library-options>`_ in the main documentation for 
     more details). So, this array will hold the tags that you specified in your config.xml, allowing
     you to create your virtual structure according to your liking.


### PR DESCRIPTION
config-import:
added taglib and ffmpeg libraries for metadata extraction usage
added example for ffmpeg auxdata configuration
removed tags from the examples that are part of UPnP 
removed tags from the examples that are not part of ID3v2.4

scripting:
added taglib and ffmpeg libraries for metadata extraction usage
fixed some copy/paste, formatting, and spell errors