### PR TITLE
convert MT_KEYS and RES_KEYS to std::pair

### DIFF
--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -138,7 +138,7 @@ void Exiv2Handler::fillMetadata(std::shared_ptr<CdsItem> item)
         }  */
 
         if (!comment.empty())
-            item->setMetadata(MT_KEYS[M_DESCRIPTION].upnp, sc->convert(comment));
+            item->setMetadata(mt_keys[M_DESCRIPTION].second, sc->convert(comment));
 
         // if there are any auxilary tags that the user wants - add them
         const auto aux = config->getArrayOption(CFG_IMPORT_LIBOPTS_EXIV2_AUXDATA_TAGS_LIST);

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -144,8 +144,8 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
         }
 
         // only use ffmpeg meta data if not found by other handler
-        if (item->getMetadata(MT_KEYS[field].upnp).empty())
-            item->setMetadata(MT_KEYS[field].upnp, sc->convert(trimString(value)));
+        if (item->getMetadata(mt_keys[field].second).empty())
+            item->setMetadata(mt_keys[field].second, sc->convert(trimString(value)));
     }
 }
 

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -198,7 +198,7 @@ void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream
             }
             std::string title(UTFstring(*title_el).GetUTF8());
             // printf("KaxTitle = %s\n", title.c_str());
-            item->setMetadata(MT_KEYS[M_TITLE].upnp, sc->convert(title));
+            item->setMetadata(mt_keys[M_TITLE].second, sc->convert(title));
         } else if (EbmlId(*el) == KaxDateUTC::ClassInfos.GlobalId) {
             auto date_el = dynamic_cast<KaxDateUTC*>(el);
             if (date_el == nullptr) {
@@ -212,7 +212,7 @@ void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream
             i_date = date.GetEpochDate();
             if (gmtime_r(&i_date, &tmres) && strftime(buffer.data(), buffer.size(), "%Y-%m-%d", &tmres)) {
                 // printf("KaxDateUTC = %s\n", buffer);
-                item->setMetadata(MT_KEYS[M_DATE].upnp, sc->convert(buffer.data()));
+                item->setMetadata(mt_keys[M_DATE].second, sc->convert(buffer.data()));
             }
         }
     }

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -87,7 +87,7 @@ std::string MetacontentHandler::expandName(const std::string& name, const std::s
     std::string copy(name);
 
     for (const auto& [key, val] : metaTags)
-        replaceString(copy, key, item->getMetadata(MT_KEYS.at(val).upnp));
+        replaceString(copy, key, item->getMetadata(mt_keys.at(val).second));
 
     fs::path location = item->getLocation();
     replaceString(copy, "%filename%", location.stem());

--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -137,12 +137,12 @@ void MetadataHandler::setMetadata(const std::shared_ptr<Config>& config, const s
 
 std::string MetadataHandler::getMetaFieldName(metadata_fields_t field)
 {
-    return MT_KEYS.at(field).upnp;
+    return mt_keys.at(field).second;
 }
 
 std::string MetadataHandler::getResAttrName(resource_attributes_t attr)
 {
-    return RES_KEYS.at(attr).upnp;
+    return mt_keys.at(attr).second;
 }
 
 std::unique_ptr<MetadataHandler> MetadataHandler::createHandler(const std::shared_ptr<Config>& config, int handlerType)

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -113,13 +113,7 @@ typedef enum {
     M_MAX
 } metadata_fields_t;
 
-using mt_key = struct mt_key;
-struct mt_key {
-    const char* sym;
-    const char* upnp;
-};
-
-constexpr std::array<mt_key, 21> MT_KEYS = { {
+constexpr std::array<std::pair<const char*, const char*>, 21> mt_keys = { {
     { "M_TITLE", "dc:title" },
     { "M_ARTIST", "upnp:artist" },
     { "M_ALBUM", "upnp:album" },
@@ -156,20 +150,16 @@ typedef enum {
     R_MAX
 } resource_attributes_t;
 
-using res_key = struct res_key;
-struct res_key {
-    const char* sym;
-    const char* upnp;
-};
-
-constexpr std::array<res_key, 8> RES_KEYS = { { { "R_SIZE", "size" },
+constexpr std::array<std::pair<const char*, const char*>, 8> res_keys = { {
+    { "R_SIZE", "size" },
     { "R_DURATION", "duration" },
     { "R_BITRATE", "bitrate" },
     { "R_SAMPLEFREQUENCY", "sampleFrequency" },
     { "R_NRAUDIOCHANNELS", "nrAudioChannels" },
     { "R_RESOLUTION", "resolution" },
     { "R_COLORDEPTH", "colorDepth" },
-    { "R_PROTOCOLINFO", "protocolInfo" } } };
+    { "R_PROTOCOLINFO", "protocolInfo" },
+} };
 
 /// \brief This class is responsible for providing access to metadata information
 /// of various media.

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -169,7 +169,7 @@ void TagLibHandler::addField(metadata_fields_t field, const TagLib::File& file, 
     value = trimString(value);
 
     if (!value.empty()) {
-        item->setMetadata(MT_KEYS.at(field).upnp, sc->convert(value));
+        item->setMetadata(mt_keys.at(field).second, sc->convert(value));
         //        log_debug("Setting metadata on item: {}, {}", field, sc->convert(value).c_str());
     }
 }
@@ -181,7 +181,7 @@ void TagLibHandler::populateGenericTags(const std::shared_ptr<CdsItem>& item, co
 
     const TagLib::Tag* tag = file.tag();
 
-    for (size_t i = 0; i < MT_KEYS.size(); i++)
+    for (size_t i = 0; i < mt_keys.size(); i++)
         addField(metadata_fields_t(i), file, tag, item);
 
     int temp;

--- a/src/scripting/script.cc
+++ b/src/scripting/script.cc
@@ -197,14 +197,14 @@ Script::Script(const std::shared_ptr<Config>& config,
     duk_put_global_string(ctx, "ONLINE_SERVICE_SOPCAST");
 #endif //ONLINE_SERVICES
 
-    for (const auto& key : MT_KEYS) {
-        duk_push_string(ctx, key.upnp);
-        duk_put_global_string(ctx, key.sym);
+    for (const auto& [sym, upnp] : mt_keys) {
+        duk_push_string(ctx, upnp);
+        duk_put_global_string(ctx, sym);
     }
 
-    for (const auto& key : RES_KEYS) {
-        duk_push_string(ctx, key.upnp);
-        duk_put_global_string(ctx, key.sym);
+    for (const auto& [sym, upnp] : res_keys) {
+        duk_push_string(ctx, upnp);
+        duk_put_global_string(ctx, sym);
     }
 
     duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_ALBUM);
@@ -390,20 +390,20 @@ std::shared_ptr<CdsObject> Script::dukObject2cdsObject(const std::shared_ptr<Cds
     duk_get_prop_string(ctx, -1, "meta");
     if (duk_is_object(ctx, -1)) {
         duk_to_object(ctx, -1);
-        /// \todo: only metadata enumerated in MT_KEYS is taken
-        for (const auto& key : MT_KEYS) {
-            val = getProperty(key.upnp);
+        /// \todo: only metadata enumerated in mt_keys is taken
+        for (const auto& [sym, upnp] : mt_keys) {
+            val = getProperty(upnp);
             if (!val.empty()) {
-                if (std::strcmp(key.sym, "M_TRACKNUMBER") == 0) {
+                if (std::strcmp(sym, "M_TRACKNUMBER") == 0) {
                     int j = stoiString(val, 0);
                     if (j > 0) {
-                        obj->setMetadata(key.upnp, val);
+                        obj->setMetadata(upnp, val);
                         std::static_pointer_cast<CdsItem>(obj)->setTrackNumber(j);
                     } else
                         std::static_pointer_cast<CdsItem>(obj)->setTrackNumber(0);
                 } else {
                     val = sc->convert(val);
-                    obj->setMetadata(key.upnp, val);
+                    obj->setMetadata(upnp, val);
                 }
             }
         }
@@ -441,7 +441,7 @@ std::shared_ptr<CdsObject> Script::dukObject2cdsObject(const std::shared_ptr<Cds
         }
 
         /// \todo check what this is doing here, wasn't it already handled
-        /// in the MT_KEYS loop?
+        /// in the mt_keys loop?
         val = getProperty("description");
         if (!val.empty()) {
             val = sc->convert(val);

--- a/test/scripting/mock/script_test_fixture.cc
+++ b/test/scripting/mock/script_test_fixture.cc
@@ -111,14 +111,14 @@ duk_ret_t ScriptTestFixture::dukMockPlaylist(duk_context* ctx, string title, str
 
 void ScriptTestFixture::addGlobalFunctions(duk_context* ctx, const duk_function_list_entry* funcs)
 {
-    for (const auto& key : MT_KEYS) {
-        duk_push_string(ctx, key.upnp);
-        duk_put_global_string(ctx, key.sym);
+    for (const auto& [sym, upnp] : mt_keys) {
+        duk_push_string(ctx, upnp);
+        duk_put_global_string(ctx, sym);
     }
 
-    for (const auto& key : RES_KEYS) {
-        duk_push_string(ctx, key.upnp);
-        duk_put_global_string(ctx, key.sym);
+    for (const auto& [sym, upnp] : res_keys) {
+        duk_push_string(ctx, upnp);
+        duk_put_global_string(ctx, sym);
     }
 
     duk_push_int(ctx, OBJECT_TYPE_ITEM_EXTERNAL_URL);

--- a/test/scripting/mock/script_test_fixture.cc
+++ b/test/scripting/mock/script_test_fixture.cc
@@ -111,14 +111,14 @@ duk_ret_t ScriptTestFixture::dukMockPlaylist(duk_context* ctx, string title, str
 
 void ScriptTestFixture::addGlobalFunctions(duk_context* ctx, const duk_function_list_entry* funcs)
 {
-    for (int i = 0; i < M_MAX; i++) {
-        duk_push_string(ctx, MT_KEYS[i].upnp);
-        duk_put_global_string(ctx, MT_KEYS[i].sym);
+    for (const auto& key : MT_KEYS) {
+        duk_push_string(ctx, key.upnp);
+        duk_put_global_string(ctx, key.sym);
     }
 
-    for (int i = 0; i < R_MAX; i++) {
-        duk_push_string(ctx, RES_KEYS[i].upnp);
-        duk_put_global_string(ctx, RES_KEYS[i].sym);
+    for (const auto& key : RES_KEYS) {
+        duk_push_string(ctx, key.upnp);
+        duk_put_global_string(ctx, key.sym);
     }
 
     duk_push_int(ctx, OBJECT_TYPE_ITEM_EXTERNAL_URL);


### PR DESCRIPTION
Allows usage of structured binding declarations as well as simplifying
the code slightly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>