### PR TITLE
clang warning fixes

### DIFF
--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -62,7 +62,7 @@ public:
         fs::path prefix_dir, fs::path magic_file,
         std::string ip, std::string interface, int port,
         bool debug_logging);
-    virtual ~ConfigManager();
+    virtual ~ConfigManager() override;
 
     /// \brief Returns the name of the config file that was used to launch the server.
     fs::path getConfigFilename() const override { return filename; }

--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -170,7 +170,6 @@ std::unique_ptr<MetadataHandler> MetadataHandler::createHandler(const std::share
         return std::make_unique<SubtitleHandler>(config);
     case CH_RESOURCE:
         return std::make_unique<ResourceHandler>(config);
-        break;
     default:
         throw_std_runtime_error("unknown content handler ID: " + std::to_string(handlerType));
     }

--- a/src/web/clients.cc
+++ b/src/web/clients.cc
@@ -38,7 +38,7 @@ web::clients::clients(std::shared_ptr<Config> config, std::shared_ptr<Database> 
 {
 }
 
-std::string steady_clock_to_string(std::chrono::steady_clock::time_point t)
+static std::string steady_clock_to_string(std::chrono::steady_clock::time_point t)
 {
     auto systime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()
         + std::chrono::duration_cast<std::chrono::system_clock::duration>(t - std::chrono::steady_clock::now()));


### PR DESCRIPTION
convert keys to use std::pair

Small code simplification. Also allows using std::get, which demands
constant expressions.

replace std::map with constexpr std::array 

The map is never modified.

std::string replaced with const char * as the former is not constexpr
until C++20.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

And yes I've tested this. Seems to work very well. Maybe because my UPnP client caches some stuff...