### PR TITLE
Actions: Bump clang-format lint action version

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: DoozyX/clang-format-lint-action@v0.10
+    - uses: DoozyX/clang-format-lint-action@v0.11
       with:
         source: './src'
         exclude: './contrib'


### PR DESCRIPTION
Looks like there were some bugs to allow false passing

See #1073, and #1074 for context