### PR TITLE
clang-tidy: use auto with several static functions

### DIFF
--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -45,7 +45,7 @@ LibExifHandler::LibExifHandler(std::shared_ptr<Config> config)
 {
 }
 
-static int getTagFromString(const std::string& tag)
+static auto getTagFromString(const std::string& tag)
 {
     if (tag == "EXIF_TAG_INTEROPERABILITY_INDEX")
         return EXIF_TAG_INTEROPERABILITY_INDEX;
@@ -255,7 +255,7 @@ static int getTagFromString(const std::string& tag)
         return EXIF_TAG_IMAGE_UNIQUE_ID;
 
     log_warning("Ignoring unknown libexif tag: {}", tag.c_str());
-    return -1;
+    return ExifTag(-1);
 }
 
 #define BUFLEN 4096

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -227,11 +227,7 @@ void MatroskaHandler::parseAttachments(const std::shared_ptr<CdsItem>& item, Ebm
         std::string fileName(UTFstring(GetChild<KaxFileName>(*attachedFile)).GetUTF8());
         // printf("KaxFileName = %s\n", fileName.c_str());
 
-        bool isCoverArt = false;
-        if (startswith(fileName, "cover")) {
-            isCoverArt = true;
-        }
-
+        bool isCoverArt = startswith(fileName, "cover");
         if (isCoverArt) {
             auto& fileData = GetChild<KaxFileData>(*attachedFile);
             // printf("KaxFileData (size=%ld)\n", fileData.GetSize());

--- a/src/scripting/js_functions.cc
+++ b/src/scripting/js_functions.cc
@@ -54,7 +54,7 @@ duk_ret_t js_print(duk_context* ctx)
 
 duk_ret_t js_copyObject(duk_context* ctx)
 {
-    auto* self = Script::getContextScript(ctx);
+    auto self = Script::getContextScript(ctx);
     if (!duk_is_object(ctx, 0))
         return duk_error(ctx, DUK_ERR_TYPE_ERROR, "copyObject argument is not an object");
     auto cds_obj = self->dukObject2cdsObject(nullptr);
@@ -64,13 +64,13 @@ duk_ret_t js_copyObject(duk_context* ctx)
 
 duk_ret_t js_addCdsObject(duk_context* ctx)
 {
-    auto* self = Script::getContextScript(ctx);
+    auto self = Script::getContextScript(ctx);
 
     if (!duk_is_object(ctx, 0))
         return 0;
     duk_to_object(ctx, 0);
     //stack: js_cds_obj
-    const char* ts = duk_to_string(ctx, 1);
+    auto ts = duk_to_string(ctx, 1);
     if (!ts)
         ts = "/";
     fs::path path = ts;
@@ -199,14 +199,14 @@ duk_ret_t js_addCdsObject(duk_context* ctx)
     return 0;
 }
 
-static duk_ret_t convert_charset_generic(duk_context* ctx, charset_convert_t chr)
+static auto convert_charset_generic(duk_context* ctx, charset_convert_t chr)
 {
-    auto* self = Script::getContextScript(ctx);
+    auto self = Script::getContextScript(ctx);
     if (duk_get_top(ctx) != 1)
         return DUK_RET_SYNTAX_ERROR;
     if (!duk_is_string(ctx, 0))
         return DUK_RET_TYPE_ERROR;
-    const char* ts = duk_to_string(ctx, 0);
+    const auto ts = duk_to_string(ctx, 0);
     duk_pop(ctx);
 
     try {

--- a/src/search_handler.cc
+++ b/src/search_handler.cc
@@ -56,7 +56,7 @@ static std::unordered_map<std::string, TokenType> tokenTypes {
     { "or", TokenType::OR }
 };
 
-static std::string aslowercase(const std::string& src)
+static auto aslowercase(const std::string& src)
 {
     std::string copy = src;
     std::transform(copy.begin(), copy.end(), copy.begin(), ::tolower);

--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -69,12 +69,12 @@ using uchar = unsigned char;
 #define M_DRI 0xDD
 
 #define ITEM_BUF_SIZE 16
-static int Get16m(const void* Short)
+static auto Get16m(const void* Short)
 {
     return (static_cast<uchar*>(const_cast<void*>(Short))[0] << 8) | static_cast<uchar*>(const_cast<void*>(Short))[1];
 }
 
-static int ioh_fgetc(const std::unique_ptr<IOHandler>& ioh)
+static auto ioh_fgetc(const std::unique_ptr<IOHandler>& ioh)
 {
     uchar c[1] = { 0 };
     int ret = ioh->read(reinterpret_cast<char*>(c), sizeof(char));

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -396,7 +396,7 @@ std::string urlUnescape(const std::string& str)
     return buf.str();
 }
 
-static std::string dict_encode(const std::map<std::string, std::string>& dict, char sep1, char sep2)
+static auto dict_encode(const std::map<std::string, std::string>& dict, char sep1, char sep2)
 {
     std::ostringstream buf;
     for (auto it = dict.begin(); it != dict.end(); it++) {

--- a/src/web/auth.cc
+++ b/src/web/auth.cc
@@ -41,19 +41,19 @@
 
 #define LOGIN_TIMEOUT 10 // in seconds
 
-static time_t get_time()
+static auto get_time()
 {
     return std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::now()).time_since_epoch().count();
 }
 
-static std::string generate_token()
+static auto generate_token()
 {
-    const time_t expiration = get_time() + LOGIN_TIMEOUT;
+    const auto expiration = get_time() + LOGIN_TIMEOUT;
     std::string salt = generate_random_id();
     return std::to_string(expiration) + '_' + salt;
 }
 
-static bool check_token(const std::string& token, const std::string& password, const std::string& encPassword)
+static auto check_token(const std::string& token, const std::string& password, const std::string& encPassword)
 {
     std::vector<std::string> parts = split_string(token, '_');
     if (parts.size() != 2)

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -37,7 +37,7 @@
 #include "content_manager.h"
 #include "storage/storage.h"
 
-static bool WebAutoscanProcessListComparator(const std::shared_ptr<AutoscanDirectory>& a1, const std::shared_ptr<AutoscanDirectory>& a2)
+static auto WebAutoscanProcessListComparator(const std::shared_ptr<AutoscanDirectory>& a1, const std::shared_ptr<AutoscanDirectory>& a2)
 {
     return strcmp(a1->getLocation().c_str(), a2->getLocation().c_str()) < 0;
 }


### PR DESCRIPTION
Found with modernize-use-trailing-return-type

Signed-off-by: Rosen Penev <rosenp@gmail.com>