### PR TITLE
add missing reference for loop

### DIFF
--- a/src/web/clients.cc
+++ b/src/web/clients.cc
@@ -55,7 +55,7 @@ void web::clients::process()
 
     auto arr = Clients::getClientList();
 
-    for (const auto obj : *arr) {
+    for (const auto& obj : *arr) {
         auto item = clients.append_child("client");
         auto ip = sockAddrGetNameInfo((const struct sockaddr*)&obj.addr);
         item.append_attribute("ip") = ip.c_str();


### PR DESCRIPTION
Found with clang's -Wrange-loop-analysis:

src/web/clients.cc:58:21: warning: loop variable 'obj' of type
'const ClientCacheEntry' creates a copy from type 'const ClientCacheEntry'
[-Wrange-loop-construct]

Signed-off-by: Rosen Penev <rosenp@gmail.com>