### PR TITLE
replace gettimeofday with timespec_get

### DIFF
--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -171,7 +171,7 @@ void ProcessIOHandler::open(enum UpnpOpenFileMode mode)
 size_t ProcessIOHandler::read(char* buf, size_t length)
 {
     fd_set readSet;
-    struct timeval timeout;
+    struct timespec timeout;
     ssize_t bytes_read = 0;
     size_t num_bytes = 0;
     char* p_buffer = buf;
@@ -184,9 +184,9 @@ size_t ProcessIOHandler::read(char* buf, size_t length)
         FD_SET(fd, &readSet);
 
         timeout.tv_sec = FIFO_READ_TIMEOUT;
-        timeout.tv_usec = 0;
+        timeout.tv_nsec = 0;
 
-        ret = select(fd + 1, &readSet, nullptr, nullptr, &timeout);
+        ret = pselect(fd + 1, &readSet, nullptr, nullptr, &timeout, nullptr);
         if (ret == -1) {
             if (errno == EINTR)
                 continue;

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -754,13 +754,8 @@ std::string toCSV(const std::shared_ptr<std::unordered_set<int>>& array)
 
 void getTimespecNow(struct timespec* ts)
 {
-    struct timeval tv;
-    int ret = gettimeofday(&tv, nullptr);
-    if (ret != 0)
-        throw_std_runtime_error(fmt::format("gettimeofday failed: {}", strerror(errno)));
-
-    ts->tv_sec = tv.tv_sec;
-    ts->tv_nsec = tv.tv_usec * 1000;
+    if (timespec_get(ts, TIME_UTC) != 0)
+        throw_std_runtime_error(fmt::format("timespec_get failed: {}", strerror(errno)));
 }
 
 long getDeltaMillis(struct timespec* first)
@@ -912,7 +907,7 @@ fs::path tempName(const fs::path& leadPath, char* tmpl)
     static const char letters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     static const int NLETTERS = sizeof(letters) - 1;
     long value;
-    struct timeval tv;
+    struct timespec ts;
     static int counter = 0;
     struct stat statbuf;
     int ret = 0;
@@ -925,8 +920,8 @@ fs::path tempName(const fs::path& leadPath, char* tmpl)
     }
 
     /* Get some more or less random data.  */
-    gettimeofday(&tv, nullptr);
-    value = (tv.tv_usec ^ tv.tv_sec) + counter++;
+    timespec_get(&ts, TIME_UTC);
+    value = (ts.tv_nsec ^ ts.tv_sec) + counter++;
 
     for (count = 0; count < 100; value += 7777, ++count) {
         long v = value;

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -250,8 +250,6 @@ std::string getValueOrDefault(const std::map<std::string, std::string>& m, const
 
 std::string toCSV(const std::shared_ptr<std::unordered_set<int>>& array);
 
-//void getTimeval(struct timeval *now) { gettimeofday(now, NULL); }
-
 void getTimespecNow(struct timespec* ts);
 
 long getDeltaMillis(struct timespec* first);


### PR DESCRIPTION
gettimeofday is deprecated under POSIX and is not year 2038 safe.

This is C++17. timespec_get should be supported.

Signed-off-by: Rosen Penev <rosenp@gmail.com>