### PR TITLE
Remove database pointer from CDS Objects

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -86,8 +86,6 @@ static constexpr bool IS_CDS_PURE_ITEM(unsigned int type) { return type == OBJEC
 /// \brief Generic object in the Content Directory.
 class CdsObject {
 protected:
-    std::shared_ptr<Database> database;
-
     /// \brief ID of the object in the content directory
     int id;
 
@@ -133,7 +131,7 @@ protected:
 
 public:
     /// \brief Constructor. Sets the default values.
-    explicit CdsObject(std::shared_ptr<Database> database);
+    explicit CdsObject();
 
     /// \brief Set the object ID.
     ///
@@ -353,9 +351,6 @@ public:
 
     static std::shared_ptr<CdsObject> createObject(const std::shared_ptr<Database>& database, unsigned int objectType);
 
-    /// \brief Returns the path to the object as it appears in the database tree.
-    virtual std::string getVirtualPath() const = 0;
-
     static std::string mapObjectType(int objectType);
     static int remapObjectType(const std::string& objectType);
 };
@@ -373,7 +368,7 @@ protected:
 
 public:
     /// \brief Constructor, sets the object type and default upnp:class (object.item)
-    explicit CdsItem(std::shared_ptr<Database> database);
+    explicit CdsItem();
 
     /// \brief Set mime-type information of the media.
     void setMimeType(const std::string& mimeType) { this->mimeType = mimeType; }
@@ -397,9 +392,6 @@ public:
     /// \brief Checks if the minimum required parameters for the object have been set and are valid.
     void validate() override;
 
-    /// \brief Returns the path to the object as it appears in the database tree.
-    std::string getVirtualPath() const override;
-
     /// \brief Set the unique service ID.
     void setServiceID(const std::string& serviceID) { this->serviceID = serviceID; }
 
@@ -411,7 +403,7 @@ public:
 class CdsItemExternalURL : public CdsItem {
 public:
     /// \brief Constructor, sets the object type.
-    explicit CdsItemExternalURL(std::shared_ptr<Database> database);
+    explicit CdsItemExternalURL();
 
     /// \brief Sets the URL for the item.
     /// \param URL full url to the item: http://somewhere.com/something.mpg
@@ -444,7 +436,7 @@ public:
 class CdsItemInternalURL : public CdsItemExternalURL {
 public:
     /// \brief Constructor, sets the object type.
-    explicit CdsItemInternalURL(std::shared_ptr<Database> database);
+    explicit CdsItemInternalURL();
 
     /// \brief Checks if the minimum required parameters for the object have been set and are valid.
     void validate() override;
@@ -464,7 +456,7 @@ protected:
 
 public:
     /// \brief Constructor, initializes default values for the flags and sets the object type.
-    explicit CdsContainer(std::shared_ptr<Database> database);
+    explicit CdsContainer();
 
     /// \brief Set the searchable flag.
     void setSearchable(bool searchable) { changeFlag(OBJECT_FLAG_SEARCHABLE, searchable); }
@@ -501,9 +493,6 @@ public:
 
     /// \brief Checks if the minimum required parameters for the object have been set and are valid.
     void validate() override;
-
-    /// \brief Returns the path to the object as it appears in the database tree.
-    std::string getVirtualPath() const override;
 };
 
 #endif // __CDS_OBJECTS_H__

--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -1093,7 +1093,7 @@ std::shared_ptr<CdsObject> ContentManager::createObjectFromFile(const fs::path& 
             }
         }
 
-        auto item = std::make_shared<CdsItem>(database);
+        auto item = std::make_shared<CdsItem>();
         obj = item;
         item->setLocation(path);
         item->setMTime(statbuf.st_mtime);
@@ -1113,7 +1113,7 @@ std::shared_ptr<CdsObject> ContentManager::createObjectFromFile(const fs::path& 
             MetadataHandler::setMetadata(config, item);
         }
     } else if (S_ISDIR(statbuf.st_mode)) {
-        auto cont = std::make_shared<CdsContainer>(database);
+        auto cont = std::make_shared<CdsContainer>();
         obj = cont;
         /* adding containers is done by Database now
          * this exists only to inform the caller that
@@ -1416,10 +1416,6 @@ void ContentManager::removeObject(int objectID, bool rescanResource, bool async,
         try {
             obj = database->loadObject(objectID);
             path = obj->getLocation();
-
-            std::string vpath = obj->getVirtualPath();
-            if (!vpath.empty())
-                task->setDescription("Removing: " + obj->getVirtualPath());
         } catch (const std::runtime_error& e) {
             log_debug("trying to remove an object ID which is no longer in the database! {}", objectID);
             return;

--- a/src/onlineservice/atrailers_content_handler.cc
+++ b/src/onlineservice/atrailers_content_handler.cc
@@ -90,7 +90,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getNextObject()
 
 std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_node& trailer) const
 {
-    auto item = std::make_shared<CdsItemExternalURL>(database);
+    auto item = std::make_shared<CdsItemExternalURL>();
     auto resource = std::make_shared<CdsResource>(CH_DEFAULT);
     item->addResource(resource);
 

--- a/src/onlineservice/sopcast_content_handler.cc
+++ b/src/onlineservice/sopcast_content_handler.cc
@@ -123,7 +123,7 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getNextObject()
 
 std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& groupName, const pugi::xml_node& channel) const
 {
-    auto item = std::make_shared<CdsItemExternalURL>(database);
+    auto item = std::make_shared<CdsItemExternalURL>();
     auto resource = std::make_shared<CdsResource>(CH_DEFAULT);
     item->addResource(resource);
 

--- a/src/web/add_object.cc
+++ b/src/web/add_object.cc
@@ -139,16 +139,16 @@ void web::addObject::process()
             throw_std_runtime_error("no location given");
         if (!isRegularFile(location, ec))
             throw_std_runtime_error("file not found");
-        obj = this->addItem(parentID, std::make_shared<CdsItem>(database));
+        obj = this->addItem(parentID, std::make_shared<CdsItem>());
         allow_fifo = true;
     } else if (obj_type == STRING_OBJECT_TYPE_EXTERNAL_URL) {
         if (location.empty())
             throw_std_runtime_error("No URL given");
-        obj = this->addUrl(parentID, std::make_shared<CdsItemExternalURL>(database), true);
+        obj = this->addUrl(parentID, std::make_shared<CdsItemExternalURL>(), true);
     } else if (obj_type == STRING_OBJECT_TYPE_INTERNAL_URL) {
         if (location.empty())
             throw_std_runtime_error("No URL given");
-        obj = this->addUrl(parentID, std::make_shared<CdsItemInternalURL>(database), false);
+        obj = this->addUrl(parentID, std::make_shared<CdsItemInternalURL>(), false);
     } else {
         throw_std_runtime_error("unknown object type: " + obj_type);
     }

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -71,10 +71,6 @@ void web::items::process()
         param->setFlag(BROWSE_TRACK_SORT);
 
     auto arr = database->browse(param);
-
-    std::string location = obj->getVirtualPath();
-    if (!location.empty())
-        items.append_attribute("location") = location.c_str();
     items.append_attribute("virtual") = obj->isVirtual();
 
     items.append_attribute("start") = start;

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -41,7 +41,7 @@ TEST_F(UpnpXmlTest, RenderObjectContainer)
     // arrange
     pugi::xml_document didl_lite;
     auto root = didl_lite.append_child("DIDL-Lite");
-    auto obj = std::make_shared<CdsContainer>(nullptr);
+    auto obj = std::make_shared<CdsContainer>();
     obj->setID(1);
     obj->setParentID(2);
     obj->setRestricted(false);
@@ -85,7 +85,7 @@ TEST_F(UpnpXmlTest, RenderObjectItem)
     // arrange
     pugi::xml_document didl_lite;
     auto root = didl_lite.append_child("DIDL-Lite");
-    auto obj = std::make_shared<CdsItem>(nullptr);
+    auto obj = std::make_shared<CdsItem>();
     obj->setID(1);
     obj->setParentID(2);
     obj->setRestricted(false);
@@ -158,7 +158,7 @@ TEST_F(UpnpXmlTest, CreateResponse)
 
 TEST_F(UpnpXmlTest, FirstResourceRendersPureWhenExternalUrl)
 {
-    auto obj = std::make_shared<CdsItemExternalURL>(nullptr);
+    auto obj = std::make_shared<CdsItemExternalURL>();
     obj->setLocation("http://localhost/external/url");
 
     auto item = std::static_pointer_cast<CdsItem>(obj);
@@ -171,7 +171,7 @@ TEST_F(UpnpXmlTest, FirstResourceRendersPureWhenExternalUrl)
 
 TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToExternalUrlWhenOnlineWithProxy)
 {
-    auto obj = std::make_shared<CdsItemExternalURL>(nullptr);
+    auto obj = std::make_shared<CdsItemExternalURL>();
     obj->setLocation("http://localhost/external/url");
     obj->setID(12345);
     obj->setFlag(OBJECT_FLAG_ONLINE_SERVICE);
@@ -187,7 +187,7 @@ TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToExternalUrlWhenOnlineWithP
 
 TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToItem)
 {
-    auto obj = std::make_shared<CdsItem>(nullptr);
+    auto obj = std::make_shared<CdsItem>();
     obj->setLocation("local/content");
     obj->setID(12345);
 
@@ -201,7 +201,7 @@ TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToItem)
 
 TEST_F(UpnpXmlTest, FirstResourceAddsContentServeToInternalUrlItem)
 {
-    auto obj = std::make_shared<CdsItemInternalURL>(nullptr);
+    auto obj = std::make_shared<CdsItemInternalURL>();
     obj->setLocation("local/content");
     obj->setID(12345);
 


### PR DESCRIPTION
Now they are just POCOs

DB access was only used for virtualUrls, and removing that functionality
seems to have no impact.