### PR TITLE
Set track number if needed and support some more meta data on FFmpeg handler.

### DIFF
--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -140,13 +140,26 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
         } else if (strcmp(e->key, "track") == 0) {
             log_debug("Identified metadata track: {}", e->value);
             field = M_TRACKNUMBER;
+        } else if (strcmp(e->key, "album_artist") == 0) {
+            log_debug("Identified metadata album_artist: {}", e->value);
+            field = M_ALBUMARTIST;
+        } else if (strcmp(e->key, "composer") == 0) {
+            log_debug("Identified metadata composer: {}", e->value);
+            field = M_COMPOSER;
+        } else if (strcmp(e->key, "performer") == 0) {
+            log_debug("Identified metadata performer: {}", e->value);
+            field = M_CONDUCTOR;
         } else {
             continue;
         }
 
         // only use ffmpeg meta data if not found by other handler
-        if (item->getMetadata(field).empty())
+        if (item->getMetadata(field).empty()) {
             item->setMetadata(field, sc->convert(trimString(value)));
+            if (field == M_TRACKNUMBER) {
+                item->setTrackNumber(std::stoi(value));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I found that DSF files are not sorted by track number on UPNP_CLASS_CONTAINER_MUSIC_ALBUM.
So I propose to update FFmpeg handler to set it if needed. 
I ever see 2 formats of track number on commercial DSF files. One is "[track number]", e.g, "1", and the other is "[track number]/[total tracks]", e.g. "1/10". I confirmed this patch can set track number correctly for both of the 2 formats.

Furthermore, I want to import some more meta data types on FFmpeg handler refer to [FFmpeg Metadata#mp3](https://wiki.multimedia.cx/index.php/FFmpeg_Metadata).