### PR TITLE
pass "*" to UpnpInit2 instead of nullptr

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -104,7 +104,11 @@ void Server::run()
     auto port = in_port_t(config->getIntOption(CFG_SERVER_PORT));
 
     log_info("Initialising libupnp with interface: '{}', port: {}", iface.c_str(), port);
+#if defined(USING_NPUPNP)
+    const char* IfName = iface.empty() ? "*" : iface.c_str();
+#else
     const char* IfName = iface.empty() ? nullptr : iface.c_str();
+#endif
     ret = UpnpInit2(IfName, port);
     if (ret != UPNP_E_SUCCESS) {
         throw UpnpException(ret, "run: UpnpInit failed");


### PR DESCRIPTION
This binds to all interfaces instead of just one.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

ping @medoc92 I haven't actually tested this. I remember an issue with docker where libnpupnp did not work properly. It only bound to an IPv6 interface or something.

Nevertheless I do believe this should work properly based on my reading of the npupnp code.