### PR TITLE
Load multivalue tags if supported instead of first item

### DIFF
--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -408,10 +408,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
     for (const auto& desiredFrame : aux_tags_list) {
 
         if (desiredFrame.empty()) {
-            continue;
-        }
-
-        if (frameListMap.contains(desiredFrame.c_str())) {
+        } else if (frameListMap.contains(desiredFrame.c_str())) {
             const auto frameList = frameListMap[desiredFrame.c_str()];
             if (frameList.isEmpty())
                 continue;
@@ -428,10 +425,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
             }
             log_debug("Adding auxdata: {} with value {}", desiredFrame.c_str(), value.c_str());
             item->setAuxData(desiredFrame, value);
-            continue;
-        }
-
-        if (hasTXXXFrames && startswith(desiredFrame, "TXXX:")) {
+        } else if (hasTXXXFrames && startswith(desiredFrame, "TXXX:")) {
             const auto frameList = frameListMap["TXXX"];
             //log_debug("TXXX Frame list has {} elements", frameList.size());
 

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -326,14 +326,29 @@ static const char* HEX_CHARS2 = "0123456789ABCDEF";
 std::string url_escape(const std::string& str)
 {
     std::ostringstream buf;
-    for (auto c : str) {
+    for (size_t i = 0; i < str.length();) {
+        auto c = str[i];
+        int cplen = 1;
+        if ((c & 0xf8) == 0xf0)
+            cplen = 4;
+        else if ((c & 0xf0) == 0xe0)
+            cplen = 3;
+        else if ((c & 0xe0) == 0xc0)
+            cplen = 2;
+        if ((i + cplen) > str.length())
+            cplen = 1;
+
         if ((c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_' || c == '-') {
             buf << static_cast<char>(c);
         } else {
             int hi = c >> 4;
             int lo = c & 15;
-            buf << '%' << HEX_CHARS2[hi] << HEX_CHARS2[lo];
+            if (cplen > 1)
+                buf << str.substr(i, cplen);
+            else
+                buf << '%' << HEX_CHARS2[hi] << HEX_CHARS2[lo];
         }
+        i += cplen;
     }
     return buf.str();
 }


### PR DESCRIPTION
Use toString() method from TagLib to get all item instead of first.

Also contains a fix for url_encode which failed with multi-byte UTF-8 characters.

This should fix #758, #759 