### PR TITLE
improve duration and bitrate calculations

### DIFF
--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -180,29 +180,24 @@ void TagLibHandler::populateGenericTags(const std::shared_ptr<CdsItem>& item, co
         return;
 
     const TagLib::Tag* tag = file.tag();
-
     for (size_t i = 0; i < mt_keys.size(); i++)
         addField(metadata_fields_t(i), file, tag, item);
 
-    int temp;
-
     const TagLib::AudioProperties* audioProps = file.audioProperties();
-
     if (!audioProps)
         return;
 
-    // note: UPnP requres bytes/second
-    temp = audioProps->bitrate() * 1024 / 8;
-
     auto res = item->getResource(0);
 
+    // UPnP bitrate is in bytes/second
+    int temp = audioProps->bitrate() * 1024 / 8; // kbit/second -> byte/second
     if (temp > 0) {
         res->addAttribute(R_BITRATE, std::to_string(temp));
     }
 
-    temp = audioProps->length();
+    temp = audioProps->lengthInMilliseconds();
     if (temp > 0) {
-        res->addAttribute(R_DURATION, secondsToHMS(temp));
+        res->addAttribute(R_DURATION, millisecondsToHMSF(temp));
     }
 
     temp = audioProps->sampleRate();

--- a/src/onlineservice/lastfm_scrobbler.cc
+++ b/src/onlineservice/lastfm_scrobbler.cc
@@ -108,7 +108,7 @@ void LastFm::startedPlaying(std::shared_ptr<CdsItem> item)
     if (item->getResourceCount() > 0) {
         auto resource = item->getResource(0);
         std::string duration = resource->getAttribute(R_DURATION);
-        info->track_length_in_secs = HMSToSeconds(duration.c_str());
+        info->track_length_in_secs = HMSFToMilliseconds(duration.c_str()) / 1000;
     }
 
     started_playing(scrobbler, info);

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -600,18 +600,21 @@ std::string getProtocol(const std::string& protocolInfo)
     return (pos == std::string::npos || pos == 0) ? "http-get" : protocolInfo.substr(0, pos);
 }
 
-std::string secondsToHMS(int seconds)
+std::string millisecondsToHMSF(int milliseconds)
 {
-    auto s = seconds % 60;
-    seconds /= 60;
+    auto ms = milliseconds % 1000;
+    milliseconds /= 1000;
 
-    auto m = seconds % 60;
-    auto h = std::min(seconds / 60, 999);
+    auto s = milliseconds % 60;
+    milliseconds /= 60;
 
-    return fmt::format("{:02}:{:02}:{:02}", h, m, s);
+    auto m = milliseconds % 60;
+    auto h = milliseconds / 60;
+
+    return fmt::format("{:01}:{:02}:{:02}.{:03}", h, m, s, ms);
 }
 
-int HMSToSeconds(const std::string& time)
+int HMSFToMilliseconds(const std::string& time)
 {
     if (time.empty()) {
         log_warning("Could not convert time representation to seconds!");
@@ -621,9 +624,10 @@ int HMSToSeconds(const std::string& time)
     int hours = 0;
     int minutes = 0;
     int seconds = 0;
-    sscanf(time.c_str(), "%d:%d:%d", &hours, &minutes, &seconds);
+    int ms = 0;
+    sscanf(time.c_str(), "%d:%d:%d.%d", &hours, &minutes, &seconds, &ms);
 
-    return (hours * 3600) + (minutes * 60) + seconds;
+    return ((hours * 3600) + (minutes * 60) + seconds) * 1000 + ms;
 }
 
 #ifdef HAVE_MAGIC

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -193,12 +193,11 @@ std::string getMTFromProtocolInfo(const std::string& protocol);
 /// \return Protocol (i.e. http-get).
 std::string getProtocol(const std::string& protocolInfo);
 
-/// \brief Converts a number of seconds to H+:MM:SS representation as required by
-/// the UPnP spec
-std::string secondsToHMS(int seconds);
+/// \brief Converts a number of milliseconds to "H*:MM:SS.F*" representation as required by the UPnP duration spec
+std::string millisecondsToHMSF(int milliseconds);
 
-/// \brief converts a "H:MM:SS:" representation to seconds
-int HMSToSeconds(const std::string& time);
+/// \brief converts a "H*:MM:SS.F*" representation to milliseconds
+int HMSFToMilliseconds(const std::string& time);
 
 #ifdef HAVE_MAGIC
 /// \brief Extracts mimetype from a file using filemagic

--- a/test/util/test_tools.cc
+++ b/test/util/test_tools.cc
@@ -4,17 +4,12 @@
 
 using namespace ::testing;
 
-TEST(ToolsTest, secondsToHMS)
+TEST(ToolsTest, millisecondsToHMSF)
 {
-    EXPECT_EQ(secondsToHMS(0), "00:00:00");
-    EXPECT_EQ(secondsToHMS(1), "00:00:01");
-    EXPECT_EQ(secondsToHMS(62), "00:01:02");
-    EXPECT_EQ(secondsToHMS(3662), "01:01:02");
-}
-
-TEST(ToolsTest, secondsToHMSOverflow)
-{
-    EXPECT_EQ(secondsToHMS(1000 * 3600 + 1), "999:00:01");
+    EXPECT_EQ(millisecondsToHMSF(0), "0:00:00.000");
+    EXPECT_EQ(millisecondsToHMSF(1 * 1000), "0:00:01.000");
+    EXPECT_EQ(millisecondsToHMSF(62 * 1000), "0:01:02.000");
+    EXPECT_EQ(millisecondsToHMSF((3600 + 60 + 2) * 1000 + 123), "1:01:02.123");
 }
 
 TEST(ToolsTest, readWriteBinaryFile)


### PR DESCRIPTION
- avoid using deprecated taglib audioProps->length()
- unify milliseconds to upnp duration string conversion
- remove cap to 999 hours, upnp spec does not enforce this, other services are also not doing this (this was only done in one of our paths)
- rename HMSToSeconds to HMSFToMilliseconds, so it matches millisecondsToHMSF