### PR TITLE
fixed mime type retrieval for symlinks with libmagic

### DIFF
--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -1095,7 +1095,7 @@ std::shared_ptr<CdsObject> ContentManager::createObjectFromFile(const fs::path& 
                 if (ignore_unknown_extensions)
                     return nullptr; // item should be ignored
 #ifdef HAVE_MAGIC
-                mimetype = getMIMETypeFromFile(path);
+                mimetype = getMIMETypeFromFile(path, config->getBoolOption(CFG_IMPORT_FOLLOW_SYMLINKS));
 #endif
             }
         }

--- a/src/serve_request_handler.cc
+++ b/src/serve_request_handler.cc
@@ -79,7 +79,7 @@ void ServeRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     {
         std::string mimetype = MIMETYPE_DEFAULT;
 #ifdef HAVE_MAGIC
-        std::string mime = getMIMETypeFromFile(path);
+        std::string mime = getMIMETypeFromFile(path, config->getBoolOption(CFG_IMPORT_FOLLOW_SYMLINKS));
         if (!mime.empty())
             mimetype = mime;
 #endif // HAVE_MAGIC
@@ -137,7 +137,7 @@ std::unique_ptr<IOHandler> ServeRequestHandler::open(const char* filename,
     {
         std::string mimetype = MIMETYPE_DEFAULT;
 #ifdef HAVE_MAGIC
-        std::string mime = getMIMETypeFromFile(path);
+        std::string mime = getMIMETypeFromFile(path, config->getBoolOption(CFG_IMPORT_FOLLOW_SYMLINKS));
         if (!mime.empty())
             mimetype = mime;
 #endif // HAVE_MAGIC

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -631,20 +631,22 @@ int HMSToSeconds(const std::string& time)
 }
 
 #ifdef HAVE_MAGIC
-std::string getMIMETypeFromFile(const fs::path& file)
+std::string getMIMETypeFromFile(const fs::path& file, bool allowSymlinks)
 {
-    return getMIME(file, nullptr, -1);
+    return getMIME(file, nullptr, -1, allowSymlinks);
 }
 
 std::string getMIMETypeFromBuffer(const void* buffer, size_t length)
 {
-    return getMIME("", buffer, length);
+    return getMIME("", buffer, length, false);
 }
 
-std::string getMIME(const fs::path& filepath, const void* buffer, size_t length)
+std::string getMIME(const fs::path& filepath, const void* buffer, size_t length, bool allowSymlinks)
 {
+    int magicFlags = allowSymlinks ? MAGIC_MIME_TYPE | MAGIC_SYMLINK : MAGIC_MIME_TYPE;
+
     /* MAGIC_MIME_TYPE tells magic to return ONLY the mimetype */
-    magic_t magic_cookie = magic_open(MAGIC_MIME_TYPE);
+    magic_t magic_cookie = magic_open(magicFlags);
 
     if (magic_cookie == nullptr) {
         log_warning("Failed to initialize libmagic");

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -203,11 +203,11 @@ int HMSToSeconds(const std::string& time);
 
 #ifdef HAVE_MAGIC
 /// \brief Extracts mimetype from a file using filemagic
-std::string getMIMETypeFromFile(const fs::path& file);
+std::string getMIMETypeFromFile(const fs::path& file, bool allowSymlinks);
 /// \brief Extracts mimetype from a buffer using filemagic
 std::string getMIMETypeFromBuffer(const void* buffer, size_t length);
 /// \brief Extracts mimetype from a filepath OR buffer using filemagic
-std::string getMIME(const fs::path& filepath, const void* buffer, size_t length);
+std::string getMIME(const fs::path& filepath, const void* buffer, size_t length, bool allowSymlinks);
 
 #endif // HAVE_MAGIC
 


### PR DESCRIPTION
I noticed (on my systems, at least) that when gerbera is built with `libmagic`, symlinks to files are not followed during the MIME type identification process, even when `CFG_IMPORT_FOLLOW_SYMLINKS` is set. This causes symlinks to media files to be identified as `inode/symlink` rather than the MIME of the target. 
 (By contrast, symlinks to directories containing non-symlink files are successfully identified as expected.) 

I've added the `MAGIC_SYMLINK` flag for the `magic_open()` call which causes `libmagic` to follow symlinks when identifying the MIME type of a file. I'm not sure if passing the symlink config setting to `getMIMETypeFromFile()` is the most elegant fix (first time contributor to gerbera here), but I thought I'd offer my solution.