### PR TITLE
Shutdown: Check pointers before access

### DIFF
--- a/src/content_manager.cc
+++ b/src/content_manager.cc
@@ -334,22 +334,24 @@ void ContentManager::shutdown()
     destroyLayout();
 
 #ifdef HAVE_INOTIFY
-    // update mofification time for database
-    for (size_t i = 0; i < autoscan_inotify->size(); i++) {
-        log_debug("AutoScanDir {}", i);
-        std::shared_ptr<AutoscanDirectory> dir = autoscan_inotify->get(i);
-        if (dir != nullptr) {
-            if (fs::is_directory(dir->getLocation())) {
-                auto t = getLastWriteTime(dir->getLocation());
-                dir->setCurrentLMT(dir->getLocation(), t);
+    if (autoscan_inotify) {
+        // update modification time for database
+        for (size_t i = 0; i < autoscan_inotify->size(); i++) {
+            log_debug("AutoScanDir {}", i);
+            std::shared_ptr<AutoscanDirectory> dir = autoscan_inotify->get(i);
+            if (dir != nullptr) {
+                if (fs::is_directory(dir->getLocation())) {
+                    auto t = getLastWriteTime(dir->getLocation());
+                    dir->setCurrentLMT(dir->getLocation(), t);
+                }
+                dir->updateLMT();
             }
-            dir->updateLMT();
         }
-    }
+        autoscan_inotify->updateLMinDB();
 
-    autoscan_inotify->updateLMinDB();
-    autoscan_inotify = nullptr;
-    inotify = nullptr;
+        autoscan_inotify = nullptr;
+        inotify = nullptr;
+    }
 #endif
 
     shutdownFlag = true;

--- a/src/server.cc
+++ b/src/server.cc
@@ -290,8 +290,10 @@ void Server::shutdown()
     log_debug("now calling upnp finish");
     UpnpFinish();
 
-    content->shutdown();
-    content = nullptr;
+    if (content) {
+        content->shutdown();
+        content = nullptr;
+    }
 #ifdef HAVE_LASTFMLIB
     last_fm->shutdown();
     last_fm = nullptr;


### PR DESCRIPTION
When UpnpInit2 fails we should should still shutdown cleanly

Replicated by trying to start gerbera without IPv4

Issue #1090
