### PR TITLE
FIxed comparison to wrong object.

### DIFF
--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -245,13 +245,10 @@ std::vector<std::shared_ptr<SQLStorage::AddUpdateTable>> SQLStorage::_addUpdateO
     //else if (isUpdate)
     //    cdsObjectSql["dc_title"] = SQL_NULL;
 
-    auto dict = obj->getMetadata();
-
     if (isUpdate)
         cdsObjectSql["auxdata"] = SQL_NULL;
-    dict = obj->getAuxData();
-    if (!dict.empty() && (!hasReference || !std::equal(dict.begin(), dict.end(), refObj->getAuxData().begin()))) {
-        cdsObjectSql["auxdata"] = quote(dict_encode(obj->getAuxData()));
+    if (auto auxData = obj->getAuxData(); !auxData.empty() && (!hasReference || auxData != refObj->getAuxData())) {
+        cdsObjectSql["auxdata"] = quote(dict_encode(auxData));
     }
 
     if (!hasReference || (!obj->getFlag(OBJECT_FLAG_USE_RESOURCE_REF) && !refObj->resourcesEqual(obj))) {
@@ -354,7 +351,7 @@ std::vector<std::shared_ptr<SQLStorage::AddUpdateTable>> SQLStorage::_addUpdateO
     returnVal.push_back(
         std::make_shared<AddUpdateTable>(CDS_OBJECT_TABLE, cdsObjectSql, isUpdate ? "update" : "insert"));
 
-    if (!hasReference || !std::equal(dict.begin(), dict.end(), refObj->getMetadata().begin())) {
+    if (!hasReference || obj->getMetadata() != refObj->getMetadata()) {
         generateMetadataDBOperations(obj, isUpdate, returnVal);
     }
 


### PR DESCRIPTION
When exploring how metadata is stored and used found that in a751fea028a025f50a18e658d455e4d49a1a0128 code was torn apart and essentially metadata was compared with aux data.
Also calling `std::equal` without range check is dangerous and just not needed.