### PR TITLE
Fix missing forward declaration of ScriptingRuntime

### DIFF
--- a/src/content/content_manager.h
+++ b/src/content/content_manager.h
@@ -52,6 +52,8 @@
 // vice versa
 class PlaylistParserScript;
 #include "scripting/playlist_parser_script.h"
+#else
+class ScriptingRuntime;
 #endif
 
 #include "layout/layout.h"


### PR DESCRIPTION
Otherwise, build fails with musl-based GCC 9.3.0 toolchain:

```
In file included from src/content/layout/layout.cc:28:
src/content/content_manager.h:320:21: error: ‘ScriptingRuntime’ was not declared in this scope
  320 |     std::shared_ptr<ScriptingRuntime> scripting_runtime;
      |                     ^~~~~~~~~~~~~~~~
src/content/content_manager.h:320:37: error: template argument 1 is invalid
  320 |     std::shared_ptr<ScriptingRuntime> scripting_runtime;
      |                                     ^
make[4]: *** [CMakeFiles/libgerbera.dir/build.make:285: CMakeFiles/libgerbera.dir/src/content/layout/layout.cc.o] Error 1
```