### PR TITLE
Fix incomplete type iohandler with Ninja generator

### DIFF
--- a/src/metadata/ffmpeg_handler.h
+++ b/src/metadata/ffmpeg_handler.h
@@ -41,6 +41,7 @@
 #include <filesystem>
 namespace fs = std::filesystem;
 
+#include "iohandler/io_handler.h"
 #include "metadata_handler.h"
 
 // forward declaration


### PR DESCRIPTION
error: invalid application of ‘sizeof’ to incomplete type ‘IOHandler’