### PR TITLE
fix UserAgent lookup, different between UpnP services and file request

### DIFF
--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -154,9 +154,6 @@ std::string ClientConfig::mapClientType(ClientType clientType)
     case ClientType::SamsungBDJ5500:
         clientType_str = "SamsungBDJ5500";
         break;
-    case ClientType::VLC:
-        clientType_str = "VLC";
-        break;
     case ClientType::StandardUPnP:
         clientType_str = "StandardUPnP";
         break;
@@ -207,9 +204,6 @@ ClientType ClientConfig::remapClientType(const std::string& clientType)
     }
     if (clientType == "StandardUPnP") {
         return ClientType::StandardUPnP;
-    }
-    if (clientType == "VLC") {
-        return ClientType::VLC;
     }
     if (clientType == "None") {
         return ClientType::Unknown;

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -59,6 +59,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     log_debug("start");
 
     const struct sockaddr_storage* ctrlPtIPAddr = UpnpFileInfo_get_CtrlPtIPAddr(info);
+    // HINT: most clients do not report exactly the same User-Agent for UPnP services and file request.
     std::string userAgent = UpnpFileInfo_get_Os_cstr(info);
     auto quirks = std::make_unique<Quirks>(config, ctrlPtIPAddr, userAgent);
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -317,13 +317,11 @@ int Server::handleUpnpRootDeviceEvent(Upnp_EventType eventtype, const void* even
     switch (eventtype) {
 
     case UPNP_CONTROL_ACTION_REQUEST:
-        // a CP is invoking an action
         log_debug("UPNP_CONTROL_ACTION_REQUEST");
         try {
             auto request = std::make_unique<ActionRequest>(config, static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
             routeActionRequest(request);
             request->update();
-            // set in update() ((struct Upnp_Action_Request *)event)->ErrCode = ret;
         } catch (const UpnpException& upnp_e) {
             ret = upnp_e.getErrorCode();
             UpnpActionRequest_set_ErrCode(static_cast<UpnpActionRequest*>(const_cast<void*>(event)), ret);
@@ -333,7 +331,6 @@ int Server::handleUpnpRootDeviceEvent(Upnp_EventType eventtype, const void* even
         break;
 
     case UPNP_EVENT_SUBSCRIPTION_REQUEST:
-        // a cp wants a subscription
         log_debug("UPNP_EVENT_SUBSCRIPTION_REQUEST");
         try {
             auto request = std::make_unique<SubscriptionRequest>(static_cast<UpnpSubscriptionRequest*>(const_cast<void*>(event)));

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -46,7 +46,6 @@ enum class ClientType {
     SamsungBDP,
     SamsungSeriesCDE,
     SamsungBDJ5500,
-    VLC,
     StandardUPnP
 };
 
@@ -72,32 +71,34 @@ struct ClientInfo {
 struct ClientCacheEntry {
     struct sockaddr_storage addr;
     std::string userAgent;
-    std::string hostName;
     std::chrono::time_point<std::chrono::steady_clock> last;
     std::chrono::time_point<std::chrono::steady_clock> age;
-
     const struct ClientInfo* pInfo;
 };
 
 class Clients {
 public:
-    static void addClientByDiscovery(const struct sockaddr_storage* addr, const std::string& userAgent, const std::string& descLocation);
-
     // always return something, 'Unknown' if we do not know better
     static void getInfo(const struct sockaddr_storage* addr, const std::string& userAgent, const ClientInfo** ppInfo);
 
+    static void addClientByDiscovery(const struct sockaddr_storage* addr, const std::string& userAgent, const std::string& descLocation);
     static void addClientInfo(const std::shared_ptr<ClientInfo>& newClientInfo);
     static std::shared_ptr<std::vector<struct ClientCacheEntry>> getClientList() { return cache; }
 
 private:
-    static bool getInfoByType(const std::string& match, ClientMatchType type, const ClientInfo** ppInfo);
     static bool getInfoByAddr(const struct sockaddr_storage* addr, const ClientInfo** ppInfo);
+    static bool getInfoByType(const std::string& match, ClientMatchType type, const ClientInfo** ppInfo);
+
+    static bool getInfoByCache(const struct sockaddr_storage* addr, const ClientInfo** ppInfo);
+    static void updateCache(const struct sockaddr_storage* addr, const std::string& userAgent, const ClientInfo* pInfo);
+
     static bool downloadDescription(const std::string& location, std::unique_ptr<pugi::xml_document>& xml);
 
 private:
     static std::mutex mutex;
     using AutoLock = std::lock_guard<std::mutex>;
     static const std::shared_ptr<std::vector<struct ClientCacheEntry>> cache;
+
     static std::vector<struct ClientInfo> clientInfo;
 };
 

--- a/src/web/clients.cc
+++ b/src/web/clients.cc
@@ -53,16 +53,12 @@ void web::clients::process()
     xml2JsonHints->setArrayName(clients, "client");
 
     auto arr = Clients::getClientList();
-
     for (const auto& obj : *arr) {
         auto item = clients.append_child("client");
         auto ip = sockAddrGetNameInfo(reinterpret_cast<const struct sockaddr*>(&obj.addr));
         item.append_attribute("ip") = ip.c_str();
-        if (obj.hostName.empty()) {
-            item.append_attribute("host") = "";
-        } else {
-            item.append_attribute("host") = obj.hostName.c_str();
-        }
+        auto hostName = getHostName(reinterpret_cast<const struct sockaddr*>(&obj.addr));
+        item.append_attribute("host") = hostName.c_str();
         item.append_attribute("time") = steady_clock_to_string(obj.age).c_str();
         item.append_attribute("last") = steady_clock_to_string(obj.last).c_str();
         item.append_attribute("userAgent") = obj.userAgent.c_str();

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(Threads REQUIRED)
 add_executable(testutil
         main.cc
         test_tools.cc
+        test_upnp_clients.cc
         test_upnp_headers.cc
 )
 

--- a/test/util/test_upnp_clients.cc
+++ b/test/util/test_upnp_clients.cc
@@ -1,0 +1,145 @@
+#include <gtest/gtest.h>
+#include <upnp.h>
+
+#include "util/upnp_clients.h"
+
+using namespace ::testing;
+
+static void fillAddr(struct sockaddr_storage* addr, const char* ip)
+{
+    struct sockaddr_in sin;
+    memset(&sin, 0, sizeof (sin));
+    sin.sin_family = AF_INET;
+    sin.sin_addr.s_addr = inet_addr(ip);
+    memcpy(addr, &sin, sizeof (sin));
+}
+
+TEST(UpnpClientsTest, bubbleUPnPV3_4_4)
+{
+    const ClientInfo* pInfo = nullptr;
+    struct sockaddr_storage addr;
+    fillAddr(&addr, "192.168.1.42");
+
+    // 1. via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "Android/8.0.0 UPnP/1.0 BubbleUPnP/3.4.4", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::BubbleUPnP);
+
+    // 2. via fileInfo (e.g. info/open/read video)
+    Clients::getInfo(&addr, "BubbleUPnP UPnP/1.1", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::BubbleUPnP);
+}
+
+TEST(UpnpClientsTest, foobar2000V1_6_2)
+{
+    const ClientInfo* pInfo = nullptr;
+    struct sockaddr_storage addr;
+    fillAddr(&addr, "192.168.1.42");
+
+    // 1. via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "UPnP/1.0 DLNADOC/1.50 Platinum/1.0.4.2-bb / foobar2000", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+
+    // 2. via fileInfo (e.g. info/open/read video)
+    Clients::getInfo(&addr, "foobar2000/1.6.2", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+}
+
+TEST(UpnpClientsTest, kodiV18_9)
+{
+    const ClientInfo* pInfo = nullptr;
+    struct sockaddr_storage addr;
+    fillAddr(&addr, "192.168.1.42");
+
+    // 1. via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "UPnP/1.0 DLNADOC/1.50 Kodi", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+
+    // 2. via fileInfo (e.g. info/open/read video)
+    Clients::getInfo(&addr, "Kodi/18.9 (Windows NT 10.0.19041; Win64; x64) App_Bitness/64 Version/18.9-(18.9.0)-Git:20201023-0655c2c718", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+}
+
+TEST(UpnpClientsTest, samsungTVQ70)
+{
+    const ClientInfo* pInfo = nullptr;
+    struct sockaddr_storage addr;
+    fillAddr(&addr, "192.168.1.42");
+
+    // 1. via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "DLNADOC/1.50 SEC_HHP_[TV] Samsung Q70 Series/1.0 UPnP/1.0", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::SamsungSeriesQ);
+
+    // 2. via fileInfo (e.g. info/open/read video)
+    Clients::getInfo(&addr, "samsung-agent/1.1", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::SamsungSeriesQ);
+}
+
+TEST(UpnpClientsTest, vlcV3_0_11_1)
+{
+    const ClientInfo* pInfo = nullptr;
+    struct sockaddr_storage addr;
+    fillAddr(&addr, "192.168.1.42");
+
+    // 1. via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "Linux/5.9.0-5-amd64, UPnP/1.0, Portable SDK for UPnP devices/1.8.4", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+
+    // 2. via fileInfo (e.g. info/open/read video)
+    Clients::getInfo(&addr, "VLC/3.0.11.1 LibVLC/3.0.11.1", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+}
+
+TEST(UpnpClientsTest, windows10)
+{
+    const ClientInfo* pInfo = nullptr;
+    struct sockaddr_storage addr;
+    fillAddr(&addr, "192.168.1.42");
+
+    // via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "Microsoft-Windows/10.0 UPnP/1.0 Microsoft-DLNA DLNADOC/1.50", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+}
+
+TEST(UpnpClientsTest, multipleClientsOnSameIP)
+{
+    const ClientInfo* pInfo = nullptr;
+    struct sockaddr_storage addr;
+    fillAddr(&addr, "192.168.1.42");
+
+    // 1. Foobar2000 via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "UPnP/1.0 DLNADOC/1.50 Platinum/1.0.4.2-bb / foobar2000", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+
+    // 2. Kodi via actionReq (e.g. doBrowse)
+    Clients::getInfo(&addr, "UPnP/1.0 DLNADOC/1.50 Kodi", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+
+    // 3. Foobar2000 via fileInfo (e.g. info/open/read video)
+    Clients::getInfo(&addr, "foobar2000/1.6.2", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+
+    // 4. Kodi via fileInfo (e.g. info/open/read video)
+    Clients::getInfo(&addr, "Kodi/18.9 (Windows NT 10.0.19041; Win64; x64) App_Bitness/64 Version/18.9-(18.9.0)-Git:20201023-0655c2c718", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::StandardUPnP);
+}
+
+// keep this at the end of all tests (otherwise we need a removeClientInfo function...)
+TEST(UpnpClientsTest, configuredIP)
+{
+    const ClientInfo* pInfo = nullptr;
+    std::string ip = "192.168.1.42";
+    struct sockaddr_storage addr;
+    fillAddr(&addr, ip.c_str());
+
+    auto clientInfo = std::make_shared<struct ClientInfo>();
+    clientInfo->name = "added by config";
+    clientInfo->type = ClientType::SamsungAllShare;
+    clientInfo->flags = QUIRK_FLAG_NONE;
+    clientInfo->matchType = ClientMatchType::IP;
+    clientInfo->match = ip;
+    Clients::addClientInfo(clientInfo);
+
+    // act
+    Clients::getInfo(&addr, "any unknown user-agent info", &pInfo);
+    EXPECT_EQ(pInfo->type, ClientType::SamsungAllShare);
+}


### PR DESCRIPTION
Refactor User-Agent lookup.

Some client do not report the same User-Agent for UPnP services and file request, therefore we use what is cached previously via UpnpActionRequest to keep the code simple.

The main idea here is that before FileRequest (image/video file access) is called, an UPnP service (e.g. doBrowse) is called. From the first call we get the client info and cache it, afterwards we can reuse that info.

VLC example User-Agent info:
- ActionRequest: `Linux/5.9.0-5-amd64, UPnP/1.0, Portable SDK for UPnP devices/1.8.4`
- FileRequest: `VLC/3.0.11.1 LibVLC/3.0.11.1`

Same happens with Samsung TVs:
- ActionRequest: `DLNADOC/1.50 SEC_HHP_[TV] Samsung Q70 Series/1.0 UPnP/1.0`
- FileRequest: `samsung-agent/1.1`

I guess the reason about this is, that clients use different libraries for each of those. For UPnP services they use something like libupnp. For file request they use hand made code or any other library.
