### PR TITLE
 use {} for cd

### DIFF
--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -42,7 +42,7 @@ StringConverter::StringConverter(const std::string& from, const std::string& to)
     dirty = false;
 
     if (!cd) {
-        cd = 0;
+        cd = {};
         throw_std_runtime_error(std::string("iconv: ") + strerror(errno));
     }
 }


### PR DESCRIPTION
iconv_t can be a pointer or an int. Normally the former but sometimes
the latter.

Silences warnings about using nullptr.

Signed-off-by: Rosen Penev <rosenp@gmail.com>