### PR TITLE
Adding external URL blocked by irRegularFile

### DIFF
--- a/src/cds_objects.cc
+++ b/src/cds_objects.cc
@@ -178,6 +178,9 @@ void CdsItem::validate()
     if (this->location.empty())
         throw_std_runtime_error("Item validation failed: missing location");
 
+    if (IS_CDS_ITEM_EXTERNAL_URL(objectType) || IS_CDS_ITEM_INTERNAL_URL(objectType))
+        return;
+
     std::error_code ec;
     if (!isRegularFile(location, ec))
         throw_std_runtime_error("Item validation failed: file " + location.string() + " not found");


### PR DESCRIPTION
When adding an external URL (internal as well) it is blocked by CdsItem::validate because there is no local file. The old "check_file" required a force param to return false which was not set.

This issue is also addressed in #841 (including other things)