### PR TITLE
Use subtitle resource for SAMSUNG clients if available

### DIFF
--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -80,10 +80,7 @@ public:
 
     static bool renderContainerImage(const std::string& virtualURL, const std::shared_ptr<CdsContainer>& cont, std::string& url);
     static bool renderItemImage(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item, std::string& url);
-
-    /// \brief Renders a subtitle resource tag
-    /// \param URL download location of the video item
-    void renderCaptionInfo(const std::string& URL, pugi::xml_node* parent) const;
+    static bool renderSubtitle(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item, std::string& url);
 
     void addResources(const std::shared_ptr<CdsItem>& item, pugi::xml_node* parent);
 

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -49,25 +49,28 @@ void Quirks::addCaptionInfo(const std::shared_ptr<CdsItem>& item, std::unique_pt
     if (!startswith(item->getMimeType(), "video"))
         return;
 
-    constexpr std::array<const char*, 4> exts {
-        ".srt",
-        ".ssa",
-        ".smi",
-        ".sub"
-    };
+    std::string url;
+    if (!UpnpXMLBuilder::renderSubtitle(context->getServer()->getVirtualUrl(), item, url)) {
+        constexpr std::array<const char*, 4> exts {
+            ".srt",
+            ".ssa",
+            ".smi",
+            ".sub"
+        };
 
-    // remove .ext
-    fs::path path = item->getLocation();
-    std::string pathNoExt = path.parent_path() / path.stem();
+        // remove .ext
+        fs::path path = item->getLocation();
+        std::string pathNoExt = path.parent_path() / path.stem();
 
-    auto it = std::find_if(exts.begin(), exts.end(), [=](const auto& ext) { std::string captionPath = pathNoExt + ext;
-          return access(captionPath.c_str(), R_OK) == 0; });
+        auto it = std::find_if(exts.begin(), exts.end(), [=](const auto& ext) { std::string captionPath = pathNoExt + ext;
+              return access(captionPath.c_str(), R_OK) == 0; });
 
-    std::string validext = (it != exts.end()) ? *it : "";
+        std::string validext = (it != exts.end()) ? *it : "";
 
-    if (validext.length() == 0)
-        return;
+        if (validext.length() == 0)
+            return;
 
-    std::string url = context->getServer()->getVirtualUrl() + RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, URL_OBJECT_ID, std::to_string(item->getID()), URL_RESOURCE_ID, "0", URL_FILE_EXTENSION, "file" + validext });
+        url = context->getServer()->getVirtualUrl() + RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, URL_OBJECT_ID, std::to_string(item->getID()), URL_RESOURCE_ID, "0", URL_FILE_EXTENSION, "file" + validext });
+    }
     headers->addHeader("CaptionInfo.sec", url);
 }

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -125,19 +125,6 @@ TEST_F(UpnpXmlTest, RenderObjectItem)
     EXPECT_STREQ(didl_lite_xml.c_str(), expectedXml.str().c_str());
 }
 
-TEST_F(UpnpXmlTest, CreatesSecCaptionInfoElement)
-{
-    pugi::xml_document doc;
-    auto container = doc.append_child("container");
-    subject->renderCaptionInfo("/media/object_id/1/file.mp4", &container);
-    auto result = container.first_child();
-
-    EXPECT_NE(result, nullptr);
-    EXPECT_STREQ(result.text().as_string(), "http://server/content/media/object_id/1/file.srt");
-    EXPECT_STREQ(result.name(), "sec:CaptionInfoEx");
-    EXPECT_STREQ(result.attribute("sec:type").as_string(), "srt");
-}
-
 TEST_F(UpnpXmlTest, CreatesEventPropertySet)
 {
     auto result = subject->createEventPropertySet();


### PR DESCRIPTION
Remove unused method

Found this while researching on #1165 

There is still a bit of hardcoding for srt files which should be bypassed for explicit resources already.