### PR TITLE
use parentheses in macros

### DIFF
--- a/src/autoscan.h
+++ b/src/autoscan.h
@@ -43,7 +43,7 @@ namespace fs = std::filesystem;
 class Database;
 class AutoscanDirectory;
 
-#define INVALID_SCAN_ID -1
+#define INVALID_SCAN_ID (-1)
 
 ///\brief Scan mode - type of scan (timed, inotify, fam, etc.)
 enum class ScanMode {

--- a/src/autoscan_inotify.h
+++ b/src/autoscan_inotify.h
@@ -47,8 +47,8 @@
 class Database;
 class ContentManager;
 
-#define INOTIFY_ROOT -1
-#define INOTIFY_UNKNOWN_PARENT_WD -2
+#define INOTIFY_ROOT (-1)
+#define INOTIFY_UNKNOWN_PARENT_WD (-2)
 
 class AutoscanInotify {
 public:

--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -62,12 +62,15 @@ class Database;
 #define STRING_OBJECT_TYPE_EXTERNAL_URL "external_url"
 #define STRING_OBJECT_TYPE_INTERNAL_URL "internal_url"
 
-#define IS_CDS_CONTAINER(type) (type & OBJECT_TYPE_CONTAINER)
-#define IS_CDS_ITEM(type) (type & OBJECT_TYPE_ITEM)
-#define IS_CDS_ACTIVE_ITEM(type) (type & OBJECT_TYPE_ACTIVE_ITEM)
-#define IS_CDS_ITEM_EXTERNAL_URL(type) (type & OBJECT_TYPE_ITEM_EXTERNAL_URL)
-#define IS_CDS_ITEM_INTERNAL_URL(type) (type & OBJECT_TYPE_ITEM_INTERNAL_URL)
-#define IS_CDS_PURE_ITEM(type) (type == OBJECT_TYPE_ITEM)
+static constexpr bool IS_CDS_CONTAINER(unsigned int type)
+{
+    return type & OBJECT_TYPE_CONTAINER;
+};
+static constexpr bool IS_CDS_ITEM(unsigned int type) { return type & OBJECT_TYPE_ITEM; };
+static constexpr bool IS_CDS_ACTIVE_ITEM(unsigned int type) { return type & OBJECT_TYPE_ACTIVE_ITEM; };
+static constexpr bool IS_CDS_ITEM_EXTERNAL_URL(unsigned int type) { return type & OBJECT_TYPE_ITEM_EXTERNAL_URL; };
+static constexpr bool IS_CDS_ITEM_INTERNAL_URL(unsigned int type) { return type & OBJECT_TYPE_ITEM_INTERNAL_URL; };
+static constexpr bool IS_CDS_PURE_ITEM(unsigned int type) { return type == OBJECT_TYPE_ITEM; };
 
 #define OBJECT_FLAG_RESTRICTED 0x00000001u
 #define OBJECT_FLAG_SEARCHABLE 0x00000002u

--- a/src/common.h
+++ b/src/common.h
@@ -96,10 +96,10 @@
 #define D_PN_AVC_MP4_EU "AVC_MP4_EU"
 #define D_PN_AVI "AVI"
 // fixed CdsObjectIDs
-#define CDS_ID_BLACKHOLE -1
+#define CDS_ID_BLACKHOLE (-1)
 #define CDS_ID_ROOT 0
 #define CDS_ID_FS_ROOT 1
-#define IS_FORBIDDEN_CDS_ID(id) (id <= CDS_ID_FS_ROOT)
+static constexpr bool IS_FORBIDDEN_CDS_ID(int id) { return id <= CDS_ID_FS_ROOT; }
 
 // internal setting keys
 #define SET_LAST_MODIFIED "last_modified"


### PR DESCRIPTION
Found with bugprone-macro-parentheses

Instead of that, just use a constexpr function. Looks cleaner.

Signed-off-by: Rosen Penev <rosenp@gmail.com>