### PR TITLE
run through clang-tidy

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -1261,7 +1261,7 @@ void ConfigManager::setOrigValue(const std::string& item, int value)
     }
 }
 
-void ConfigManager::dumpOptions()
+void ConfigManager::dumpOptions() const
 {
 #ifdef TOMBDEBUG
     log_debug("Dumping options!");

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -720,7 +720,7 @@ std::shared_ptr<ConfigSetup> ConfigManager::findConfigSetup(config_option_t opti
     throw std::runtime_error(fmt::format("Error in config code: {} tag not found", static_cast<int>(option)));
 }
 
-std::shared_ptr<ConfigSetup> ConfigManager::findConfigSetupByPath(const std::string& key, bool save, const std::shared_ptr<ConfigSetup> parent)
+std::shared_ptr<ConfigSetup> ConfigManager::findConfigSetupByPath(const std::string& key, bool save, const std::shared_ptr<ConfigSetup>& parent)
 {
     auto co = std::find_if(complexOptions.begin(), complexOptions.end(), [&](const auto& s) { return s->getUniquePath() == key; });
 

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -64,7 +64,7 @@ ConfigManager::ConfigManager(fs::path filename,
     fs::path prefix_dir, fs::path magic_file,
     std::string ip, std::string interface, int port,
     bool debug_logging)
-    : filename(filename)
+    : filename(std::move(filename))
     , prefix_dir(std::move(prefix_dir))
     , magic_file(std::move(magic_file))
     , ip(std::move(ip))

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -159,7 +159,7 @@ protected:
 
     std::shared_ptr<Config> getSelf();
 
-    void dumpOptions();
+    void dumpOptions() const;
 };
 
 #endif // __CONFIG_MANAGER_H__

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -75,7 +75,7 @@ public:
     static const char* mapConfigOption(config_option_t option);
 
     static std::shared_ptr<ConfigSetup> findConfigSetup(config_option_t option, bool save = false);
-    static std::shared_ptr<ConfigSetup> findConfigSetupByPath(const std::string& key, bool save = false, const std::shared_ptr<ConfigSetup> parent = nullptr);
+    static std::shared_ptr<ConfigSetup> findConfigSetupByPath(const std::string& key, bool save = false, const std::shared_ptr<ConfigSetup>& parent = nullptr);
 
     void load(const fs::path& userHome);
     void updateConfigFromDatabase(std::shared_ptr<Database> database) override;

--- a/src/config/config_options.cc
+++ b/src/config/config_options.cc
@@ -92,9 +92,9 @@ std::vector<std::string> ArrayOption::getArrayOption(bool forEdit) const
     auto editSize = getEditSize();
     for (size_t i = 0; i < editSize; i++) {
         if (indexMap.at(i) < SIZE_MAX) {
-            editOption.push_back(option[indexMap.at(i)]);
+            editOption.emplace_back(option[indexMap.at(i)]);
         } else {
-            editOption.push_back("");
+            editOption.emplace_back("");
         }
     }
     return editOption;

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -400,7 +400,7 @@ void ConfigBoolSetup::makeOption(const pugi::xml_node& root, std::shared_ptr<Con
     setOption(config);
 }
 
-bool validateTrueFalse(const std::string& optValue)
+static bool validateTrueFalse(const std::string& optValue)
 {
     return (optValue == "true" || optValue == "false");
 }

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -167,10 +167,7 @@ bool ConfigPathSetup::checkPathValue(std::string& optValue, std::string& pathVal
         return false;
     }
     pathValue.assign(resolvePath(optValue));
-    if (notEmpty && pathValue.empty()) {
-        return false;
-    }
-    return true;
+    return !(notEmpty && pathValue.empty());
 }
 
 bool ConfigPathSetup::checkAgentPath(std::string& optValue)
@@ -382,17 +379,17 @@ bool ConfigIntSetup::CheckProfleNumberValue(std::string& value)
 
 bool ConfigIntSetup::CheckMinValue(int value, int minValue)
 {
-    return (value < minValue) ? false : true;
+    return value >= minValue;
 }
 
 bool ConfigIntSetup::CheckImageQualityValue(int value)
 {
-    return (value < 0 || value > 10) ? false : true;
+    return !(value < 0 || value > 10);
 }
 
 bool ConfigIntSetup::CheckUpnpStringLimitValue(int value)
 {
-    return (value != -1) && (value < 4) ? false : true;
+    return !((value != -1) && (value < 4));
 }
 
 void ConfigBoolSetup::makeOption(const pugi::xml_node& root, std::shared_ptr<Config> config, const std::map<std::string, std::string>* arguments)

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -472,9 +472,8 @@ bool ConfigBoolSetup::CheckInotifyValue(std::string& value)
             log_error("You specified \"yes\" in \"<autoscan use-inotify=\"\">"
                       " however your system does not have inotify support");
             return false;
-        } else {
-            temp_bool = true;
         }
+        temp_bool = true;
 #else
         log_error("You specified \"yes\" in \"<autoscan use-inotify=\"\">"
                   " however this version of Gerbera was compiled without inotify support");

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -28,6 +28,8 @@
 #include <filesystem>
 #include <iostream>
 #include <numeric>
+#include <utility>
+
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -116,13 +118,13 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim) co
 void ConfigSetup::makeOption(const pugi::xml_node& root, std::shared_ptr<Config> config, const std::map<std::string, std::string>* arguments)
 {
     optionValue = std::make_shared<Option>("");
-    setOption(config);
+    setOption(std::move(config));
 }
 
 void ConfigSetup::makeOption(std::string optValue, std::shared_ptr<Config> config, const std::map<std::string, std::string>* arguments)
 {
     optionValue = std::make_shared<Option>(optValue);
-    setOption(config);
+    setOption(std::move(config));
 };
 
 size_t ConfigSetup::extractIndex(const std::string& item)
@@ -531,7 +533,7 @@ void ConfigArraySetup::makeOption(const pugi::xml_node& root, std::shared_ptr<Co
     setOption(config);
 }
 
-bool ConfigArraySetup::updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<ArrayOption> value, const std::string& optValue, const std::string& status) const
+bool ConfigArraySetup::updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, const std::shared_ptr<ArrayOption>& value, const std::string& optValue, const std::string& status) const
 {
     auto index = getItemPath(i);
     if (optItem == index || !status.empty()) {
@@ -728,7 +730,7 @@ void ConfigDictionarySetup::makeOption(const pugi::xml_node& root, std::shared_p
     setOption(config);
 }
 
-bool ConfigDictionarySetup::updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<DictionaryOption> value, const std::string& optKey, const std::string& optValue, const std::string& status) const
+bool ConfigDictionarySetup::updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, const std::shared_ptr<DictionaryOption>& value, const std::string& optKey, const std::string& optValue, const std::string& status) const
 {
     auto keyIndex = getItemPath(i, keyOption);
     auto valIndex = getItemPath(i, valOption);
@@ -863,7 +865,7 @@ bool ConfigAutoscanSetup::createAutoscanListFromNode(const pugi::xml_node& eleme
     return true;
 }
 
-bool ConfigAutoscanSetup::updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<AutoscanDirectory>& entry, std::string& optValue, const std::string& status) const
+bool ConfigAutoscanSetup::updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, std::shared_ptr<AutoscanDirectory>& entry, std::string& optValue, const std::string& status) const
 {
     auto index = getItemPath(i, ATTR_AUTOSCAN_DIRECTORY_LOCATION);
     if (optItem == getUniquePath() && status != STATUS_CHANGED) {
@@ -1334,7 +1336,7 @@ bool ConfigTranscodingSetup::updateDetail(const std::string& optItem, std::strin
             }
             index = getItemPath(i, ATTR_TRANSCODING_PROFILES, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC);
             if (optItem == index) {
-                config->setOrigValue(index, std::accumulate(std::next(fcc_list.begin()), fcc_list.end(), fcc_list[0], [](std::string a, std::string b) { return a + ", " + b; }));
+                config->setOrigValue(index, std::accumulate(std::next(fcc_list.begin()), fcc_list.end(), fcc_list[0], [](const std::string& a, const std::string& b) { return a + ", " + b; }));
                 fcc_list.clear();
                 if (findConfigSetup<ConfigArraySetup>(ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC)->checkArrayValue(optValue, fcc_list)) {
                     set4cc = true;
@@ -1404,7 +1406,7 @@ void ConfigClientSetup::makeOption(const pugi::xml_node& root, std::shared_ptr<C
     setOption(config);
 }
 
-bool ConfigClientSetup::updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<ClientConfig>& entry, std::string& optValue, const std::string& status) const
+bool ConfigClientSetup::updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, std::shared_ptr<ClientConfig>& entry, std::string& optValue, const std::string& status) const
 {
     if (optItem == getItemPath(i) && (status == STATUS_ADDED || status == STATUS_MANUAL)) {
         return true;
@@ -1559,7 +1561,7 @@ void ConfigDirectorySetup::makeOption(const pugi::xml_node& root, std::shared_pt
     setOption(config);
 }
 
-bool ConfigDirectorySetup::updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<DirectoryTweak>& entry, std::string& optValue, const std::string& status) const
+bool ConfigDirectorySetup::updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, std::shared_ptr<DirectoryTweak>& entry, std::string& optValue, const std::string& status) const
 {
     if (optItem == getItemPath(i) && (status == STATUS_ADDED || status == STATUS_MANUAL)) {
         return true;

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -618,7 +618,7 @@ protected:
     /// \brief Creates an array of TranscodingProfile objects from an XML
     /// nodeset.
     /// \param element starting element of the nodeset.
-    bool createTranscodingProfileListFromNode(const pugi::xml_node& element, std::shared_ptr<TranscodingProfileList>& result);
+    static bool createTranscodingProfileListFromNode(const pugi::xml_node& element, std::shared_ptr<TranscodingProfileList>& result);
 
 public:
     ConfigTranscodingSetup(config_option_t option, const char* xpath, const char* help)
@@ -654,7 +654,7 @@ protected:
 
     /// \brief Creates an array of ClientConfig objects from a XML nodeset.
     /// \param element starting element of the nodeset.
-    bool createClientConfigListFromNode(const pugi::xml_node& element, std::shared_ptr<ClientConfigList>& result);
+    static bool createClientConfigListFromNode(const pugi::xml_node& element, std::shared_ptr<ClientConfigList>& result);
 
     bool updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<ClientConfig>& entry, std::string& optValue, const std::string& status = "") const;
 
@@ -693,7 +693,7 @@ class ConfigDirectorySetup : public ConfigSetup {
 protected:
     /// \brief Creates an array of ClientConfig objects from a XML nodeset.
     /// \param element starting element of the nodeset.
-    bool createDirectoryTweakListFromNode(const pugi::xml_node& element, std::shared_ptr<DirectoryConfigList>& result);
+    static bool createDirectoryTweakListFromNode(const pugi::xml_node& element, std::shared_ptr<DirectoryConfigList>& result);
 
     bool updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<DirectoryTweak>& entry, std::string& optValue, const std::string& status = "") const;
 

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -452,7 +452,7 @@ protected:
     /// This function will create an array like that: ["data", "otherdata"]
     bool createArrayFromNode(const pugi::xml_node& element, std::vector<std::string>& result) const;
 
-    bool updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<ArrayOption> value, const std::string& optValue, const std::string& status = "") const;
+    bool updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, const std::shared_ptr<ArrayOption>& value, const std::string& optValue, const std::string& status = "") const;
 
 public:
     config_option_t nodeOption;
@@ -529,7 +529,7 @@ protected:
     /// key:value paris: "1":"2", "3":"4"
     bool createDictionaryFromNode(const pugi::xml_node& optValue, std::map<std::string, std::string>& result) const;
 
-    bool updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<DictionaryOption> value, const std::string& optKey, const std::string& optValue, const std::string& status = "") const;
+    bool updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, const std::shared_ptr<DictionaryOption>& value, const std::string& optKey, const std::string& optValue, const std::string& status = "") const;
 
 public:
     config_option_t keyOption;
@@ -583,7 +583,7 @@ protected:
     /// \param scanmode add only directories with the specified scanmode to the array
     bool createAutoscanListFromNode(const pugi::xml_node& element, std::shared_ptr<AutoscanList>& result);
 
-    bool updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<AutoscanDirectory>& entry, std::string& optValue, const std::string& status = "") const;
+    bool updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, std::shared_ptr<AutoscanDirectory>& entry, std::string& optValue, const std::string& status = "") const;
 
 public:
     ConfigAutoscanSetup(config_option_t option, const char* xpath, const char* help, ScanMode scanmode)
@@ -656,7 +656,7 @@ protected:
     /// \param element starting element of the nodeset.
     static bool createClientConfigListFromNode(const pugi::xml_node& element, std::shared_ptr<ClientConfigList>& result);
 
-    bool updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<ClientConfig>& entry, std::string& optValue, const std::string& status = "") const;
+    bool updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, std::shared_ptr<ClientConfig>& entry, std::string& optValue, const std::string& status = "") const;
 
 public:
     ConfigClientSetup(config_option_t option, const char* xpath, const char* help)
@@ -695,7 +695,7 @@ protected:
     /// \param element starting element of the nodeset.
     static bool createDirectoryTweakListFromNode(const pugi::xml_node& element, std::shared_ptr<DirectoryConfigList>& result);
 
-    bool updateItem(size_t i, const std::string& optItem, std::shared_ptr<Config> config, std::shared_ptr<DirectoryTweak>& entry, std::string& optValue, const std::string& status = "") const;
+    bool updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, std::shared_ptr<DirectoryTweak>& entry, std::string& optValue, const std::string& status = "") const;
 
 public:
     ConfigDirectorySetup(config_option_t option, const char* xpath, const char* help)

--- a/src/config/directory_tweak.cc
+++ b/src/config/directory_tweak.cc
@@ -31,7 +31,7 @@
 
 #include <utility>
 
-void AutoScanSetting::mergeOptions(const std::shared_ptr<Config>& config, const fs::path location)
+void AutoScanSetting::mergeOptions(const std::shared_ptr<Config>& config, const fs::path& location)
 {
    auto tweak = config->getDirectoryTweakOption(CFG_IMPORT_DIRECTORIES_LIST)->get(location);
    if (tweak == nullptr)

--- a/src/config/directory_tweak.cc
+++ b/src/config/directory_tweak.cc
@@ -100,7 +100,7 @@ std::shared_ptr<DirectoryTweak> DirectoryConfigList::get(const fs::path& locatio
 {
     AutoLock lock(mutex);
     for(auto testLoc = location.has_filename() ? location.parent_path() : location; testLoc.has_parent_path() && testLoc != "/"; testLoc = testLoc.parent_path()) {
-        auto entry = std::find_if(list.begin(), list.end(), [=] (const auto& d) { return ((d->getLocation() == location || d->getInherit() == true) && d->getLocation() == testLoc); }); 
+        auto entry = std::find_if(list.begin(), list.end(), [=](const auto& d) { return (d->getLocation() == location || d->getInherit()) && d->getLocation() == testLoc; });
         if (entry != list.end() && *entry != nullptr) {
             return *entry;
         }

--- a/src/config/directory_tweak.h
+++ b/src/config/directory_tweak.h
@@ -44,7 +44,7 @@ public:
     bool hidden = false;
     bool rescanResource = true;
 
-    void mergeOptions(const std::shared_ptr<Config>& config, const fs::path location);
+    void mergeOptions(const std::shared_ptr<Config>& config, const fs::path& location);
 };
 
 class DirectoryConfigList {

--- a/src/content_manager.h
+++ b/src/content_manager.h
@@ -355,7 +355,7 @@ protected:
     void _rescanDirectory(const std::shared_ptr<AutoscanDirectory>& adir, int objectId, const std::shared_ptr<GenericTask>& task = nullptr);
     /* for recursive addition */
     void addRecursive(const fs::path& path, bool followSymlinks, bool hidden, const std::shared_ptr<CMAddFileTask>& task);
-    bool isLink(const fs::path& path, bool allowLinks);
+    static bool isLink(const fs::path& path, bool allowLinks);
     std::shared_ptr<CdsObject> createSingleItem(const fs::path& path, fs::path& rootPath, bool followSymlinks, bool checkDatabase, bool processExisting, const std::shared_ptr<CMAddFileTask>& task);
     bool updateAttachedResources(const char* obj, const std::string& parentPath, bool all);
     std::string extension2mimetype(std::string extension);

--- a/src/content_manager.h
+++ b/src/content_manager.h
@@ -352,12 +352,12 @@ protected:
 
     void _removeObject(int objectID, bool rescanResource, bool all);
 
-    void _rescanDirectory(const std::shared_ptr<AutoscanDirectory>& adir, int objectId, const std::shared_ptr<GenericTask>& task = nullptr);
+    void _rescanDirectory(const std::shared_ptr<AutoscanDirectory>& adir, int containerID, const std::shared_ptr<GenericTask>& task = nullptr);
     /* for recursive addition */
     void addRecursive(const fs::path& path, bool followSymlinks, bool hidden, const std::shared_ptr<CMAddFileTask>& task);
     static bool isLink(const fs::path& path, bool allowLinks);
     std::shared_ptr<CdsObject> createSingleItem(const fs::path& path, fs::path& rootPath, bool followSymlinks, bool checkDatabase, bool processExisting, const std::shared_ptr<CMAddFileTask>& task);
-    bool updateAttachedResources(const char* obj, const std::string& parentPath, bool all);
+    bool updateAttachedResources(const char* location, const std::string& parentPath, bool all);
     std::string extension2mimetype(std::string extension);
     std::string mimetype2upnpclass(const std::string& mimeType);
 

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -311,7 +311,7 @@ inline auto wrap_unique_ptr()
     auto raw_ptr = C();
     return std::unique_ptr<std::remove_pointer_t<decltype(raw_ptr)>, decltype(D)>(raw_ptr, D);
 }
-}
+} // namespace
 
 std::unique_ptr<IOHandler> FfmpegHandler::serveContent(std::shared_ptr<CdsItem> item, int resNum)
 {

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -245,7 +245,7 @@ void ContentDirectoryService::doGetSystemUpdateID(const std::unique_ptr<ActionRe
     log_debug("end");
 }
 
-void ContentDirectoryService::doSamsungBookmark(const std::unique_ptr<ActionRequest>& request) const
+void ContentDirectoryService::doSamsungBookmark(const std::unique_ptr<ActionRequest>& request)
 {
     log_warning("Stub method for Samsung extension: X_SetBookmark");
 }

--- a/src/upnp_cds.h
+++ b/src/upnp_cds.h
@@ -98,7 +98,7 @@ protected:
     /// \brief Samsung Extension X_SetBookmark
     /// \param request Incoming ActionRequest.
     ///
-    void doSamsungBookmark(const std::unique_ptr<ActionRequest>& request) const;
+    static void doSamsungBookmark(const std::unique_ptr<ActionRequest>& request);
 
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;

--- a/src/util/xml_to_json.h
+++ b/src/util/xml_to_json.h
@@ -60,7 +60,7 @@ public:
 private:
     static void handleElement(std::ostringstream& buf, const pugi::xml_node& node, const Hints& hints);
     static std::string getAsString(const char* str);
-    static std::string getValue(const std::string& at, const char* text, const Hints& hints);
+    static std::string getValue(const std::string& name, const char* text, const Hints& hints);
     static bool isArray(const pugi::xml_node& node, const Hints& hints, std::string* arrayName);
 };
 

--- a/src/web/clients.cc
+++ b/src/web/clients.cc
@@ -38,7 +38,7 @@ web::clients::clients(std::shared_ptr<Config> config, std::shared_ptr<Database> 
 {
 }
 
-std::string steady_clock_to_string(std::chrono::steady_clock::time_point t)
+static std::string steady_clock_to_string(std::chrono::steady_clock::time_point t)
 {
     auto systime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now()
         + std::chrono::duration_cast<std::chrono::system_clock::duration>(t - std::chrono::steady_clock::now()));

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -380,7 +380,7 @@ void web::configLoad::process()
         }
     }
 
-    for (auto entry : dbEntries) {
+    for (const auto& entry : dbEntries) {
         auto exItem = allItems.find(entry.item);
         if (exItem != allItems.end()) {
             auto item = (*exItem).second;

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -52,7 +52,7 @@ web::configLoad::configLoad(std::shared_ptr<Config> config, std::shared_ptr<Data
     }
 }
 
-void web::configLoad::addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup> cs)
+void web::configLoad::addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup>& cs)
 {
     auto info = meta.append_child("item");
     info.append_attribute("item") = cs->getUniquePath().c_str();
@@ -296,9 +296,7 @@ void web::configLoad::process()
             if (!fourCCList.empty()) {
                 item = values.append_child("item");
                 createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_PROFILES, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC), cs->option, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC);
-                setValue(item, std::accumulate(std::next(fourCCList.begin()),
-                    fourCCList.end(), fourCCList[0],
-                    [](std::string a, std::string b) { return a + ", " + b; }));
+                setValue(item, std::accumulate(std::next(fourCCList.begin()), fourCCList.end(), fourCCList[0], [](const std::string& a, const std::string& b) { return a + ", " + b; }));
             }
         }
         pr++;

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -198,15 +198,15 @@ void web::configLoad::process()
     int pr = 0;
     std::map<std::string, int> profiles;
     for (const auto& [key, val] : transcoding->getList()) {
-        for (auto it = val->begin(); it != val->end(); it++) {
+        for (const auto& [a, name] : *val) {
             auto item = values.append_child("item");
             createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_MIMETYPE_PROF_MAP, ATTR_TRANSCODING_MIMETYPE_PROF_MAP_TRANSCODE, ATTR_TRANSCODING_MIMETYPE_PROF_MAP_MIMETYPE), cs->option, ATTR_TRANSCODING_MIMETYPE_PROF_MAP_MIMETYPE);
             setValue(item, key);
 
             item = values.append_child("item");
             createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_MIMETYPE_PROF_MAP, ATTR_TRANSCODING_MIMETYPE_PROF_MAP_TRANSCODE, ATTR_TRANSCODING_MIMETYPE_PROF_MAP_USING), cs->option, ATTR_TRANSCODING_MIMETYPE_PROF_MAP_USING);
-            setValue(item, it->second->getName());
-            profiles[it->second->getName()] = pr;
+            setValue(item, name->getName());
+            profiles[name->getName()] = pr;
 
             pr++;
         }

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -52,7 +52,7 @@ web::configLoad::configLoad(std::shared_ptr<Config> config, std::shared_ptr<Data
     }
 }
 
-void web::configLoad::addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup> cs) const
+void web::configLoad::addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup> cs)
 {
     auto info = meta.append_child("item");
     info.append_attribute("item") = cs->getUniquePath().c_str();

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -293,7 +293,7 @@ void web::configLoad::process()
             setValue(item, TranscodingProfile::mapFourCcMode(fourCCMode));
 
             const auto fourCCList = entry->getAVIFourCCList();
-            if (fourCCList.size() > 0) {
+            if (!fourCCList.empty()) {
                 item = values.append_child("item");
                 createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_PROFILES, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC), cs->option, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC);
                 setValue(item, std::accumulate(std::next(fourCCList.begin()),

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -204,7 +204,7 @@ protected:
     static void setValue(pugi::xml_node& item, unsigned int value);
     static void setValue(pugi::xml_node& item, size_t value);
 
-    static void addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup> cs);
+    static void addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup>& cs);
 
 public:
     configLoad(std::shared_ptr<Config> config, std::shared_ptr<Database> database,

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -198,13 +198,13 @@ protected:
     std::vector<ConfigValue> dbEntries;
     std::map<std::string, pugi::xml_node*> allItems;
     void createItem(pugi::xml_node& item, const std::string& name, config_option_t id, config_option_t aid);
-    void setValue(pugi::xml_node& item, bool value);
-    void setValue(pugi::xml_node& item, const std::string& value);
-    void setValue(pugi::xml_node& item, int value);
-    void setValue(pugi::xml_node& item, unsigned int value);
-    void setValue(pugi::xml_node& item, size_t value);
+    static void setValue(pugi::xml_node& item, bool value);
+    static void setValue(pugi::xml_node& item, const std::string& value);
+    static void setValue(pugi::xml_node& item, int value);
+    static void setValue(pugi::xml_node& item, unsigned int value);
+    static void setValue(pugi::xml_node& item, size_t value);
 
-    void addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup> cs) const;
+    static void addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup> cs);
 
 public:
     configLoad(std::shared_ptr<Config> config, std::shared_ptr<Database> database,


### PR DESCRIPTION
I think https://github.com/gerbera/gerbera/commit/d7c84cc9e967528ae91e62f513c8385248721746 introduced a bunch of clang-tidy fixes.