### PR TITLE
Fix resource_zero_ok

### DIFF
--- a/src/storage/sql_storage.cc
+++ b/src/storage/sql_storage.cc
@@ -914,7 +914,7 @@ std::shared_ptr<CdsObject> SQLStorage::createObjectFromRow(const std::unique_ptr
     if (!resources_str.empty()) {
         std::vector<std::string> resources = splitString(resources_str,
             RESOURCE_SEP);
-        resource_zero_ok = resources.empty();
+        resource_zero_ok = !resources.empty();
         for (const auto& resource : resources) {
             obj->addResource(CdsResource::decode(resource));
         }
@@ -1020,7 +1020,7 @@ std::shared_ptr<CdsObject> SQLStorage::createObjectFromSearchRow(const std::uniq
     bool resource_zero_ok = false;
     if (!resources_str.empty()) {
         std::vector<std::string> resources = splitString(resources_str, RESOURCE_SEP);
-        resource_zero_ok = resources.empty();
+        resource_zero_ok = !resources.empty();
         for (const auto& resource : resources) {
             obj->addResource(CdsResource::decode(resource));
         }


### PR DESCRIPTION
Has to be true if resources contains at least one item

`error: Exception caught: tried to create object without at least one resource file://home/karl/Source/gerbera/src/storage/sql_storage.cc line:952 function:createObjectFromRow`