### PR TITLE
Move call to MetadataHandler::getMetaFieldName into CdsObject::get/setMetadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ add_library(libgerbera STATIC
         src/scripting/runtime.h
         src/scripting/script.cc
         src/scripting/script.h
+        src/scripting/script_names.h
         src/search_handler.cc
         src/search_handler.h
         src/server.cc

--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -43,6 +43,7 @@ namespace fs = std::filesystem;
 
 #include "cds_resource.h"
 #include "common.h"
+#include "metadata/metadata_handler.h"
 #include "util/tools.h"
 
 // forward declaration
@@ -238,9 +239,9 @@ public:
     void clearFlag(unsigned int mask) { objectFlags &= ~mask; }
 
     /// \brief Query single metadata value.
-    std::string getMetadata(const std::string& key) const
+    std::string getMetadata(const metadata_fields_t key) const
     {
-        return getValueOrDefault(metadata, key);
+        return getValueOrDefault(metadata, MetadataHandler::getMetaFieldName(key));
     }
 
     /// \brief Query entire metadata dictionary.
@@ -253,15 +254,15 @@ public:
     }
 
     /// \brief Set a single metadata value.
-    void setMetadata(const std::string& key, const std::string& value)
+    void setMetadata(const metadata_fields_t key, const std::string& value)
     {
-        metadata[key] = value;
+        metadata[MetadataHandler::getMetaFieldName(key)] = value;
     }
 
     /// \brief Removes metadata with the given key
-    void removeMetadata(const std::string& key)
+    void removeMetadata(const metadata_fields_t key)
     {
-        metadata.erase(key);
+        metadata.erase(MetadataHandler::getMetaFieldName(key));
     }
 
     /// \brief Query single auxdata value.

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -905,9 +905,9 @@ void ContentManager::updateObject(int objectID, const std::map<std::string, std:
         }
 
         if (!description.empty()) {
-            cloned_item->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), description);
+            cloned_item->setMetadata(M_DESCRIPTION, description);
         } else {
-            cloned_item->removeMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION));
+            cloned_item->removeMetadata(M_DESCRIPTION);
         }
 
         log_debug("updateObject: checking equality of item {}", item->getTitle().c_str());
@@ -938,9 +938,9 @@ void ContentManager::updateObject(int objectID, const std::map<std::string, std:
 
         // state and description can be an empty strings - if you want to clear it
         if (!description.empty()) {
-            cloned_item->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), description);
+            cloned_item->setMetadata(M_DESCRIPTION, description);
         } else {
-            cloned_item->removeMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION));
+            cloned_item->removeMetadata(M_DESCRIPTION);
         }
 
         if (!state.empty())

--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -75,7 +75,7 @@ void Exiv2Handler::fillMetadata(std::shared_ptr<CdsItem> item)
             if (value.length() >= 11) {
                 value = value.substr(0, 4) + "-" + value.substr(5, 2) + "-" + value.substr(8, 2);
                 log_debug("date: {}", value.c_str());
-                item->setMetadata(MetadataHandler::getMetaFieldName(M_DATE), value);
+                item->setMetadata(M_DATE, value);
             }
         }
 
@@ -138,7 +138,7 @@ void Exiv2Handler::fillMetadata(std::shared_ptr<CdsItem> item)
         }  */
 
         if (!comment.empty())
-            item->setMetadata(mt_keys[M_DESCRIPTION].second, sc->convert(comment));
+            item->setMetadata(M_DESCRIPTION, sc->convert(comment));
 
         // if there are any auxilary tags that the user wants - add them
         const auto aux = config->getArrayOption(CFG_IMPORT_LIBOPTS_EXIV2_AUXDATA_TAGS_LIST);

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -144,8 +144,8 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
         }
 
         // only use ffmpeg meta data if not found by other handler
-        if (item->getMetadata(mt_keys[field].second).empty())
-            item->setMetadata(mt_keys[field].second, sc->convert(trimString(value)));
+        if (item->getMetadata(field).empty())
+            item->setMetadata(field, sc->convert(trimString(value)));
     }
 }
 

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -302,7 +302,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
                 // from YYYY:MM:DD to YYYY-MM-DD
                 if (value.length() >= 11) {
                     value = value.substr(0, 4) + "-" + value.substr(5, 2) + "-" + value.substr(8, 2);
-                    item->setMetadata(MetadataHandler::getMetaFieldName(M_DATE), value);
+                    item->setMetadata(M_DATE, value);
                 }
             }
             break;
@@ -312,7 +312,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
             value = trimString(value);
             if (!value.empty()) {
                 value = sc->convert(value);
-                item->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), value);
+                item->setMetadata(M_DESCRIPTION, value);
             }
             break;
 

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -198,7 +198,7 @@ void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream
             }
             std::string title(UTFstring(*title_el).GetUTF8());
             // printf("KaxTitle = %s\n", title.c_str());
-            item->setMetadata(mt_keys[M_TITLE].second, sc->convert(title));
+            item->setMetadata(M_TITLE, sc->convert(title));
         } else if (EbmlId(*el) == KaxDateUTC::ClassInfos.GlobalId) {
             auto date_el = dynamic_cast<KaxDateUTC*>(el);
             if (date_el == nullptr) {
@@ -212,7 +212,7 @@ void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream
             i_date = date.GetEpochDate();
             if (gmtime_r(&i_date, &tmres) && strftime(buffer.data(), buffer.size(), "%Y-%m-%d", &tmres)) {
                 // printf("KaxDateUTC = %s\n", buffer);
-                item->setMetadata(mt_keys[M_DATE].second, sc->convert(buffer.data()));
+                item->setMetadata(M_DATE, sc->convert(buffer.data()));
             }
         }
     }

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -76,7 +76,7 @@ fs::path MetacontentHandler::getContentPath(const std::vector<std::string>& name
     return "";
 }
 
-static std::map<std::string, int> metaTags = {
+static std::map<std::string, metadata_fields_t> metaTags = {
     { "%album%", M_ALBUM },
     { "%title%", M_TITLE },
 };
@@ -87,7 +87,7 @@ std::string MetacontentHandler::expandName(const std::string& name, const std::s
     std::string copy(name);
 
     for (const auto& [key, val] : metaTags)
-        replaceString(copy, key, item->getMetadata(mt_keys.at(val).second));
+        replaceString(copy, key, item->getMetadata(val));
 
     fs::path location = item->getLocation();
     replaceString(copy, "%filename%", location.stem());

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -113,29 +113,30 @@ typedef enum {
     M_MAX
 } metadata_fields_t;
 
-constexpr std::array<std::pair<const char*, const char*>, 21> mt_keys = { {
-    { "M_TITLE", "dc:title" },
-    { "M_ARTIST", "upnp:artist" },
-    { "M_ALBUM", "upnp:album" },
-    { "M_DATE", "dc:date" },
-    { "M_UPNP_DATE", "upnp:date" },
-    { "M_GENRE", "upnp:genre" },
-    { "M_DESCRIPTION", "dc:description" },
-    { "M_LONGDESCRIPTION", "upnp:longDescription" },
-    { "M_TRACKNUMBER", "upnp:originalTrackNumber" },
-    { "M_ALBUMARTURI", "upnp:albumArtURI" },
-    { "M_REGION", "upnp:region" },
-    { "M_AUTHOR", "upnp:author" },
-    { "M_DIRECTOR", "upnp:director" },
-    { "M_PUBLISHER", "dc:publisher" },
-    { "M_RATING", "upnp:rating" },
-    { "M_ACTOR", "upnp:actor" },
-    { "M_PRODUCER", "upnp:producer" },
-    { "M_ALBUMARTIST", "upnp:artist@role[AlbumArtist]" },
-    { "M_COMPOSER", "upnp:composer" },
-    { "M_CONDUCTOR", "upnp:conductor" },
-    { "M_ORCHESTRA", "upnp:orchestra" },
+constexpr std::array<std::pair<metadata_fields_t, const char*>, 21> mt_keys = { {
+    { M_TITLE, "dc:title" },
+    { M_ARTIST, "upnp:artist" },
+    { M_ALBUM, "upnp:album" },
+    { M_DATE, "dc:date" },
+    { M_UPNP_DATE, "upnp:date" },
+    { M_GENRE, "upnp:genre" },
+    { M_DESCRIPTION, "dc:description" },
+    { M_LONGDESCRIPTION, "upnp:longDescription" },
+    { M_TRACKNUMBER, "upnp:originalTrackNumber" },
+    { M_ALBUMARTURI, "upnp:albumArtURI" },
+    { M_REGION, "upnp:region" },
+    { M_AUTHOR, "upnp:author" },
+    { M_DIRECTOR, "upnp:director" },
+    { M_PUBLISHER, "dc:publisher" },
+    { M_RATING, "upnp:rating" },
+    { M_ACTOR, "upnp:actor" },
+    { M_PRODUCER, "upnp:producer" },
+    { M_ALBUMARTIST, "upnp:artist@role[AlbumArtist]" },
+    { M_COMPOSER, "upnp:composer" },
+    { M_CONDUCTOR, "upnp:conductor" },
+    { M_ORCHESTRA, "upnp:orchestra" },
 } };
+
 
 // res tag attributes
 typedef enum {

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -169,7 +169,7 @@ void TagLibHandler::addField(metadata_fields_t field, const TagLib::File& file, 
     value = trimString(value);
 
     if (!value.empty()) {
-        item->setMetadata(mt_keys.at(field).second, sc->convert(value));
+        item->setMetadata(field, sc->convert(value));
         //        log_debug("Setting metadata on item: {}, {}", field, sc->convert(value).c_str());
     }
 }

--- a/src/onlineservice/atrailers_content_handler.cc
+++ b/src/onlineservice/atrailers_content_handler.cc
@@ -142,18 +142,15 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
 
     temp = info.child("rating").text().as_string();
     if (!temp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_RATING),
-            temp);
+        item->setMetadata(M_RATING, temp);
 
     temp = info.child("studio").text().as_string();
     if (!temp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_PRODUCER),
-            temp);
+        item->setMetadata(M_PRODUCER, temp);
 
     temp = info.child("director").text().as_string();
     if (!temp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_DIRECTOR),
-            temp);
+        item->setMetadata(M_DIRECTOR, temp);
 
     temp = info.child("postdate").text().as_string();
     if (!temp.empty())
@@ -161,13 +158,12 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
 
     temp = info.child("releasedate").text().as_string();
     if (!temp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_DATE),
-            temp);
+        item->setMetadata(M_DATE, temp);
 
     temp = info.child("description").text().as_string();
     if (!temp.empty()) {
         /// \todo cut out a small part for the usual description
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_LONGDESCRIPTION), temp);
+        item->setMetadata(M_LONGDESCRIPTION, temp);
     }
 
     auto cast = trailer.child("cast");
@@ -189,8 +185,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
         }
 
         if (!actors.empty())
-            item->setMetadata(MetadataHandler::getMetaFieldName(M_GENRE),
-                temp);
+            item->setMetadata(M_GENRE, temp);
     }
 
     auto genre = trailer.child("genre");
@@ -212,8 +207,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
         }
 
         if (!genres.empty())
-            item->setMetadata(MetadataHandler::getMetaFieldName(M_GENRE),
-                temp);
+            item->setMetadata(M_GENRE, temp);
     }
 
     /*

--- a/src/onlineservice/sopcast_content_handler.cc
+++ b/src/onlineservice/sopcast_content_handler.cc
@@ -196,12 +196,12 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& g
     if (tmp_el != nullptr) {
         temp = tmp_el.attribute("en").as_string();
         if (!temp.empty())
-            item->setMetadata(MetadataHandler::getMetaFieldName(M_REGION), temp);
+            item->setMetadata(M_REGION, temp);
     }
 
     temp = channel.child("description").text().as_string();
     if (!temp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), temp);
+        item->setMetadata(M_DESCRIPTION, temp);
 
     temp = channel.attribute("language").as_string();
     if (!temp.empty())

--- a/src/scripting/script_names.h
+++ b/src/scripting/script_names.h
@@ -1,0 +1,80 @@
+/*GRB*
+
+    Gerbera - https://gerbera.io/
+
+    script_names.h - this file is part of Gerbera.
+
+    Copyright (C) 2020 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+
+    $Id$
+*/
+
+/// \file script_names.h
+
+#ifndef __SCRIPTING_SCRIPT_NAMES_H__
+#define __SCRIPTING_SCRIPT_NAMES_H__
+
+#include <array>
+
+#include "metadata/metadata_handler.h"
+
+constexpr std::array<std::pair<metadata_fields_t, const char*>, 21> mt_names = { {
+    { M_TITLE, "M_TITLE" },
+    { M_ARTIST, "M_ARTIST" },
+    { M_ALBUM, "M_ALBUM" },
+    { M_DATE, "M_DATE" },
+    { M_UPNP_DATE, "M_UPNP_DATE" },
+    { M_GENRE, "M_GENRE" },
+    { M_DESCRIPTION, "M_DESCRIPTION" },
+    { M_LONGDESCRIPTION, "M_LONGDESCRIPTION" },
+    { M_TRACKNUMBER, "M_TRACKNUMBER" },
+    { M_ALBUMARTURI, "M_ALBUMARTURI" },
+    { M_REGION, "M_REGION" },
+    { M_AUTHOR, "M_AUTHOR" },
+    { M_DIRECTOR, "M_DIRECTOR" },
+    { M_PUBLISHER, "M_PUBLISHER" },
+    { M_RATING, "M_RATING" },
+    { M_ACTOR, "M_ACTOR" },
+    { M_PRODUCER, "M_PRODUCER" },
+    { M_ALBUMARTIST, "M_ALBUMARTIST" },
+    { M_COMPOSER, "M_COMPOSER" },
+    { M_CONDUCTOR, "M_CONDUCTOR" },
+    { M_ORCHESTRA, "M_ORCHESTRA" }
+} };
+
+constexpr std::array<std::pair<int, const char*>, 5> ot_names = { {
+    { OBJECT_TYPE_CONTAINER, "OBJECT_TYPE_CONTAINER" },
+    { OBJECT_TYPE_ITEM, "OBJECT_TYPE_ITEM" },
+    { OBJECT_TYPE_ACTIVE_ITEM, "OBJECT_TYPE_ACTIVE_ITEM" },
+    { OBJECT_TYPE_ITEM_EXTERNAL_URL, "OBJECT_TYPE_ITEM_EXTERNAL_URL" },
+    { OBJECT_TYPE_ITEM_INTERNAL_URL, "OBJECT_TYPE_ITEM_INTERNAL_URL" }
+} };
+
+constexpr std::array<std::pair<const char*, const char*>, 12> upnp_classes = { {
+    { UPNP_DEFAULT_CLASS_MUSIC_ALBUM, "UPNP_CLASS_CONTAINER_MUSIC_ALBUM" },
+    { UPNP_DEFAULT_CLASS_MUSIC_ARTIST, "UPNP_CLASS_CONTAINER_MUSIC_ARTIST" },
+    { UPNP_DEFAULT_CLASS_MUSIC_GENRE, "UPNP_CLASS_CONTAINER_MUSIC_GENRE" },
+    { UPNP_DEFAULT_CLASS_MUSIC_COMPOSER, "UPNP_CLASS_CONTAINER_MUSIC_COMPOSER" },
+    { UPNP_DEFAULT_CLASS_MUSIC_CONDUCTOR, "UPNP_CLASS_CONTAINER_MUSIC_CONDUCTOR" },
+    { UPNP_DEFAULT_CLASS_MUSIC_ORCHESTRA, "UPNP_CLASS_CONTAINER_MUSIC_ORCHESTRA" },
+    { UPNP_DEFAULT_CLASS_CONTAINER, "UPNP_CLASS_CONTAINER" },
+    { UPNP_DEFAULT_CLASS_ITEM, "UPNP_CLASS_ITEM" },
+    { UPNP_DEFAULT_CLASS_MUSIC_TRACK, "UPNP_CLASS_ITEM_MUSIC_TRACK" },
+    { UPNP_DEFAULT_CLASS_VIDEO_ITEM, "UPNP_CLASS_CONTAINER_ITEM_VIDEO" },
+    { UPNP_DEFAULT_CLASS_IMAGE_ITEM, "UPNP_CLASS_CONTAINER_ITEM_IMAGE" },
+    { UPNP_DEFAULT_CLASS_PLAYLIST_CONTAINER, "UPNP_CLASS_PLAYLIST_CONTAINER" }
+} };
+
+#endif

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -224,8 +224,7 @@ void UpnpXMLBuilder::updateObject(const std::shared_ptr<CdsObject>& obj, const s
 
         /// \todo description should be taken from the dictionary
         std::string description = root.child("dc:description").text().as_string();
-        aitem->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION),
-            description);
+        aitem->setMetadata(M_DESCRIPTION, description);
 
         std::string location = root.child("location").text().as_string();
         if (!location.empty())

--- a/src/web/add_object.cc
+++ b/src/web/add_object.cc
@@ -63,7 +63,7 @@ std::shared_ptr<CdsObject> web::addObject::addItem(int parentID, std::shared_ptr
 
     std::string tmp = param("description");
     if (!tmp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), tmp);
+        item->setMetadata(M_DESCRIPTION, tmp);
 
     /// \todo is there a default setting? autoscan? import settings?
     tmp = param("mime-type");
@@ -102,7 +102,7 @@ std::shared_ptr<CdsObject> web::addObject::addActiveItem(int parentID)
 
     tmp = param("description");
     if (!tmp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), tmp);
+        item->setMetadata(M_DESCRIPTION, tmp);
 
     /// \todo is there a default setting? autoscan? import settings?
 
@@ -128,7 +128,7 @@ std::shared_ptr<CdsObject> web::addObject::addUrl(int parentID, std::shared_ptr<
 
     std::string tmp = param("description");
     if (!tmp.empty())
-        item->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), tmp);
+        item->setMetadata(M_DESCRIPTION, tmp);
 
     /// \todo is there a default setting? autoscan? import settings?
     tmp = param("mime-type");

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -78,7 +78,7 @@ void web::edit_load::process()
         auto objItem = std::static_pointer_cast<CdsItem>(obj);
 
         auto description = item.append_child("description");
-        description.append_attribute("value") = objItem->getMetadata("dc:description").c_str();
+        description.append_attribute("value") = objItem->getMetadata(M_DESCRIPTION).c_str();
         description.append_attribute("editable") = true;
 
         auto location = item.append_child("location");

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -47,11 +47,11 @@ TEST_F(UpnpXmlTest, RenderObjectContainer)
     obj->setRestricted(false);
     obj->setTitle("Title");
     obj->setClass(UPNP_DEFAULT_CLASS_MUSIC_ALBUM);
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_ALBUMARTIST), "Creator");
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_COMPOSER), "Composer");
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_CONDUCTOR), "Conductor");
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_ORCHESTRA), "Orchestra");
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_UPNP_DATE), "2001-01-01");
+    obj->setMetadata(M_ALBUMARTIST, "Creator");
+    obj->setMetadata(M_COMPOSER, "Composer");
+    obj->setMetadata(M_CONDUCTOR, "Conductor");
+    obj->setMetadata(M_ORCHESTRA, "Orchestra");
+    obj->setMetadata(M_UPNP_DATE, "2001-01-01");
     // albumArtURI
     database->findFolderImageMap.clear();
     database->findFolderImageMap[std::to_string(obj->getID())] = "10";
@@ -91,9 +91,9 @@ TEST_F(UpnpXmlTest, RenderObjectItem)
     obj->setRestricted(false);
     obj->setTitle("Title");
     obj->setClass(UPNP_DEFAULT_CLASS_MUSIC_TRACK);
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_DESCRIPTION), "Description");
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_TRACKNUMBER), "10");
-    obj->setMetadata(MetadataHandler::getMetaFieldName(M_ALBUM), "Album");
+    obj->setMetadata(M_DESCRIPTION, "Description");
+    obj->setMetadata(M_TRACKNUMBER, "10");
+    obj->setMetadata(M_ALBUM, "Album");
 
     std::ostringstream expectedXml;
     expectedXml << "<DIDL-Lite>\n";
@@ -161,7 +161,7 @@ TEST_F(UpnpXmlTest, UpdatesObjectActiveItem)
     auto aitem = std::static_pointer_cast<CdsActiveItem>(obj);
     EXPECT_NE(aitem, nullptr);
     EXPECT_STREQ(aitem->getTitle().c_str(), "Title");
-    EXPECT_STREQ(aitem->getMetadata("dc:description").c_str(), "description");
+    EXPECT_STREQ(aitem->getMetadata(M_DESCRIPTION).c_str(), "description");
     EXPECT_STREQ(aitem->getLocation().c_str(), "/location");
     EXPECT_STREQ(aitem->getMimeType().c_str(), "audio/mpeg");
     EXPECT_STREQ(aitem->getAction().c_str(), "action");

--- a/test/scripting/mock/script_test_fixture.cc
+++ b/test/scripting/mock/script_test_fixture.cc
@@ -10,6 +10,7 @@ namespace fs = std::filesystem;
 #include "cds_objects.h"
 #include "metadata/metadata_handler.h"
 #include "onlineservice/atrailers_content_handler.h"
+#include "scripting/script_names.h"
 #include "util/string_converter.h"
 #include "util/tools.h"
 
@@ -111,9 +112,11 @@ duk_ret_t ScriptTestFixture::dukMockPlaylist(duk_context* ctx, string title, str
 
 void ScriptTestFixture::addGlobalFunctions(duk_context* ctx, const duk_function_list_entry* funcs)
 {
-    for (const auto& [sym, upnp] : mt_keys) {
-        duk_push_string(ctx, upnp);
-        duk_put_global_string(ctx, sym);
+    for (const auto& entry : mt_keys) {
+        duk_push_string(ctx, entry.second);
+        auto sym = std::find_if(mt_names.begin(), mt_names.end(), [=](const auto& n) { return n.first == entry.first; });
+        if (sym != mt_names.end())
+            duk_put_global_string(ctx, sym->second);
     }
 
     for (const auto& [sym, upnp] : res_keys) {
@@ -121,30 +124,15 @@ void ScriptTestFixture::addGlobalFunctions(duk_context* ctx, const duk_function_
         duk_put_global_string(ctx, sym);
     }
 
-    duk_push_int(ctx, OBJECT_TYPE_ITEM_EXTERNAL_URL);
-    duk_put_global_string(ctx, "OBJECT_TYPE_ITEM_EXTERNAL_URL");
-    duk_push_int(ctx, OBJECT_TYPE_ITEM_INTERNAL_URL);
-    duk_put_global_string(ctx, "OBJECT_TYPE_ITEM_INTERNAL_URL");
-    duk_push_int(ctx, OBJECT_TYPE_ITEM);
-    duk_put_global_string(ctx, "OBJECT_TYPE_ITEM");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_TRACK);
-    duk_put_global_string(ctx, "UPNP_CLASS_ITEM_MUSIC_TRACK");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_PLAYLIST_CONTAINER);
-    duk_put_global_string(ctx, "UPNP_CLASS_PLAYLIST_CONTAINER");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_ALBUM);
-    duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_ALBUM");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_ARTIST);
-    duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_ARTIST");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_GENRE);
-    duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_GENRE");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_COMPOSER);
-    duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_COMPOSER");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_CONDUCTOR);
-    duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_CONDUCTOR");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_MUSIC_ORCHESTRA);
-    duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER_MUSIC_ORCHESTRA");
-    duk_push_string(ctx, UPNP_DEFAULT_CLASS_CONTAINER);
-    duk_put_global_string(ctx, "UPNP_CLASS_CONTAINER");
+    for (const auto& [field, sym] : ot_names)  {
+        duk_push_int(ctx, field);
+        duk_put_global_string(ctx, sym);
+    }
+
+    for (const auto& [field, sym] : upnp_classes)  {
+        duk_push_string(ctx, field);
+        duk_put_global_string(ctx, sym);
+    }
 
     duk_push_int(ctx, 0);
     duk_put_global_string(ctx, "ONLINE_SERVICE_NONE");


### PR DESCRIPTION
Move call to `MetadataHandler::getMetaFieldName` into `CdsObject::get/setMetadata`.

Avoids propagation of internal structure of `mt_keys`.
Additionally move names for scripting variables into separate array.