### PR TITLE
CMake: find_package for pkgconfig

### DIFF
--- a/cmake/FindSystemd.cmake
+++ b/cmake/FindSystemd.cmake
@@ -6,8 +6,8 @@
 # SYSTEMD_UNIT_DIR: path to install system unit files
 
 include(FindPackageHandleStandardArgs)
-include(FindPkgConfig)
 
+find_package(PkgConfig QUIET)
 pkg_check_modules(SYSTEMD systemd QUIET)
 
 if (SYSTEMD_FOUND)

--- a/cmake/Findlibuuid.cmake
+++ b/cmake/Findlibuuid.cmake
@@ -1,4 +1,4 @@
-# Find a UUID Implementaion
+# Find a UUID Implementation
 #
 # Supports e2fsprogs libuuid or BSD native UUID
 #
@@ -9,7 +9,6 @@
 # FOUND_LIBUUID            e2fsprogs UUID found
 #
 
-INCLUDE(FindPkgConfig)
 INCLUDE(CheckCXXSourceRuns)
 INCLUDE(FindPackageHandleStandardArgs)
 
@@ -31,8 +30,9 @@ endif()
 
 if(NOT libuuid_FOUND)
 	message(STATUS "Looking for libuuid")
-	pkg_search_module(_UUID libuuid QUIET)
-	if(NOT _UUID_FOUND)
+	find_package(PkgConfig QUIET)
+	pkg_search_module(PC_UUID libuuid QUIET)
+	if(NOT PC_UUID_FOUND)
 		FIND_PATH(libuuid_INCLUDE_DIRS uuid/uuid.h)
 		FIND_LIBRARY(libuuid_LIBRARIES uuid)
 


### PR DESCRIPTION
Include is the old way apparently, not that you would know that as CMake's docs are useless
This should fix warnings like:

  The package name passed to `find_package_handle_standard_args` (PkgConfig)
  does not match the name of the calling package (Blah).
