### PR TITLE
FFMPEG-metadata: Ensure date content can be parsed

### DIFF
--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -124,7 +124,7 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
             log_debug("Identified metadata album: {}", e->value);
             field = M_ALBUM;
         } else if (strcmp(e->key, "date") == 0) {
-            if ((value.length() == 4) && (std::find_if(value.begin(), value.end(), [](unsigned char c) { return !std::isdigit(c); }) == value.end()) && (std::stoi(value) > 0)) {
+            if ((value.length() == 4) && (std::find_if(value.begin(), value.end(), [](auto c) { return !std::isdigit(c); }) == value.end()) && (std::stoi(value) > 0)) {
                 value.append("-01-01");
                 log_debug("Identified metadata date: {}", value.c_str());
             }

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -124,7 +124,7 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
             log_debug("Identified metadata album: {}", e->value);
             field = M_ALBUM;
         } else if (strcmp(e->key, "date") == 0) {
-            if ((value.length() == 4) && (std::stoi(value) > 0)) {
+            if ((value.length() == 4) && (std::find_if(value.begin(), value.end(), [](unsigned char c) { return !std::isdigit(c); }) == value.end()) && (std::stoi(value) > 0)) {
                 value.append("-01-01");
                 log_debug("Identified metadata date: {}", value.c_str());
             }


### PR DESCRIPTION
Fixes #994