### PR TITLE
getAutoscanDirectory may return nullptr

### DIFF
--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -680,7 +680,9 @@ void ContentManager::_rescanDirectory(std::shared_ptr<AutoscanDirectory> adir, c
                     list->erase(objectID);
                 // add a task to rescan the directory that was found
                 auto adir2 = getAutoscanDirectory(objectID);
-                rescanDirectory(adir2, newPath, task->isCancellable());
+                if (adir2) {
+                    rescanDirectory(adir2, newPath, task->isCancellable());
+                }
             } else {
                 // we have to make sure that we will never add a path to the task list
                 // if it is going to be removed by a pending remove task.


### PR DESCRIPTION
`gsl::not_null` anyone? :D

Looks like handling of this `adir` is just patched up whenever a problem comes... For example, why can `CMRescanDirectoryTask` be constructed with `nullptr` if it will do nothing in `run()`? I don't see anyone touches it...