### PR TITLE
clang-tidy: add const to several globals

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -107,7 +107,7 @@ std::shared_ptr<Config> ConfigManager::getSelf()
     return shared_from_this();
 }
 
-std::vector<std::shared_ptr<ConfigSetup>> ConfigManager::complexOptions = {
+const std::vector<std::shared_ptr<ConfigSetup>> ConfigManager::complexOptions = {
     std::make_shared<ConfigIntSetup>(CFG_SERVER_PORT,
         "/server/port", "config-server.html#port",
         0, ConfigIntSetup::CheckPortValue),
@@ -656,7 +656,7 @@ std::vector<std::shared_ptr<ConfigSetup>> ConfigManager::complexOptions = {
         ""),
 };
 
-std::map<config_option_t, std::vector<config_option_t>> ConfigManager::parentOptions = {
+const std::map<config_option_t, std::vector<config_option_t>> ConfigManager::parentOptions = {
     { ATTR_TRANSCODING_PROFILES_PROFLE_ENABLED, { CFG_TRANSCODING_PROFILE_LIST } },
     { ATTR_TRANSCODING_PROFILES_PROFLE_ACCURL, { CFG_TRANSCODING_PROFILE_LIST } },
     { ATTR_TRANSCODING_PROFILES_PROFLE_TYPE, { CFG_TRANSCODING_PROFILE_LIST } },

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -139,9 +139,9 @@ public:
     static bool isDebugLogging() { return debug_logging; }
 
 protected:
-    static std::vector<std::shared_ptr<ConfigSetup>> complexOptions;
+    static const std::vector<std::shared_ptr<ConfigSetup>> complexOptions;
     static const std::array<std::pair<config_option_t, const char*>, 16> simpleOptions;
-    static std::map<config_option_t, std::vector<config_option_t>> parentOptions;
+    static const std::map<config_option_t, std::vector<config_option_t>> parentOptions;
 
     fs::path filename;
     fs::path prefix_dir;

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -142,7 +142,7 @@ size_t ConfigSetup::extractIndex(const std::string& item)
     return i;
 }
 
-const char* ConfigSetup::ROOT_NAME = "config";
+const char* const ConfigSetup::ROOT_NAME = "config";
 
 void ConfigStringSetup::makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -80,7 +80,7 @@ protected:
     }
 
 public:
-    static const char* ROOT_NAME;
+    static const char* const ROOT_NAME;
     config_option_t option;
     const char* xpath;
 


### PR DESCRIPTION
Found with cppcoreguidelines-avoid-non-const-global-variables

Signed-off-by: Rosen Penev <rosenp@gmail.com>