### PR TITLE
Metadata comparison does not work

### DIFF
--- a/src/cds_objects.cc
+++ b/src/cds_objects.cc
@@ -81,7 +81,7 @@ int CdsObject::equals(const std::shared_ptr<CdsObject>& obj, bool exactly)
     if (!resourcesEqual(obj))
         return 0;
 
-    if (!std::equal(metadata.begin(), metadata.end(), obj->getMetadata().begin()))
+    if (metadata != obj->getMetadata())
         return 0;
 
     if (exactly


### PR DESCRIPTION
Changing description after object creation was not possible anymore (another issue discover alongside #897). 
== operatior for map should do what we want:
`Checks if the contents of lhs and rhs are equal, that is, they have the same number of elements and each element in lhs compares equal with the element in rhs at the same position`