### PR TITLE
Config: Map .ts files to video/mp2t by default

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -202,28 +202,33 @@ void ConfigGenerator::generateMappings(pugi::xml_node* import)
 
     auto ext2mt = mappings.append_child("extension-mimetype");
     ext2mt.append_attribute("ignore-unknown") = DEFAULT_IGNORE_UNKNOWN_EXTENSIONS;
+    map_from_to("asf", "video/x-ms-asf", &ext2mt);
+    map_from_to("asx", "video/x-ms-asf", &ext2mt);
+    map_from_to("dff", "audio/x-dsd", &ext2mt);
+    map_from_to("dsf", "audio/x-dsd", &ext2mt);
+    map_from_to("flv", "video/x-flv", &ext2mt);
+    map_from_to("m2ts", "video/mp2t", &ext2mt); // LibMagic fails to identify MPEG2 Transport Streams
+    map_from_to("m3u", "audio/x-mpegurl", &ext2mt);
+    map_from_to("mka", "audio/x-matroska", &ext2mt);
+    map_from_to("mkv", "video/x-matroska", &ext2mt);
     map_from_to("mp3", "audio/mpeg", &ext2mt);
-    map_from_to("ogx", "application/ogg", &ext2mt);
-    map_from_to("ogv", "video/ogg", &ext2mt);
+    map_from_to("mts", "video/mp2t", &ext2mt); // LibMagic fails to identify MPEG2 Transport Streams
     map_from_to("oga", "audio/ogg", &ext2mt);
     map_from_to("ogg", "audio/ogg", &ext2mt);
     map_from_to("ogm", "video/ogg", &ext2mt);
-    map_from_to("asf", "video/x-ms-asf", &ext2mt);
-    map_from_to("asx", "video/x-ms-asf", &ext2mt);
-    map_from_to("wma", "audio/x-ms-wma", &ext2mt);
-    map_from_to("wax", "audio/x-ms-wax", &ext2mt);
-    map_from_to("wmv", "video/x-ms-wmv", &ext2mt);
-    map_from_to("wvx", "video/x-ms-wvx", &ext2mt);
-    map_from_to("wm", "video/x-ms-wm", &ext2mt);
-    map_from_to("wmx", "video/x-ms-wmx", &ext2mt);
-    map_from_to("m3u", "audio/x-mpegurl", &ext2mt);
+    map_from_to("ogv", "video/ogg", &ext2mt);
+    map_from_to("ogx", "application/ogg", &ext2mt);
     map_from_to("pls", "audio/x-scpls", &ext2mt);
-    map_from_to("flv", "video/x-flv", &ext2mt);
-    map_from_to("mkv", "video/x-matroska", &ext2mt);
-    map_from_to("mka", "audio/x-matroska", &ext2mt);
-    map_from_to("dsf", "audio/x-dsd", &ext2mt);
-    map_from_to("dff", "audio/x-dsd", &ext2mt);
+    map_from_to("ts", "video/mp2t", &ext2mt); // LibMagic fails to identify MPEG2 Transport Streams
+    map_from_to("tsa", "audio/mp2t", &ext2mt); // LibMagic fails to identify MPEG2 Transport Streams
+    map_from_to("tsv", "video/mp2t", &ext2mt); // LibMagic fails to identify MPEG2 Transport Streams
+    map_from_to("wax", "audio/x-ms-wax", &ext2mt);
+    map_from_to("wm", "video/x-ms-wm", &ext2mt);
+    map_from_to("wma", "audio/x-ms-wma", &ext2mt);
+    map_from_to("wmv", "video/x-ms-wmv", &ext2mt);
+    map_from_to("wmx", "video/x-ms-wmx", &ext2mt);
     map_from_to("wv", "audio/x-wavpack", &ext2mt);
+    map_from_to("wvx", "video/x-ms-wvx", &ext2mt);
 
     ext2mt.append_child(pugi::node_comment).set_value(" Uncomment the line below for PS3 divx support ");
     ext2mt.append_child(pugi::node_comment).set_value(R"( <map from="avi" to="video/divx" /> )");

--- a/test/config/CMakeLists.txt
+++ b/test/config/CMakeLists.txt
@@ -11,8 +11,11 @@ target_link_libraries(testconfig PRIVATE
 
 add_custom_command(TARGET testconfig POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
+    DEPENDS fixtures/*
+    COMMENT "Copying Fixtures"
 )
 target_compile_definitions(testconfig PRIVATE CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR}")
+add_dependencies(testconfig gerbera)
 
 include(GoogleTest)
 gtest_discover_tests(testconfig)

--- a/test/config/fixtures/mock-config-all.xml
+++ b/test/config/fixtures/mock-config-all.xml
@@ -61,28 +61,33 @@
     </scripting>
     <mappings>
       <extension-mimetype ignore-unknown="no">
+        <map from="asf" to="video/x-ms-asf" />
+        <map from="asx" to="video/x-ms-asf" />
+        <map from="dff" to="audio/x-dsd" />
+        <map from="dsf" to="audio/x-dsd" />
+        <map from="flv" to="video/x-flv" />
+        <map from="m2ts" to="video/mp2t" />
+        <map from="m3u" to="audio/x-mpegurl" />
+        <map from="mka" to="audio/x-matroska" />
+        <map from="mkv" to="video/x-matroska" />
         <map from="mp3" to="audio/mpeg" />
-        <map from="ogx" to="application/ogg" />
-        <map from="ogv" to="video/ogg" />
+        <map from="mts" to="video/mp2t" />
         <map from="oga" to="audio/ogg" />
         <map from="ogg" to="audio/ogg" />
         <map from="ogm" to="video/ogg" />
-        <map from="asf" to="video/x-ms-asf" />
-        <map from="asx" to="video/x-ms-asf" />
-        <map from="wma" to="audio/x-ms-wma" />
-        <map from="wax" to="audio/x-ms-wax" />
-        <map from="wmv" to="video/x-ms-wmv" />
-        <map from="wvx" to="video/x-ms-wvx" />
-        <map from="wm" to="video/x-ms-wm" />
-        <map from="wmx" to="video/x-ms-wmx" />
-        <map from="m3u" to="audio/x-mpegurl" />
+        <map from="ogv" to="video/ogg" />
+        <map from="ogx" to="application/ogg" />
         <map from="pls" to="audio/x-scpls" />
-        <map from="flv" to="video/x-flv" />
-        <map from="mkv" to="video/x-matroska" />
-        <map from="mka" to="audio/x-matroska" />
-        <map from="dsf" to="audio/x-dsd" />
-        <map from="dff" to="audio/x-dsd" />
+        <map from="ts" to="video/mp2t" />
+        <map from="tsa" to="audio/mp2t" />
+        <map from="tsv" to="video/mp2t" />
+        <map from="wax" to="audio/x-ms-wax" />
+        <map from="wm" to="video/x-ms-wm" />
+        <map from="wma" to="audio/x-ms-wma" />
+        <map from="wmv" to="video/x-ms-wmv" />
+        <map from="wmx" to="video/x-ms-wmx" />
         <map from="wv" to="audio/x-wavpack" />
+        <map from="wvx" to="video/x-ms-wvx" />
         <!-- Uncomment the line below for PS3 divx support -->
         <!-- <map from="avi" to="video/divx" /> -->
         <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/config/fixtures/mock-config-minimal.xml
+++ b/test/config/fixtures/mock-config-minimal.xml
@@ -49,28 +49,33 @@
     </scripting>
     <mappings>
       <extension-mimetype ignore-unknown="no">
+        <map from="asf" to="video/x-ms-asf" />
+        <map from="asx" to="video/x-ms-asf" />
+        <map from="dff" to="audio/x-dsd" />
+        <map from="dsf" to="audio/x-dsd" />
+        <map from="flv" to="video/x-flv" />
+        <map from="m2ts" to="video/mp2t" />
+        <map from="m3u" to="audio/x-mpegurl" />
+        <map from="mka" to="audio/x-matroska" />
+        <map from="mkv" to="video/x-matroska" />
         <map from="mp3" to="audio/mpeg" />
-        <map from="ogx" to="application/ogg" />
-        <map from="ogv" to="video/ogg" />
+        <map from="mts" to="video/mp2t" />
         <map from="oga" to="audio/ogg" />
         <map from="ogg" to="audio/ogg" />
         <map from="ogm" to="video/ogg" />
-        <map from="asf" to="video/x-ms-asf" />
-        <map from="asx" to="video/x-ms-asf" />
-        <map from="wma" to="audio/x-ms-wma" />
-        <map from="wax" to="audio/x-ms-wax" />
-        <map from="wmv" to="video/x-ms-wmv" />
-        <map from="wvx" to="video/x-ms-wvx" />
-        <map from="wm" to="video/x-ms-wm" />
-        <map from="wmx" to="video/x-ms-wmx" />
-        <map from="m3u" to="audio/x-mpegurl" />
+        <map from="ogv" to="video/ogg" />
+        <map from="ogx" to="application/ogg" />
         <map from="pls" to="audio/x-scpls" />
-        <map from="flv" to="video/x-flv" />
-        <map from="mkv" to="video/x-matroska" />
-        <map from="mka" to="audio/x-matroska" />
-        <map from="dsf" to="audio/x-dsd" />
-        <map from="dff" to="audio/x-dsd" />
+        <map from="ts" to="video/mp2t" />
+        <map from="tsa" to="audio/mp2t" />
+        <map from="tsv" to="video/mp2t" />
+        <map from="wax" to="audio/x-ms-wax" />
+        <map from="wm" to="video/x-ms-wm" />
+        <map from="wma" to="audio/x-ms-wma" />
+        <map from="wmv" to="video/x-ms-wmv" />
+        <map from="wmx" to="video/x-ms-wmx" />
         <map from="wv" to="audio/x-wavpack" />
+        <map from="wvx" to="video/x-ms-wvx" />
         <!-- Uncomment the line below for PS3 divx support -->
         <!-- <map from="avi" to="video/divx" /> -->
         <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/config/fixtures/mock-import-magic-js-online.xml
+++ b/test/config/fixtures/mock-import-magic-js-online.xml
@@ -9,28 +9,33 @@
   </scripting>
   <mappings>
     <extension-mimetype ignore-unknown="no">
+      <map from="asf" to="video/x-ms-asf" />
+      <map from="asx" to="video/x-ms-asf" />
+      <map from="dff" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsd" />
+      <map from="flv" to="video/x-flv" />
+      <map from="m2ts" to="video/mp2t" />
+      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="mka" to="audio/x-matroska" />
+      <map from="mkv" to="video/x-matroska" />
       <map from="mp3" to="audio/mpeg" />
-      <map from="ogx" to="application/ogg" />
-      <map from="ogv" to="video/ogg" />
+      <map from="mts" to="video/mp2t" />
       <map from="oga" to="audio/ogg" />
       <map from="ogg" to="audio/ogg" />
       <map from="ogm" to="video/ogg" />
-      <map from="asf" to="video/x-ms-asf" />
-      <map from="asx" to="video/x-ms-asf" />
-      <map from="wma" to="audio/x-ms-wma" />
-      <map from="wax" to="audio/x-ms-wax" />
-      <map from="wmv" to="video/x-ms-wmv" />
-      <map from="wvx" to="video/x-ms-wvx" />
-      <map from="wm" to="video/x-ms-wm" />
-      <map from="wmx" to="video/x-ms-wmx" />
-      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="ogv" to="video/ogg" />
+      <map from="ogx" to="application/ogg" />
       <map from="pls" to="audio/x-scpls" />
-      <map from="flv" to="video/x-flv" />
-      <map from="mkv" to="video/x-matroska" />
-      <map from="mka" to="audio/x-matroska" />
-      <map from="dsf" to="audio/x-dsd" />
-      <map from="dff" to="audio/x-dsd" />
+      <map from="ts" to="video/mp2t" />
+      <map from="tsa" to="audio/mp2t" />
+      <map from="tsv" to="video/mp2t" />
+      <map from="wax" to="audio/x-ms-wax" />
+      <map from="wm" to="video/x-ms-wm" />
+      <map from="wma" to="audio/x-ms-wma" />
+      <map from="wmv" to="video/x-ms-wmv" />
+      <map from="wmx" to="video/x-ms-wmx" />
       <map from="wv" to="audio/x-wavpack" />
+      <map from="wvx" to="video/x-ms-wvx" />
       <!-- Uncomment the line below for PS3 divx support -->
       <!-- <map from="avi" to="video/divx" /> -->
       <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/config/fixtures/mock-import-magic-js.xml
+++ b/test/config/fixtures/mock-import-magic-js.xml
@@ -9,28 +9,33 @@
   </scripting>
   <mappings>
     <extension-mimetype ignore-unknown="no">
+      <map from="asf" to="video/x-ms-asf" />
+      <map from="asx" to="video/x-ms-asf" />
+      <map from="dff" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsd" />
+      <map from="flv" to="video/x-flv" />
+      <map from="m2ts" to="video/mp2t" />
+      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="mka" to="audio/x-matroska" />
+      <map from="mkv" to="video/x-matroska" />
       <map from="mp3" to="audio/mpeg" />
-      <map from="ogx" to="application/ogg" />
-      <map from="ogv" to="video/ogg" />
+      <map from="mts" to="video/mp2t" />
       <map from="oga" to="audio/ogg" />
       <map from="ogg" to="audio/ogg" />
       <map from="ogm" to="video/ogg" />
-      <map from="asf" to="video/x-ms-asf" />
-      <map from="asx" to="video/x-ms-asf" />
-      <map from="wma" to="audio/x-ms-wma" />
-      <map from="wax" to="audio/x-ms-wax" />
-      <map from="wmv" to="video/x-ms-wmv" />
-      <map from="wvx" to="video/x-ms-wvx" />
-      <map from="wm" to="video/x-ms-wm" />
-      <map from="wmx" to="video/x-ms-wmx" />
-      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="ogv" to="video/ogg" />
+      <map from="ogx" to="application/ogg" />
       <map from="pls" to="audio/x-scpls" />
-      <map from="flv" to="video/x-flv" />
-      <map from="mkv" to="video/x-matroska" />
-      <map from="mka" to="audio/x-matroska" />
-      <map from="dsf" to="audio/x-dsd" />
-      <map from="dff" to="audio/x-dsd" />
+      <map from="ts" to="video/mp2t" />
+      <map from="tsa" to="audio/mp2t" />
+      <map from="tsv" to="video/mp2t" />
+      <map from="wax" to="audio/x-ms-wax" />
+      <map from="wm" to="video/x-ms-wm" />
+      <map from="wma" to="audio/x-ms-wma" />
+      <map from="wmv" to="video/x-ms-wmv" />
+      <map from="wmx" to="video/x-ms-wmx" />
       <map from="wv" to="audio/x-wavpack" />
+      <map from="wvx" to="video/x-ms-wvx" />
       <!-- Uncomment the line below for PS3 divx support -->
       <!-- <map from="avi" to="video/divx" /> -->
       <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/config/fixtures/mock-import-magic.xml
+++ b/test/config/fixtures/mock-import-magic.xml
@@ -5,25 +5,33 @@
   </scripting>
   <mappings>
     <extension-mimetype ignore-unknown="no">
+      <map from="asf" to="video/x-ms-asf" />
+      <map from="asx" to="video/x-ms-asf" />
+      <map from="dff" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsd" />
+      <map from="flv" to="video/x-flv" />
+      <map from="m2ts" to="video/mp2t" />
+      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="mka" to="audio/x-matroska" />
+      <map from="mkv" to="video/x-matroska" />
       <map from="mp3" to="audio/mpeg" />
-      <map from="ogx" to="application/ogg" />
-      <map from="ogv" to="video/ogg" />
+      <map from="mts" to="video/mp2t" />
       <map from="oga" to="audio/ogg" />
       <map from="ogg" to="audio/ogg" />
       <map from="ogm" to="video/ogg" />
-      <map from="asf" to="video/x-ms-asf" />
-      <map from="asx" to="video/x-ms-asf" />
-      <map from="wma" to="audio/x-ms-wma" />
-      <map from="wax" to="audio/x-ms-wax" />
-      <map from="wmv" to="video/x-ms-wmv" />
-      <map from="wvx" to="video/x-ms-wvx" />
-      <map from="wm" to="video/x-ms-wm" />
-      <map from="wmx" to="video/x-ms-wmx" />
-      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="ogv" to="video/ogg" />
+      <map from="ogx" to="application/ogg" />
       <map from="pls" to="audio/x-scpls" />
-      <map from="flv" to="video/x-flv" />
-      <map from="mkv" to="video/x-matroska" />
-      <map from="mka" to="audio/x-matroska" />
+      <map from="ts" to="video/mp2t" />
+      <map from="tsa" to="audio/mp2t" />
+      <map from="tsv" to="video/mp2t" />
+      <map from="wax" to="audio/x-ms-wax" />
+      <map from="wm" to="video/x-ms-wm" />
+      <map from="wma" to="audio/x-ms-wma" />
+      <map from="wmv" to="video/x-ms-wmv" />
+      <map from="wmx" to="video/x-ms-wmx" />
+      <map from="wv" to="audio/x-wavpack" />
+      <map from="wvx" to="video/x-ms-wvx" />
       <!-- Uncomment the line below for PS3 divx support -->
       <!-- <map from="avi" to="video/divx" /> -->
       <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/config/fixtures/mock-import-mappings.xml
+++ b/test/config/fixtures/mock-import-mappings.xml
@@ -1,27 +1,32 @@
 <mappings>
   <extension-mimetype ignore-unknown="no">
+    <map from="asf" to="video/x-ms-asf" />
+    <map from="asx" to="video/x-ms-asf" />
+    <map from="dff" to="audio/x-dsd" />
+    <map from="dsf" to="audio/x-dsd" />
+    <map from="flv" to="video/x-flv" />
+    <map from="m2ts" to="video/mp2t" />
+    <map from="m3u" to="audio/x-mpegurl" />
+    <map from="mka" to="audio/x-matroska" />
+    <map from="mkv" to="video/x-matroska" />
     <map from="mp3" to="audio/mpeg" />
-    <map from="ogx" to="application/ogg" />
-    <map from="ogv" to="video/ogg" />
+    <map from="mts" to="video/mp2t" />
     <map from="oga" to="audio/ogg" />
     <map from="ogg" to="audio/ogg" />
     <map from="ogm" to="video/ogg" />
-    <map from="asf" to="video/x-ms-asf" />
-    <map from="asx" to="video/x-ms-asf" />
-    <map from="wma" to="audio/x-ms-wma" />
-    <map from="wax" to="audio/x-ms-wax" />
-    <map from="wmv" to="video/x-ms-wmv" />
-    <map from="wvx" to="video/x-ms-wvx" />
-    <map from="wm" to="video/x-ms-wm" />
-    <map from="wmx" to="video/x-ms-wmx" />
-    <map from="m3u" to="audio/x-mpegurl" />
+    <map from="ogv" to="video/ogg" />
+    <map from="ogx" to="application/ogg" />
     <map from="pls" to="audio/x-scpls" />
-    <map from="flv" to="video/x-flv" />
-    <map from="mkv" to="video/x-matroska" />
-    <map from="mka" to="audio/x-matroska" />
-    <map from="dsf" to="audio/x-dsd" />
-    <map from="dff" to="audio/x-dsd" />
+    <map from="ts" to="video/mp2t" />
+    <map from="tsa" to="audio/mp2t" />
+    <map from="tsv" to="video/mp2t" />
+    <map from="wax" to="audio/x-ms-wax" />
+    <map from="wm" to="video/x-ms-wm" />
+    <map from="wma" to="audio/x-ms-wma" />
+    <map from="wmv" to="video/x-ms-wmv" />
+    <map from="wmx" to="video/x-ms-wmx" />
     <map from="wv" to="audio/x-wavpack" />
+    <map from="wvx" to="video/x-ms-wvx" />
     <!-- Uncomment the line below for PS3 divx support -->
     <!-- <map from="avi" to="video/divx" /> -->
     <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/config/fixtures/mock-import-none.xml
+++ b/test/config/fixtures/mock-import-none.xml
@@ -4,28 +4,33 @@
   </scripting>
   <mappings>
     <extension-mimetype ignore-unknown="no">
+      <map from="asf" to="video/x-ms-asf" />
+      <map from="asx" to="video/x-ms-asf" />
+      <map from="dff" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsd" />
+      <map from="flv" to="video/x-flv" />
+      <map from="m2ts" to="video/mp2t" />
+      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="mka" to="audio/x-matroska" />
+      <map from="mkv" to="video/x-matroska" />
       <map from="mp3" to="audio/mpeg" />
-      <map from="ogx" to="application/ogg" />
-      <map from="ogv" to="video/ogg" />
+      <map from="mts" to="video/mp2t" />
       <map from="oga" to="audio/ogg" />
       <map from="ogg" to="audio/ogg" />
       <map from="ogm" to="video/ogg" />
-      <map from="asf" to="video/x-ms-asf" />
-      <map from="asx" to="video/x-ms-asf" />
-      <map from="wma" to="audio/x-ms-wma" />
-      <map from="wax" to="audio/x-ms-wax" />
-      <map from="wmv" to="video/x-ms-wmv" />
-      <map from="wvx" to="video/x-ms-wvx" />
-      <map from="wm" to="video/x-ms-wm" />
-      <map from="wmx" to="video/x-ms-wmx" />
-      <map from="m3u" to="audio/x-mpegurl" />
+      <map from="ogv" to="video/ogg" />
+      <map from="ogx" to="application/ogg" />
       <map from="pls" to="audio/x-scpls" />
-      <map from="flv" to="video/x-flv" />
-      <map from="mkv" to="video/x-matroska" />
-      <map from="mka" to="audio/x-matroska" />
-      <map from="dsf" to="audio/x-dsd" />
-      <map from="dff" to="audio/x-dsd" />
+      <map from="ts" to="video/mp2t" />
+      <map from="tsa" to="audio/mp2t" />
+      <map from="tsv" to="video/mp2t" />
+      <map from="wax" to="audio/x-ms-wax" />
+      <map from="wm" to="video/x-ms-wm" />
+      <map from="wma" to="audio/x-ms-wma" />
+      <map from="wmv" to="video/x-ms-wmv" />
+      <map from="wmx" to="video/x-ms-wmx" />
       <map from="wv" to="audio/x-wavpack" />
+      <map from="wvx" to="video/x-ms-wvx" />
       <!-- Uncomment the line below for PS3 divx support -->
       <!-- <map from="avi" to="video/divx" /> -->
       <!-- Uncomment the line below for D-Link DSM / ZyXEL DMA-1000 -->

--- a/test/config/test_configmanager.cc
+++ b/test/config/test_configmanager.cc
@@ -65,7 +65,7 @@ public:
     void create_directory(fs::path dir)
     {
         if (mkdir(dir.c_str(), 0777) < 0) {
-            throw_std_runtime_error("Failed to create test_config temporary directory for testing");
+            throw_std_runtime_error(fmt::format("Failed to create test_config temporary directory for testing: {}", dir.c_str()));
         };
     }
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -14,6 +14,8 @@ target_link_libraries(testcore PRIVATE
 )
 add_custom_command(TARGET testcore POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
+        DEPENDS fixtures/*
+        COMMENT "Copying Fixtures"
 )
 target_compile_definitions(testcore PRIVATE CMAKE_BINARY_DIR="$<TARGET_FILE_DIR:gerbera>")
 

--- a/test/database/CMakeLists.txt
+++ b/test/database/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(testdb
+        main.cc
+        import.cc
+        mysql_config_fake.h)
+
+add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
+
+target_link_libraries(testdb PUBLIC
+        libgerbera
+        GTest::GTest
+)
+
+add_test(NAME testdb COMMAND testdb)

--- a/test/database/import.cc
+++ b/test/database/import.cc
@@ -1,0 +1,70 @@
+/*GRB*
+
+Gerbera - https://gerbera.io/
+
+    import.cc.c - this file is part of Gerbera.
+
+    Copyright (C) 2020 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file import.cc.c
+#include "../mock/config_mock.h"
+#include "cds_objects.h"
+#include "database/mysql/mysql_database.h"
+#include "mysql_config_fake.h"
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+class DatabaseTest : public ::testing::Test {
+
+public:
+    DatabaseTest() {};
+    virtual ~DatabaseTest() {};
+
+    virtual void SetUp()
+    {
+        config = std::make_shared<MySQLConfigFake>();
+        subject = Database::createInstance(config, nullptr , "mysql");
+    }
+
+    virtual void TearDown()
+    {
+        //delete subject;
+    };
+
+    std::shared_ptr<Database> subject;
+    std::shared_ptr<Config> config;
+};
+
+
+TEST_F(DatabaseTest, AddObject)
+{
+    auto cds = std::make_shared<CdsItem>();
+    cds->setTrackNumber(854);
+    cds->setMetadata(M_ARTIST, "Your Mother");
+    cds->setMetadata(M_ALBUM, "Wombats");
+    cds->setLocation(fs::path("/mnt/basilisk/Music/Adele/21/01 - Adele - Rolling In The Deep.flac"));
+    int number = 1;
+
+    spdlog::set_level(spdlog::level::debug);
+    auto start_time = std::chrono::high_resolution_clock::now();
+    //for(int i = 0; i<1000;i++) {
+        subject->addObject(cds, &number);
+    //}
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    log_info("took {}ms to add 1 item", std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time).count() );
+}

--- a/test/database/main.cc
+++ b/test/database/main.cc
@@ -1,0 +1,32 @@
+/*GRB*
+
+Gerbera - https://gerbera.io/
+
+    main.cc.c - this file is part of Gerbera.
+
+    Copyright (C) 2020 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file main.cc.c
+#include <gmock/gmock.h>
+
+using namespace ::testing;
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleMock(&argc, argv);
+    int ret = RUN_ALL_TESTS();
+    return ret;
+}

--- a/test/database/mysql_config_fake.h
+++ b/test/database/mysql_config_fake.h
@@ -1,0 +1,59 @@
+/*GRB*
+
+Gerbera - https://gerbera.io/
+
+    my_sql_config_fake.h - this file is part of Gerbera.
+
+    Copyright (C) 2020 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file my_sql_config_fake.h
+
+#ifndef GERBERA_MYSQL_CONFIG_FAKE_H
+#define GERBERA_MYSQL_CONFIG_FAKE_H
+
+class MySQLConfigFake : public Config {
+public:
+    fs::path getConfigFilename() const override { return ""; }
+    std::string getOption(config_option_t option) const override {
+        if (option == CFG_SERVER_STORAGE_MYSQL_HOST) {
+            return "hydra.home";
+        }
+        if (option == CFG_SERVER_STORAGE_MYSQL_USERNAME) {
+            return "root";
+        }
+//        if (option == CFG_SERVER_STORAGE_MYSQL_DATABASE) {
+//            return "gerbera";
+//        }
+        return "";
+    };
+    void addOption(config_option_t option, std::shared_ptr<ConfigOption> optionValue) override { }
+    int getIntOption(config_option_t option) const override { return 0; }
+    bool getBoolOption(config_option_t option) const override { return false; }
+    std::map<std::string, std::string> getDictionaryOption(config_option_t option) const override { return std::map<std::string, std::string>(); }
+    std::vector<std::string> getArrayOption(config_option_t option) const override { return std::vector<std::string>(); }
+    std::shared_ptr<AutoscanList> getAutoscanListOption(config_option_t option) const override { return nullptr; }
+    std::shared_ptr<ClientConfigList> getClientConfigListOption(config_option_t option) const override { return nullptr; }
+    std::shared_ptr<DirectoryConfigList> getDirectoryTweakOption(config_option_t option) const override { return nullptr; }
+    void updateConfigFromDatabase(std::shared_ptr<Database> database) override {};
+    std::string getOrigValue(const std::string& item) const override { return ""; }
+    void setOrigValue(const std::string& item, const std::string& value) override { }
+    void setOrigValue(const std::string& item, bool value) override { }
+    void setOrigValue(const std::string& item, int value) override { }
+    bool hasOrigValue(const std::string& item) const override { return false; }
+    std::shared_ptr<TranscodingProfileList> getTranscodingProfileListOption(config_option_t option) const override { return nullptr; }
+};
+
+#endif //GERBERA_MYSQL_CONFIG_FAKE_H


### PR DESCRIPTION
This should not be needed but LibMagic fails to identify these files
(as of 2021/01).

Reorder the map alphabetically.

Fixes: https://github.com/gerbera/gerbera/issues/1130
Fixes: https://github.com/gerbera/gerbera/issues/1041
