### PR TITLE
fix compilation with libcxx

### DIFF
--- a/src/web/clients.cc
+++ b/src/web/clients.cc
@@ -41,7 +41,7 @@ web::clients::clients(std::shared_ptr<Config> config, std::shared_ptr<Storage> s
 std::string steady_clock_to_string(std::chrono::steady_clock::time_point t)
 {
     auto systime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()
-        + (t - std::chrono::steady_clock::now()));
+        + std::chrono::duration_cast<std::chrono::system_clock::duration>(t - std::chrono::steady_clock::now()));
     return trim_string(std::asctime(std::localtime(&systime)));
 }
 


### PR DESCRIPTION
A duration cast is missing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Fixes: https://github.com/gerbera/gerbera/issues/880