### PR TITLE
Propagate layout init errors

### DIFF
--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -1147,10 +1147,10 @@ void ContentManager::initLayout()
 
     if (layout == nullptr) {
         AutoLock lock(mutex);
-        if (layout == nullptr)
+        if (layout == nullptr) {
+            std::string layout_type = config->getOption(CFG_IMPORT_SCRIPTING_VIRTUAL_LAYOUT_TYPE);
+            auto self = shared_from_this();
             try {
-                std::string layout_type = config->getOption(CFG_IMPORT_SCRIPTING_VIRTUAL_LAYOUT_TYPE);
-                auto self = shared_from_this();
                 if (layout_type == "js") {
 #ifdef HAVE_JS
                     layout = std::make_shared<JSLayout>(config, storage, self, scripting_runtime);
@@ -1163,7 +1163,10 @@ void ContentManager::initLayout()
             } catch (const std::runtime_error& e) {
                 layout = nullptr;
                 log_error("ContentManager virtual container layout: {}", e.what());
+                if (layout_type != "disabled")
+                    throw e;
             }
+        }
     }
 }
 


### PR DESCRIPTION
If we ignore these errors, the following can happen:
1. The layout type fails initialization
2. An object is added
3. The object is not added to the virtual layout

After this happens, the object will never again have an opportunity
to be added to the virtual layout unless it is manually deleted
from the database.  This could be observed while developing the
JS import script, for example.

By propagating failure, we ensure that adding the object will fail
and will thus be reattempted later.