### PR TITLE
Fix compilation without JavaScript support

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -255,9 +255,9 @@ void ConfigGenerator::generateImport(const fs::path& prefixDir, const fs::path& 
     }
 #endif
 
+#ifdef HAVE_JS
     setValue(CFG_IMPORT_SCRIPTING_CHARSET);
 
-#ifdef HAVE_JS
     std::string script;
     script = prefixDir / DEFAULT_JS_DIR / DEFAULT_COMMON_SCRIPT;
     setValue(CFG_IMPORT_SCRIPTING_COMMON_SCRIPT, script);


### PR DESCRIPTION
`CFG_IMPORT_SCRIPTING_CHARSET` is only defined when JavaScript support
is enabled. Otherwise the build fails with:

```
src/config/config_generator.cc: In static member function ‘static void ConfigGenerator::generateImport(const std::filesystem::__cxx11::path&, const std::filesystem::__cxx11::path&)’:
src/config/config_generator.cc:258:14: error: ‘CFG_IMPORT_SCRIPTING_CHARSET’ was not declared in this scope; did you mean ‘CFG_IMPORT_LIBOPTS_ID3_CHARSET’?
  258 |     setValue(CFG_IMPORT_SCRIPTING_CHARSET);
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |              CFG_IMPORT_LIBOPTS_ID3_CHARSET
make[4]: *** [CMakeFiles/libgerbera.dir/build.make:142: CMakeFiles/libgerbera.dir/src/config/config_generator.cc.o] Error
```