### PR TITLE
remove typedef enum

### DIFF
--- a/src/config/config.h
+++ b/src/config/config.h
@@ -39,7 +39,7 @@ class Database;
 class DirectoryConfigList;
 class TranscodingProfileList;
 
-typedef enum {
+enum config_option_t {
     CFG_SERVER_PORT = 0,
     CFG_SERVER_IP,
     CFG_SERVER_NETWORK_INTERFACE,
@@ -262,7 +262,7 @@ typedef enum {
     ATTR_DIRECTORIES_TWEAK_FANART_FILE,
     ATTR_DIRECTORIES_TWEAK_SUBTILTE_FILE,
     ATTR_DIRECTORIES_TWEAK_RESOURCE_FILE,
-} config_option_t;
+};
 
 class Config {
 public:

--- a/src/content/onlineservice/online_service.h
+++ b/src/content/onlineservice/online_service.h
@@ -51,14 +51,14 @@ class Layout;
 #define ONLINE_SERVICE_LAST_UPDATE "lu"
 
 // make sure to add the database prefixes when adding new services
-typedef enum {
+enum service_type_t {
     OS_None = 0,
     OS_YouTube = 1,
     OS_SopCast = 2,
 
     OS_ATrailers = 4,
     OS_Max
-} service_type_t;
+};
 
 /// \brief This is an interface for all online services, the function
 /// handles adding/refreshing content in the database.

--- a/src/content/scripting/script.h
+++ b/src/content/scripting/script.h
@@ -47,18 +47,18 @@ class StringConverter;
 // perform garbage collection after script has been run for x times
 #define JS_CALL_GC_AFTER_NUM (1000)
 
-typedef enum {
+enum script_class_t {
     S_IMPORT = 0,
     S_PLAYLIST
-} script_class_t;
+};
 
-typedef enum {
+enum charset_convert_t {
     M2I,
     F2I,
     J2I,
     P2I,
     I2I,
-} charset_convert_t;
+};
 
 class Script {
 public:

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -86,7 +86,7 @@ class IOHandler;
 #define EXIF_THUMBNAIL "EX_TH"
 #define THUMBNAIL "th" // thumbnail without need for special handling
 
-typedef enum {
+enum metadata_fields_t {
     M_TITLE = 0,
     M_ARTIST,
     M_ALBUM,
@@ -113,7 +113,7 @@ typedef enum {
     M_ORCHESTRA,
 
     M_MAX
-} metadata_fields_t;
+};
 
 constexpr std::array<std::pair<metadata_fields_t, const char*>, M_MAX> mt_keys = { {
     { M_TITLE, "dc:title" },
@@ -140,7 +140,7 @@ constexpr std::array<std::pair<metadata_fields_t, const char*>, M_MAX> mt_keys =
 } };
 
 // res tag attributes
-typedef enum {
+enum resource_attributes_t {
     R_SIZE = 0,
     R_DURATION,
     R_BITRATE,
@@ -155,7 +155,7 @@ typedef enum {
     R_FANART_RES_ID,
     R_BITS_PER_SAMPLE,
     R_MAX
-} resource_attributes_t;
+};
 
 constexpr std::array<std::pair<resource_attributes_t, const char*>, R_MAX> res_keys = { {
     { R_SIZE, "size" },

--- a/src/transcoding/transcoding.h
+++ b/src/transcoding/transcoding.h
@@ -44,17 +44,17 @@ namespace fs = std::filesystem;
 #define SOURCE (-1)
 #define OFF 0
 
-typedef enum {
+enum transcoding_type_t {
     TR_None,
     TR_External,
     TR_Remote
-} transcoding_type_t;
+};
 
-typedef enum {
+enum avi_fourcc_listmode_t {
     FCC_None,
     FCC_Process,
     FCC_Ignore
-} avi_fourcc_listmode_t;
+};
 
 /// \brief this class keeps all data associated with one transcoding profile.
 class TranscodingProfile {


### PR DESCRIPTION
typedef enum is meant to give the enum an alternate name. But these are
anonymous enums. Just place the name up top.

Avoids clang-tidy's modernize-use-using checks.

Signed-off-by: Rosen Penev <rosenp@gmail.com>