### PR TITLE
treewide: use fmt::to_string instead of std version

### DIFF
--- a/src/cds_objects.cc
+++ b/src/cds_objects.cc
@@ -126,7 +126,7 @@ std::shared_ptr<CdsObject> CdsObject::createObject(unsigned int objectType)
     } else if (IS_CDS_ITEM(objectType)) {
         obj = std::make_shared<CdsItem>();
     } else {
-        throw_std_runtime_error("invalid object type: " + std::to_string(objectType));
+        throw_std_runtime_error("invalid object type: " + fmt::to_string(objectType));
     }
     return obj;
 }
@@ -243,5 +243,5 @@ std::string CdsObject::mapObjectType(unsigned int type)
         return STRING_OBJECT_TYPE_ITEM;
     if (IS_CDS_ITEM_EXTERNAL_URL(type))
         return STRING_OBJECT_TYPE_EXTERNAL_URL;
-    throw_std_runtime_error("illegal objectType: " + std::to_string(type));
+    throw_std_runtime_error("illegal objectType: " + fmt::to_string(type));
 }

--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -147,9 +147,9 @@ std::string ConfigGenerator::generate(const fs::path& userHome, const fs::path& 
     auto config = init();
 
     config->append_attribute("version") = CONFIG_XML_VERSION;
-    config->append_attribute("xmlns") = (XML_XMLNS + std::to_string(CONFIG_XML_VERSION)).c_str();
+    config->append_attribute("xmlns") = (XML_XMLNS + fmt::to_string(CONFIG_XML_VERSION)).c_str();
     config->append_attribute("xmlns:xsi") = XML_XMLNS_XSI;
-    config->append_attribute("xsi:schemaLocation") = (std::string(XML_XMLNS) + std::to_string(CONFIG_XML_VERSION) + " " + XML_XMLNS + std::to_string(CONFIG_XML_VERSION) + ".xsd").c_str();
+    config->append_attribute("xsi:schemaLocation") = (std::string(XML_XMLNS) + fmt::to_string(CONFIG_XML_VERSION) + " " + XML_XMLNS + fmt::to_string(CONFIG_XML_VERSION) + ".xsd").c_str();
 
     auto docinfo = config->append_child(pugi::node_comment);
     docinfo.set_value("\n\
@@ -185,7 +185,7 @@ void ConfigGenerator::generateServer(const fs::path& userHome, const fs::path& c
         ("\n\
         How frequently (in seconds) to send ssdp:alive advertisements.\n\
         Minimum alive value accepted is: "
-            + std::to_string(ALIVE_INTERVAL_MIN) + "\n\n\
+            + fmt::to_string(ALIVE_INTERVAL_MIN) + "\n\n\
         The advertisement will be sent every (A/2)-30 seconds,\n\
         and will have a cache-control max-age of A where A is\n\
         the value configured here. Ex: A value of 62 will result\n\
@@ -375,9 +375,9 @@ void ConfigGenerator::generateTranscoding()
     setValue(agent, ATTR_TRANSCODING_PROFILES_PROFLE_AGENT_ARGS, "-y -i %in -f mp3 %out");
 
     auto buffer = setValue(fmt::format("{}/{}/", profileTag, ConfigManager::mapConfigOption(ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER)), "", true);
-    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_SIZE, std::to_string(DEFAULT_AUDIO_BUFFER_SIZE));
-    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_CHUNK, std::to_string(DEFAULT_AUDIO_CHUNK_SIZE));
-    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_FILL, std::to_string(DEFAULT_AUDIO_FILL_SIZE));
+    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_SIZE, fmt::to_string(DEFAULT_AUDIO_BUFFER_SIZE));
+    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_CHUNK, fmt::to_string(DEFAULT_AUDIO_CHUNK_SIZE));
+    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_FILL, fmt::to_string(DEFAULT_AUDIO_FILL_SIZE));
 
     auto vlcmpeg = setValue(fmt::format("{}/", profileTag), "", true);
     setValue(vlcmpeg, ATTR_TRANSCODING_PROFILES_PROFLE_NAME, "vlcmpeg");
@@ -393,9 +393,9 @@ void ConfigGenerator::generateTranscoding()
     setValue(agent, ATTR_TRANSCODING_PROFILES_PROFLE_AGENT_ARGS, "-I dummy %in --sout #transcode{venc=ffmpeg,vcodec=mp2v,vb=4096,fps=25,aenc=ffmpeg,acodec=mpga,ab=192,samplerate=44100,channels=2}:standard{access=file,mux=ps,dst=%out} vlc:quit");
 
     buffer = setValue(fmt::format("{}/{}/", profileTag, ConfigManager::mapConfigOption(ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER)), "", true);
-    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_SIZE, std::to_string(DEFAULT_VIDEO_BUFFER_SIZE));
-    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_CHUNK, std::to_string(DEFAULT_VIDEO_CHUNK_SIZE));
-    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_FILL, std::to_string(DEFAULT_VIDEO_FILL_SIZE));
+    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_SIZE, fmt::to_string(DEFAULT_VIDEO_BUFFER_SIZE));
+    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_CHUNK, fmt::to_string(DEFAULT_VIDEO_CHUNK_SIZE));
+    setValue(buffer, ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_FILL, fmt::to_string(DEFAULT_VIDEO_FILL_SIZE));
 }
 
 void ConfigGenerator::generateUdn()

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -465,7 +465,7 @@ const std::vector<std::shared_ptr<ConfigSetup>> ConfigManager::complexOptions = 
         DEFAULT_ATRAILERS_REFRESH),
     std::make_shared<ConfigEnumSetup<std::string>>(CFG_ONLINE_CONTENT_ATRAILERS_RESOLUTION,
         "/import/online-content/AppleTrailers/attribute::resolution", "config-online.html#appletrailers",
-        std::to_string(DEFAULT_ATRAILERS_RESOLUTION).c_str(),
+        fmt::to_string(DEFAULT_ATRAILERS_RESOLUTION).c_str(),
         std::map<std::string, std::string>({ { "640", "640" }, { "720", "720p" }, { "720p", "720p" } })),
 #endif
 
@@ -988,7 +988,7 @@ void ConfigManager::load(const fs::path& userHome)
 
     // now get the option list for the drop down menu
     auto menu_opts = setOption(root, CFG_SERVER_UI_ITEMS_PER_PAGE_DROPDOWN)->getArrayOption();
-    if (std::none_of(menu_opts.begin(), menu_opts.end(), [=](const auto& s) { return s == std::to_string(def_ipp); }))
+    if (std::none_of(menu_opts.begin(), menu_opts.end(), [=](const auto& s) { return s == fmt::to_string(def_ipp); }))
         throw std::runtime_error("Error in config file: at least one <option> "
                                  "under <items-per-page> must match the "
                                  "<items-per-page default=\"\" /> attribute");
@@ -1006,7 +1006,7 @@ void ConfigManager::load(const fs::path& userHome)
     setOption(root, CFG_IMPORT_FOLLOW_SYMLINKS);
     setOption(root, CFG_IMPORT_MAPPINGS_IGNORE_UNKNOWN_EXTENSIONS);
     bool csens = setOption(root, CFG_IMPORT_MAPPINGS_EXTENSION_TO_MIMETYPE_CASE_SENSITIVE)->getBoolOption();
-    args["tolower"] = std::to_string(!csens);
+    args["tolower"] = fmt::to_string(!csens);
     setOption(root, CFG_IMPORT_MAPPINGS_EXTENSION_TO_MIMETYPE_LIST, &args);
     args.clear();
     setOption(root, CFG_IMPORT_MAPPINGS_MIMETYPE_TO_CONTENTTYPE_LIST);
@@ -1137,9 +1137,9 @@ void ConfigManager::load(const fs::path& userHome)
     }
 
     co = findConfigSetup(CFG_IMPORT_SCRIPTING_IMPORT_SCRIPT);
-    args["isFile"] = std::to_string(true);
-    args["mustExist"] = std::to_string(layoutType == "js");
-    args["notEmpty"] = std::to_string(layoutType == "js");
+    args["isFile"] = fmt::to_string(true);
+    args["mustExist"] = fmt::to_string(layoutType == "js");
+    args["notEmpty"] = fmt::to_string(layoutType == "js");
     co->setDefaultValue(dataDir / DEFAULT_JS_DIR / DEFAULT_IMPORT_SCRIPT);
     co->makeOption(root, self, &args);
     args.clear();
@@ -1148,7 +1148,7 @@ void ConfigManager::load(const fs::path& userHome)
 #endif
     co = findConfigSetup(CFG_SERVER_PORT);
     // 0 means, that the SDK will any free port itself
-    co->makeOption((port == 0) ? co->getXmlContent(root) : std::to_string(port), self);
+    co->makeOption((port == 0) ? co->getXmlContent(root) : fmt::to_string(port), self);
 
     setOption(root, CFG_SERVER_ALIVE_INTERVAL);
     setOption(root, CFG_IMPORT_MAPPINGS_MIMETYPE_TO_UPNP_CLASS_LIST);
@@ -1285,7 +1285,7 @@ void ConfigManager::load(const fs::path& userHome)
     int atrailers_refresh = setOption(root, CFG_ONLINE_CONTENT_ATRAILERS_REFRESH)->getIntOption();
 
     co = findConfigSetup(CFG_ONLINE_CONTENT_ATRAILERS_PURGE_AFTER);
-    co->makeOption(std::to_string(atrailers_refresh), self);
+    co->makeOption(fmt::to_string(atrailers_refresh), self);
 
     setOption(root, CFG_ONLINE_CONTENT_ATRAILERS_UPDATE_AT_START);
     setOption(root, CFG_ONLINE_CONTENT_ATRAILERS_RESOLUTION);

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -361,31 +361,31 @@ std::shared_ptr<ConfigOption> ConfigIntSetup::newOption(int optValue)
 bool ConfigIntSetup::CheckSqlLiteSyncValue(std::string& value)
 {
     auto temp_int = 0;
-    if (value == "off" || value == std::to_string(MT_SQLITE_SYNC_OFF))
+    if (value == "off" || value == fmt::to_string(MT_SQLITE_SYNC_OFF))
         temp_int = MT_SQLITE_SYNC_OFF;
-    else if (value == "normal" || value == std::to_string(MT_SQLITE_SYNC_NORMAL))
+    else if (value == "normal" || value == fmt::to_string(MT_SQLITE_SYNC_NORMAL))
         temp_int = MT_SQLITE_SYNC_NORMAL;
-    else if (value == "full" || value == std::to_string(MT_SQLITE_SYNC_FULL))
+    else if (value == "full" || value == fmt::to_string(MT_SQLITE_SYNC_FULL))
         temp_int = MT_SQLITE_SYNC_FULL;
     else
         return false;
-    value.assign(std::to_string(temp_int));
+    value.assign(fmt::to_string(temp_int));
     return true;
 }
 
 bool ConfigIntSetup::CheckProfileNumberValue(std::string& value)
 {
     auto temp_int = 0;
-    if (value == "source" || value == std::to_string(SOURCE))
+    if (value == "source" || value == fmt::to_string(SOURCE))
         temp_int = SOURCE;
-    else if (value == "off" || value == std::to_string(OFF))
+    else if (value == "off" || value == fmt::to_string(OFF))
         temp_int = OFF;
     else {
         temp_int = std::stoi(value);
         if (temp_int <= 0)
             return false;
     }
-    value.assign(std::to_string(temp_int));
+    value.assign(fmt::to_string(temp_int));
     return true;
 }
 
@@ -658,10 +658,10 @@ bool ConfigArraySetup::InitItemsPerPage(const pugi::xml_node& value, std::vector
 {
     // create default structure
     if (std::distance(value.begin(), value.end()) == 0) {
-        result.emplace_back(std::to_string(DEFAULT_ITEMS_PER_PAGE_1));
-        result.emplace_back(std::to_string(DEFAULT_ITEMS_PER_PAGE_2));
-        result.emplace_back(std::to_string(DEFAULT_ITEMS_PER_PAGE_3));
-        result.emplace_back(std::to_string(DEFAULT_ITEMS_PER_PAGE_4));
+        result.emplace_back(fmt::to_string(DEFAULT_ITEMS_PER_PAGE_1));
+        result.emplace_back(fmt::to_string(DEFAULT_ITEMS_PER_PAGE_2));
+        result.emplace_back(fmt::to_string(DEFAULT_ITEMS_PER_PAGE_3));
+        result.emplace_back(fmt::to_string(DEFAULT_ITEMS_PER_PAGE_4));
     } else {
         // create the array from either user settings
         for (const auto& it : value.select_nodes(node_name)) {

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -335,14 +335,14 @@ public:
         : ConfigSetup(option, xpath, help)
 
     {
-        this->defaultValue = std::to_string(0);
+        this->defaultValue = fmt::to_string(0);
     }
 
     ConfigIntSetup(config_option_t option, const char* xpath, const char* help, int defaultValue)
         : ConfigSetup(option, xpath, help)
 
     {
-        this->defaultValue = std::to_string(defaultValue);
+        this->defaultValue = fmt::to_string(defaultValue);
     }
 
     ConfigIntSetup(config_option_t option, const char* xpath, const char* help, IntCheckFunction check)
@@ -350,7 +350,7 @@ public:
         , valueCheck(check)
 
     {
-        this->defaultValue = std::to_string(0);
+        this->defaultValue = fmt::to_string(0);
     }
 
     ConfigIntSetup(config_option_t option, const char* xpath, const char* help, int defaultValue, IntCheckFunction check)
@@ -358,7 +358,7 @@ public:
         , valueCheck(check)
 
     {
-        this->defaultValue = std::to_string(defaultValue);
+        this->defaultValue = fmt::to_string(defaultValue);
     }
 
     ConfigIntSetup(config_option_t option, const char* xpath, const char* help, int defaultValue, int minValue, IntMinFunction check)
@@ -366,7 +366,7 @@ public:
         , minCheck(check)
         , minValue(minValue)
     {
-        this->defaultValue = std::to_string(defaultValue);
+        this->defaultValue = fmt::to_string(defaultValue);
     }
 
     ConfigIntSetup(config_option_t option, const char* xpath, const char* help, const char* defaultValue, IntCheckFunction check = nullptr)

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1092,8 +1092,8 @@ int ContentManager::addContainerChain(const std::string& chain, const std::strin
                 fanart = std::find_if(origResources.begin(), origResources.end(), [=](const auto& res) { return res->isMetaResource(ID3_ALBUM_ART); });
                 if (fanart != origResources.end()) {
                     if ((*fanart)->getAttribute(R_RESOURCE_FILE).empty()) {
-                        (*fanart)->addAttribute(R_FANART_OBJ_ID, std::to_string(origObj->getID()));
-                        (*fanart)->addAttribute(R_FANART_RES_ID, std::to_string(fanart - origResources.begin()));
+                        (*fanart)->addAttribute(R_FANART_OBJ_ID, fmt::to_string(origObj->getID()));
+                        (*fanart)->addAttribute(R_FANART_RES_ID, fmt::to_string(fanart - origResources.begin()));
                     }
                     container->addResource(*fanart);
                 }

--- a/src/content/onlineservice/atrailers_content_handler.cc
+++ b/src/content/onlineservice/atrailers_content_handler.cc
@@ -104,7 +104,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
     item->setMimeType(trailer_mimetype);
     resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(trailer_mimetype));
 
-    item->setAuxData(ONLINE_SERVICE_AUX_ID, std::to_string(OS_ATrailers));
+    item->setAuxData(ONLINE_SERVICE_AUX_ID, fmt::to_string(OS_ATrailers));
 
     temp = trailer.attribute("id").as_string();
     if (temp.empty()) {
@@ -114,7 +114,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
         return nullptr;
     }
 
-    temp = std::to_string(OnlineService::getDatabasePrefix(OS_ATrailers)) + temp;
+    temp = fmt::to_string(OnlineService::getDatabasePrefix(OS_ATrailers)) + temp;
     item->setServiceID(temp);
 
     auto preview = trailer.child("preview");
@@ -220,7 +220,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
 
     struct timespec ts;
     getTimespecNow(&ts);
-    item->setAuxData(ONLINE_SERVICE_LAST_UPDATE, std::to_string(ts.tv_sec));
+    item->setAuxData(ONLINE_SERVICE_LAST_UPDATE, fmt::to_string(ts.tv_sec));
 
     item->setFlag(OBJECT_FLAG_ONLINE_SERVICE);
     try {

--- a/src/content/onlineservice/sopcast_content_handler.cc
+++ b/src/content/onlineservice/sopcast_content_handler.cc
@@ -126,7 +126,7 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& g
     item->addResource(resource);
 
     item->setAuxData(ONLINE_SERVICE_AUX_ID,
-        std::to_string(OS_SopCast));
+        fmt::to_string(OS_SopCast));
 
     item->setAuxData(SOPCAST_AUXDATA_GROUP, groupName);
 
@@ -208,7 +208,7 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& g
 
     struct timespec ts;
     getTimespecNow(&ts);
-    item->setAuxData(ONLINE_SERVICE_LAST_UPDATE, std::to_string(ts.tv_sec));
+    item->setAuxData(ONLINE_SERVICE_LAST_UPDATE, fmt::to_string(ts.tv_sec));
     item->setFlag(OBJECT_FLAG_PROXY_URL);
     item->setFlag(OBJECT_FLAG_ONLINE_SERVICE);
 

--- a/src/content/scripting/js_functions.cc
+++ b/src/content/scripting/js_functions.cc
@@ -190,7 +190,7 @@ duk_ret_t js_addCdsObject(duk_context* ctx)
         cm->addObject(cds_obj);
 
         /* setting object ID as return value */
-        std::string tmp = std::to_string(parentId);
+        std::string tmp = fmt::to_string(parentId);
         duk_push_string(ctx, tmp.c_str());
         return 1;
     } catch (const ServerShutdownException& se) {

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -534,7 +534,7 @@ void Script::cdsObject2dukObject(const std::shared_ptr<CdsObject>& obj)
         }
 
         if (std::static_pointer_cast<CdsItem>(obj)->getTrackNumber() > 0)
-            setProperty(MetadataHandler::getMetaFieldName(M_TRACKNUMBER), std::to_string(std::static_pointer_cast<CdsItem>(obj)->getTrackNumber()));
+            setProperty(MetadataHandler::getMetaFieldName(M_TRACKNUMBER), fmt::to_string(std::static_pointer_cast<CdsItem>(obj)->getTrackNumber()));
 
         duk_put_prop_string(ctx, -2, "meta");
         // stack: js
@@ -571,7 +571,7 @@ void Script::cdsObject2dukObject(const std::shared_ptr<CdsObject>& obj)
             for (const auto& res : obj->getResources()) {
                 auto attributes = res->getAttributes();
                 for (const auto& [key, val] : attributes) {
-                    setProperty(resCount == 0 ? key : (std::to_string(resCount) + "-" + key), val);
+                    setProperty(resCount == 0 ? key : (fmt::to_string(resCount) + "-" + key), val);
                 }
                 resCount++;
             }

--- a/src/database/mysql/mysql_database.h
+++ b/src/database/mysql/mysql_database.h
@@ -53,13 +53,13 @@ private:
 
     std::string quote(std::string value) const override;
     std::string quote(const char* str) const override { return quote(std::string(str)); }
-    std::string quote(int val) const override { return std::to_string(val); }
-    std::string quote(unsigned int val) const override { return std::to_string(val); }
-    std::string quote(long val) const override { return std::to_string(val); }
-    std::string quote(unsigned long val) const override { return std::to_string(val); }
-    std::string quote(bool val) const override { return std::to_string(val ? '1' : '0'); }
-    std::string quote(char val) const override { return quote(std::to_string(val)); }
-    std::string quote(long long val) const override { return std::to_string(val); }
+    std::string quote(int val) const override { return fmt::to_string(val); }
+    std::string quote(unsigned int val) const override { return fmt::to_string(val); }
+    std::string quote(long val) const override { return fmt::to_string(val); }
+    std::string quote(unsigned long val) const override { return fmt::to_string(val); }
+    std::string quote(bool val) const override { return fmt::to_string(val ? '1' : '0'); }
+    std::string quote(char val) const override { return quote(fmt::to_string(val)); }
+    std::string quote(long long val) const override { return fmt::to_string(val); }
     std::shared_ptr<SQLResult> select(const char* query, int length) override;
     int exec(const char* query, int length, bool getLastInsertId = false) override;
     void storeInternalSetting(const std::string& key, const std::string& value) override;

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -341,7 +341,7 @@ std::vector<std::shared_ptr<SQLDatabase::AddUpdateTable>> SQLDatabase::_addUpdat
 
     if (obj->getParentID() == INVALID_OBJECT_ID)
         throw_std_runtime_error("tried to create or update an object with an illegal parent id");
-    cdsObjectSql["parent_id"] = std::to_string(obj->getParentID());
+    cdsObjectSql["parent_id"] = fmt::to_string(obj->getParentID());
 
     returnVal.push_back(
         std::make_shared<AddUpdateTable>(CDS_OBJECT_TABLE, cdsObjectSql, isUpdate ? "update" : "insert"));
@@ -387,7 +387,7 @@ void SQLDatabase::updateObject(std::shared_ptr<CdsObject> obj, int* changedConta
         data.push_back(std::make_shared<AddUpdateTable>(CDS_OBJECT_TABLE, cdsObjectSql, "update"));
     } else {
         if (IS_FORBIDDEN_CDS_ID(obj->getID()))
-            throw_std_runtime_error("tried to update an object with a forbidden ID (" + std::to_string(obj->getID()) + ")");
+            throw_std_runtime_error("tried to update an object with a forbidden ID (" + fmt::to_string(obj->getID()) + ")");
         data = _addUpdateObject(obj, true, changedContainer);
     }
     for (const auto& addUpdateTable : data) {
@@ -418,7 +418,7 @@ std::shared_ptr<CdsObject> SQLDatabase::loadObject(int objectID)
     if (res != nullptr && (row = res->nextRow()) != nullptr) {
         return createObjectFromRow(row);
     }
-    throw ObjectNotFoundException("Object not found: " + std::to_string(objectID));
+    throw ObjectNotFoundException("Object not found: " + fmt::to_string(objectID));
 }
 
 std::shared_ptr<CdsObject> SQLDatabase::loadObjectByServiceID(const std::string& serviceID)
@@ -477,7 +477,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::browse(const std::unique_pt
     if (res != nullptr && (row = res->nextRow()) != nullptr) {
         objectType = std::stoi(row->col(0));
     } else {
-        throw ObjectNotFoundException("Object not found: " + std::to_string(objectID));
+        throw ObjectNotFoundException("Object not found: " + fmt::to_string(objectID));
     }
 
     row = nullptr;
@@ -952,7 +952,7 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromRow(const std::unique_pt
     }
 
     if (!matched_types) {
-        throw DatabaseException("", "unknown object type: " + std::to_string(objectType));
+        throw DatabaseException("", "unknown object type: " + fmt::to_string(objectType));
     }
 
     return obj;
@@ -999,7 +999,7 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
 
         item->setTrackNumber(stoiString(row->col(to_underlying(SearchCol::track_number))));
     } else {
-        throw DatabaseException("", "unknown object type: " + std::to_string(objectType));
+        throw DatabaseException("", "unknown object type: " + fmt::to_string(objectType));
     }
 
     return obj;
@@ -1131,7 +1131,7 @@ std::string SQLDatabase::findFolderImage(int id, std::string trackArtBase)
     q << TQ("id") << " IN ";
     q << "(";
     q << "SELECT " << TQ("ref_id") << " FROM " << TQ(CDS_OBJECT_TABLE) << " WHERE ";
-    q << TQ("parent_id") << '=' << quote(std::to_string(id)) << " AND ";
+    q << TQ("parent_id") << '=' << quote(fmt::to_string(id)) << " AND ";
     q << TQ("object_type") << '=' << quote(OBJECT_TYPE_ITEM);
 
     // only use this optimization on sqlite3
@@ -1144,7 +1144,7 @@ std::string SQLDatabase::findFolderImage(int id, std::string trackArtBase)
     q << "     ) OR ";
 #endif
     // straightforward folder listing of real filesystem
-    q << TQ("parent_id") << '=' << quote(std::to_string(id));
+    q << TQ("parent_id") << '=' << quote(fmt::to_string(id));
 #ifndef ONLY_REAL_FOLDER_ART
     q << ")";
 #endif
@@ -1194,7 +1194,7 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::removeObjects(const st
 
     for (int id : *list) {
         if (IS_FORBIDDEN_CDS_ID(id)) {
-            throw_std_runtime_error("tried to delete a forbidden ID (" + std::to_string(id) + ")");
+            throw_std_runtime_error("tried to delete a forbidden ID (" + fmt::to_string(id) + ")");
         }
     }
 
@@ -1303,7 +1303,7 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::removeObject(int objec
         }
     }
     if (IS_FORBIDDEN_CDS_ID(objectID))
-        throw_std_runtime_error("tried to delete a forbidden ID (" + std::to_string(objectID) + ")");
+        throw_std_runtime_error("tried to delete a forbidden ID (" + fmt::to_string(objectID) + ")");
     std::vector<int32_t> itemIds;
     std::vector<int32_t> containerIds;
     if (isContainer) {
@@ -1960,7 +1960,7 @@ std::unique_ptr<std::vector<int>> SQLDatabase::_checkOverlappingAutoscans(const 
         q << "SELECT " << TQ("obj_id")
           << " FROM " << TQ(AUTOSCAN_TABLE)
           << " WHERE " << TQ("path_ids") << " LIKE "
-          << quote("%," + std::to_string(checkObjectID) + ",%");
+          << quote("%," + fmt::to_string(checkObjectID) + ",%");
         if (databaseID >= 0)
             q << " AND " << TQ("id") << " != " << quote(databaseID);
         q << " LIMIT 1";

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -309,7 +309,7 @@ std::string Sqlite3Database::quote(std::string value) const
 
 std::string Sqlite3Database::getError(const std::string& query, const std::string& error, sqlite3* db)
 {
-    return std::string("SQLITE3: (") + std::to_string(sqlite3_errcode(db)) + " : " + std::to_string(sqlite3_extended_errcode(db)) + ") "
+    return std::string("SQLITE3: (") + fmt::to_string(sqlite3_errcode(db)) + " : " + fmt::to_string(sqlite3_extended_errcode(db)) + ") "
         + sqlite3_errmsg(db) + "\nQuery:" + (query.empty() ? "unknown" : query) + "\nerror: " + (error.empty() ? "unknown" : error);
 }
 

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -161,13 +161,13 @@ private:
 
     std::string quote(std::string value) const override;
     std::string quote(const char* str) const override { return quote(std::string(str)); }
-    std::string quote(int val) const override { return std::to_string(val); }
-    std::string quote(unsigned int val) const override { return std::to_string(val); }
-    std::string quote(long val) const override { return std::to_string(val); }
-    std::string quote(unsigned long val) const override { return std::to_string(val); }
+    std::string quote(int val) const override { return fmt::to_string(val); }
+    std::string quote(unsigned int val) const override { return fmt::to_string(val); }
+    std::string quote(long val) const override { return fmt::to_string(val); }
+    std::string quote(unsigned long val) const override { return fmt::to_string(val); }
     std::string quote(bool val) const override { return std::string(val ? "1" : "0"); }
     std::string quote(char val) const override { return quote(std::string(1, val)); }
-    std::string quote(long long val) const override { return std::to_string(val); }
+    std::string quote(long long val) const override { return fmt::to_string(val); }
     std::shared_ptr<SQLResult> select(const char* query, int length) override;
     int exec(const char* query, int length, bool getLastInsertId = false) override;
     void storeInternalSetting(const std::string& key, const std::string& value) override;

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -44,7 +44,7 @@
 #endif
 
 #define throw_std_runtime_error(msg) throw std::runtime_error(std::string(msg) \
-    + " file:" + std::string(__FILE__) + " line:" + std::to_string(__LINE__) + " function:" + std::string(PRETTY_FUNCTION))
+    + " file:" + std::string(__FILE__) + " line:" + fmt::to_string(__LINE__) + " function:" + std::string(PRETTY_FUNCTION))
 
 class ConfigParseException : public std::runtime_error {
 public:

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -183,7 +183,7 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
         // See http://www.upnp.org/schemas/av/didl-lite-v3.xsd
         auto bitrate = pFormatCtx->bit_rate / 8;
         log_debug("Added bitrate: {} kb/s", bitrate);
-        resource->addAttribute(R_BITRATE, std::to_string(bitrate));
+        resource->addAttribute(R_BITRATE, fmt::to_string(bitrate));
     }
 
     // video resolution, audio sampling rate, nr of audio channels
@@ -219,13 +219,13 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
             if (as_codecpar(st)->sample_rate > 0) {
                 samplefreq = as_codecpar(st)->sample_rate;
                 log_debug("Added sample frequency: {} Hz from stream {}", samplefreq, i);
-                resource->addAttribute(R_SAMPLEFREQUENCY, std::to_string(samplefreq));
+                resource->addAttribute(R_SAMPLEFREQUENCY, fmt::to_string(samplefreq));
                 audioset = true;
 
                 audioch = as_codecpar(st)->channels;
                 if (audioch > 0) {
                     log_debug("Added number of audio channels: {} from stream {}", audioch, i);
-                    resource->addAttribute(R_NRAUDIOCHANNELS, std::to_string(audioch));
+                    resource->addAttribute(R_NRAUDIOCHANNELS, fmt::to_string(audioch));
                 }
             }
         }
@@ -244,7 +244,7 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
             std::string thumb_mimetype = it != mappings.end() && !it->second.empty() ? it->second : "image/jpeg";
 
             auto ffres = std::make_shared<CdsResource>(CH_FFTH);
-            ffres->addParameter(RESOURCE_HANDLER, std::to_string(CH_FFTH));
+            ffres->addParameter(RESOURCE_HANDLER, fmt::to_string(CH_FFTH));
             ffres->addOption(RESOURCE_CONTENT_TYPE, THUMBNAIL);
             ffres->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(thumb_mimetype));
 

--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -77,7 +77,7 @@ void MetadataHandler::setMetadata(const std::shared_ptr<Context>& context, const
 
     auto resource = std::make_shared<CdsResource>(CH_DEFAULT);
     resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(mimetype));
-    resource->addAttribute(R_SIZE, std::to_string(filesize));
+    resource->addAttribute(R_SIZE, fmt::to_string(filesize));
 
     item->addResource(resource);
 
@@ -181,7 +181,7 @@ std::unique_ptr<MetadataHandler> MetadataHandler::createHandler(const std::share
     case CH_RESOURCE:
         return std::make_unique<ResourceHandler>(context);
     default:
-        throw_std_runtime_error("unknown content handler ID: " + std::to_string(handlerType));
+        throw_std_runtime_error("unknown content handler ID: " + fmt::to_string(handlerType));
     }
 }
 

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -92,7 +92,7 @@ void TagLibHandler::addField(metadata_fields_t field, const TagLib::File& file, 
     case M_DATE:
         i = tag->year();
         if (i > 0) {
-            value = std::to_string(i);
+            value = fmt::to_string(i);
 
             if (!value.empty())
                 value = value + "-01-01";
@@ -102,7 +102,7 @@ void TagLibHandler::addField(metadata_fields_t field, const TagLib::File& file, 
     case M_UPNP_DATE:
         i = tag->year();
         if (i > 0) {
-            value = std::to_string(i);
+            value = fmt::to_string(i);
 
             if (!value.empty())
                 value = value + "-01-01";
@@ -120,7 +120,7 @@ void TagLibHandler::addField(metadata_fields_t field, const TagLib::File& file, 
     case M_TRACKNUMBER:
         i = tag->track();
         if (i > 0) {
-            value = std::to_string(i);
+            value = fmt::to_string(i);
             item->setTrackNumber(int(i));
         } else
             return;
@@ -192,7 +192,7 @@ void TagLibHandler::populateGenericTags(const std::shared_ptr<CdsItem>& item, co
     // UPnP bitrate is in bytes/second
     int temp = audioProps->bitrate() * 1024 / 8; // kbit/second -> byte/second
     if (temp > 0) {
-        res->addAttribute(R_BITRATE, std::to_string(temp));
+        res->addAttribute(R_BITRATE, fmt::to_string(temp));
     }
 
     temp = audioProps->lengthInMilliseconds();
@@ -202,12 +202,12 @@ void TagLibHandler::populateGenericTags(const std::shared_ptr<CdsItem>& item, co
 
     temp = audioProps->sampleRate();
     if (temp > 0) {
-        res->addAttribute(R_SAMPLEFREQUENCY, std::to_string(temp));
+        res->addAttribute(R_SAMPLEFREQUENCY, fmt::to_string(temp));
     }
 
     temp = audioProps->channels();
     if (temp > 0) {
-        res->addAttribute(R_NRAUDIOCHANNELS, std::to_string(temp));
+        res->addAttribute(R_NRAUDIOCHANNELS, fmt::to_string(temp));
     }
 }
 
@@ -523,7 +523,7 @@ void TagLibHandler::extractASF(TagLib::IOStream* roStream, const std::shared_ptr
     auto temp = audioProps->bitsPerSample();
     auto res = item->getResource(0);
     if (temp > 0) {
-        res->addAttribute(R_BITS_PER_SAMPLE, std::to_string(temp));
+        res->addAttribute(R_BITS_PER_SAMPLE, fmt::to_string(temp));
     }
 
     const TagLib::ASF::AttributeListMap& attrListMap = asf.tag()->attributeListMap();
@@ -593,7 +593,7 @@ void TagLibHandler::extractFLAC(TagLib::IOStream* roStream, const std::shared_pt
     auto temp = audioProps->bitsPerSample();
     auto res = item->getResource(0);
     if (temp > 0) {
-        res->addAttribute(R_BITS_PER_SAMPLE, std::to_string(temp));
+        res->addAttribute(R_BITS_PER_SAMPLE, fmt::to_string(temp));
     }
 
     std::string art_mimetype = sc->convert(pic->mimeType().toCString(true));
@@ -618,7 +618,7 @@ void TagLibHandler::extractAPE(TagLib::IOStream* roStream, const std::shared_ptr
     auto temp = audioProps->bitsPerSample();
     auto res = item->getResource(0);
     if (temp > 0) {
-        res->addAttribute(R_BITS_PER_SAMPLE, std::to_string(temp));
+        res->addAttribute(R_BITS_PER_SAMPLE, fmt::to_string(temp));
     }
 }
 
@@ -637,7 +637,7 @@ void TagLibHandler::extractWavPack(TagLib::IOStream* roStream, const std::shared
     auto temp = audioProps->bitsPerSample();
     auto res = item->getResource(0);
     if (temp > 0) {
-        res->addAttribute(R_BITS_PER_SAMPLE, std::to_string(temp));
+        res->addAttribute(R_BITS_PER_SAMPLE, fmt::to_string(temp));
     }
 }
 
@@ -663,7 +663,7 @@ void TagLibHandler::extractMP4(TagLib::IOStream* roStream, const std::shared_ptr
     auto temp = audioProps->bitsPerSample();
     auto res = item->getResource(0);
     if (temp > 0) {
-        res->addAttribute(R_BITS_PER_SAMPLE, std::to_string(temp));
+        res->addAttribute(R_BITS_PER_SAMPLE, fmt::to_string(temp));
     }
 
     if (mp4.tag()->contains("covr")) {
@@ -701,7 +701,7 @@ void TagLibHandler::extractAiff(TagLib::IOStream* roStream, const std::shared_pt
     auto temp = audioProps->bitsPerSample();
     auto res = item->getResource(0);
     if (temp > 0) {
-        res->addAttribute(R_BITS_PER_SAMPLE, std::to_string(temp));
+        res->addAttribute(R_BITS_PER_SAMPLE, fmt::to_string(temp));
     }
 }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -123,7 +123,7 @@ void Server::run()
 
     log_info("Server bound to: {}", ip.c_str());
 
-    virtualUrl = "http://" + ip + ":" + std::to_string(port) + "/" + virtual_directory;
+    virtualUrl = "http://" + ip + ":" + fmt::to_string(port) + "/" + virtual_directory;
 
     // next set webroot directory
     std::string web_root = config->getOption(CFG_SERVER_WEBROOT);
@@ -153,13 +153,13 @@ void Server::run()
 
     std::string presentationURL = config->getOption(CFG_SERVER_PRESENTATION_URL);
     if (presentationURL.empty()) {
-        presentationURL = "http://" + ip + ":" + std::to_string(port) + "/";
+        presentationURL = "http://" + ip + ":" + fmt::to_string(port) + "/";
     } else {
         std::string appendto = config->getOption(CFG_SERVER_APPEND_PRESENTATION_URL_TO);
         if (appendto == "ip") {
             presentationURL = "http://" + ip + ":" + presentationURL;
         } else if (appendto == "port") {
-            presentationURL = "http://" + ip + ":" + std::to_string(port) + "/" + presentationURL;
+            presentationURL = "http://" + ip + ":" + fmt::to_string(port) + "/" + presentationURL;
         } // else appendto is none and we take the URL as it entered by user
     }
 

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -110,11 +110,11 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(std::shared_pt
         std::vector<std::string> sop_args;
         int p1 = find_local_port(45000, 65500);
         int p2 = find_local_port(45000, 65500);
-        sop_args = populateCommandLine(location + " " + std::to_string(p1) + " " + std::to_string(p2));
+        sop_args = populateCommandLine(location + " " + fmt::to_string(p1) + " " + fmt::to_string(p2));
         auto spsc = std::make_shared<ProcessExecutor>("sp-sc-auth", sop_args);
         auto pr_item = std::make_shared<ProcListItem>(spsc);
         proc_list.push_back(pr_item);
-        location = "http://localhost:" + std::to_string(p2) + "/tv.asf";
+        location = "http://localhost:" + fmt::to_string(p2) + "/tv.asf";
 
         //FIXME: #warning check if socket is ready
         sleep(15);

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -132,9 +132,9 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto resp_root = response->document_element();
     resp_root.append_child("Result").append_child(pugi::node_pcdata).set_value(didl_lite_xml.c_str());
-    resp_root.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(std::to_string(arr.size()).c_str());
-    resp_root.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(std::to_string(param->getTotalMatches()).c_str());
-    resp_root.append_child("UpdateID").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());
+    resp_root.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(arr.size()).c_str());
+    resp_root.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(param->getTotalMatches()).c_str());
+    resp_root.append_child("UpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     request->setResponse(response);
 
     log_debug("end");
@@ -197,9 +197,9 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto resp_root = response->document_element();
     resp_root.append_child("Result").append_child(pugi::node_pcdata).set_value(didl_lite_xml.c_str());
-    resp_root.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(std::to_string(results.size()).c_str());
-    resp_root.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(std::to_string(numMatches).c_str());
-    resp_root.append_child("UpdateID").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());
+    resp_root.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(results.size()).c_str());
+    resp_root.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(numMatches).c_str());
+    resp_root.append_child("UpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     request->setResponse(response);
 
     log_debug("end");
@@ -235,7 +235,7 @@ void ContentDirectoryService::doGetSystemUpdateID(const std::unique_ptr<ActionRe
 
     auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
-    root.append_child("Id").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());
+    root.append_child("Id").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     request->setResponse(response);
 
     log_debug("end");
@@ -278,7 +278,7 @@ void ContentDirectoryService::processSubscriptionRequest(const std::unique_ptr<S
 
     auto propset = UpnpXMLBuilder::createEventPropertySet();
     auto property = propset->document_element().first_child();
-    property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());
+    property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     auto obj = database->loadObject(0);
     auto cont = std::static_pointer_cast<CdsContainer>(obj);
     property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(fmt::format("0,{}", +cont->getUpdateID()).c_str());
@@ -316,7 +316,7 @@ void ContentDirectoryService::sendSubscriptionUpdate(const std::string& containe
     auto propset = UpnpXMLBuilder::createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(containerUpdateIDs_CSV.c_str());
-    property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(std::to_string(systemUpdateID).c_str());
+    property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
 
     std::ostringstream buf;
     propset->print(buf, "", 0);

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -329,7 +329,7 @@ std::unique_ptr<UpnpXMLBuilder::PathBase> UpnpXMLBuilder::getPathBase(const std:
     /// \todo resource options must be read from configuration files
 
     std::map<std::string, std::string> dict;
-    dict[URL_OBJECT_ID] = std::to_string(item->getID());
+    dict[URL_OBJECT_ID] = fmt::to_string(item->getID());
 
     pathBase->addResID = false;
     /// \todo move this down into the "for" loop and create different urls
@@ -359,7 +359,7 @@ std::string UpnpXMLBuilder::getFirstResourcePath(const std::shared_ptr<CdsItem>&
     if (item->isExternalItem() && !urlBase->addResID) { // a remote resource
         result = urlBase->pathBase;
     } else if (urlBase->addResID) { // a proxy, remote, resource
-        result = SERVER_VIRTUAL_DIR + urlBase->pathBase + std::to_string(0);
+        result = SERVER_VIRTUAL_DIR + urlBase->pathBase + fmt::to_string(0);
     } else { // a local resource
         result = SERVER_VIRTUAL_DIR + urlBase->pathBase;
     }
@@ -373,7 +373,7 @@ std::string UpnpXMLBuilder::getArtworkUrl(const std::shared_ptr<CdsItem>& item) 
 
     auto urlBase = getPathBase(item);
     if (urlBase->addResID) {
-        return virtualURL + urlBase->pathBase + std::to_string(1) + "/rct/aa";
+        return virtualURL + urlBase->pathBase + fmt::to_string(1) + "/rct/aa";
     }
     return virtualURL + urlBase->pathBase;
 }
@@ -389,11 +389,11 @@ bool UpnpXMLBuilder::renderContainerImage(const std::string& virtualURL, const s
             if (!resFile.empty()) {
                 // found, FanArtHandler deals already with file
                 std::map<std::string, std::string> dict;
-                dict[URL_OBJECT_ID] = std::to_string(cont->getID());
+                dict[URL_OBJECT_ID] = fmt::to_string(cont->getID());
 
                 auto res_params = res->getParameters();
-                res_params[RESOURCE_HANDLER] = std::to_string(res->getHandlerType());
-                url.assign(virtualURL + RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, dictEncodeSimple(dict), URL_RESOURCE_ID, std::to_string(resIdx), dictEncodeSimple(res_params) }));
+                res_params[RESOURCE_HANDLER] = fmt::to_string(res->getHandlerType());
+                url.assign(virtualURL + RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, dictEncodeSimple(dict), URL_RESOURCE_ID, fmt::to_string(resIdx), dictEncodeSimple(res_params) }));
 
                 artAdded = true;
                 break;
@@ -426,7 +426,7 @@ bool UpnpXMLBuilder::renderItemImage(const std::string& virtualURL, const std::s
             auto res_attrs = res->getAttributes();
             auto res_params = res->getParameters();
             if (urlBase->addResID) {
-                url = virtualURL + urlBase->pathBase + std::to_string(realCount) + _URL_PARAM_SEPARATOR;
+                url = virtualURL + urlBase->pathBase + fmt::to_string(realCount) + _URL_PARAM_SEPARATOR;
             } else
                 url = virtualURL + urlBase->pathBase;
 
@@ -451,7 +451,7 @@ bool UpnpXMLBuilder::renderSubtitle(const std::string& virtualURL, const std::sh
             auto res_attrs = res->getAttributes();
             auto res_params = res->getParameters();
             if (urlBase->addResID) {
-                url = virtualURL + urlBase->pathBase + std::to_string(realCount) + _URL_PARAM_SEPARATOR;
+                url = virtualURL + urlBase->pathBase + fmt::to_string(realCount) + _URL_PARAM_SEPARATOR;
             } else
                 url = virtualURL + urlBase->pathBase;
 
@@ -582,8 +582,8 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
                         targetMimeType.append(";rate=").append(frequency);
                     }
                 } else if (freq != OFF) {
-                    t_res->addAttribute(R_SAMPLEFREQUENCY, std::to_string(freq));
-                    targetMimeType.append(";rate=").append(std::to_string(freq));
+                    t_res->addAttribute(R_SAMPLEFREQUENCY, fmt::to_string(freq));
+                    targetMimeType.append(";rate=").append(fmt::to_string(freq));
                 }
 
                 int chan = tp->getNumChannels();
@@ -594,8 +594,8 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
                         targetMimeType.append(";channels=").append(nchannels);
                     }
                 } else if (chan != OFF) {
-                    t_res->addAttribute(R_NRAUDIOCHANNELS, std::to_string(chan));
-                    targetMimeType.append(";channels=").append(std::to_string(chan));
+                    t_res->addAttribute(R_NRAUDIOCHANNELS, fmt::to_string(chan));
+                    targetMimeType.append(";channels=").append(fmt::to_string(chan));
                 }
             }
 
@@ -659,7 +659,7 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
         bool transcoded = (getValueOrDefault(res_params, URL_PARAM_TRANSCODE) == URL_VALUE_TRANSCODE);
         if (!transcoded) {
             if (urlBase->addResID) {
-                url = urlBase->pathBase + std::to_string(realCount);
+                url = urlBase->pathBase + fmt::to_string(realCount);
             } else
                 url = urlBase->pathBase;
 

--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -175,5 +175,5 @@ std::string get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh)
     }
     ioh->close();
 
-    return std::to_string(w) + "x" + std::to_string(h);
+    return fmt::to_string(w) + "x" + fmt::to_string(h);
 }

--- a/src/util/timer.cc
+++ b/src/util/timer.cc
@@ -48,7 +48,7 @@ void Timer::run()
         this);
 
     if (ret)
-        throw_std_runtime_error("failed to start timer thread: " + std::to_string(ret));
+        throw_std_runtime_error("failed to start timer thread: " + fmt::to_string(ret));
 }
 
 void* Timer::staticThreadProc(void* arg)

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -1163,7 +1163,7 @@ int sockAddrCmpAddr(const struct sockaddr* sa, const struct sockaddr* sb)
         return memcmp(reinterpret_cast<const char*>(&(SOCK_ADDR_IN6_ADDR(sa))), reinterpret_cast<const char*>(&(SOCK_ADDR_IN6_ADDR(sb))), sizeof(SOCK_ADDR_IN6_ADDR(sa)));
     }
 
-    throw_std_runtime_error("unsupported address family :" + std::to_string(sa->sa_family));
+    throw_std_runtime_error("unsupported address family :" + fmt::to_string(sa->sa_family));
 }
 
 std::string sockAddrGetNameInfo(const struct sockaddr* sa)

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -70,7 +70,7 @@ void Quirks::addCaptionInfo(const std::shared_ptr<CdsItem>& item, std::unique_pt
         if (validext.length() == 0)
             return;
 
-        url = context->getServer()->getVirtualUrl() + RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, URL_OBJECT_ID, std::to_string(item->getID()), URL_RESOURCE_ID, "0", URL_FILE_EXTENSION, "file" + validext });
+        url = context->getServer()->getVirtualUrl() + RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, URL_OBJECT_ID, fmt::to_string(item->getID()), URL_RESOURCE_ID, "0", URL_FILE_EXTENSION, "file" + validext });
     }
     headers->addHeader("CaptionInfo.sec", url);
 }

--- a/src/util/url.cc
+++ b/src/util/url.cc
@@ -134,7 +134,7 @@ std::unique_ptr<URL::Stat> URL::getInfo(const std::string& URL, CURL* curl_handl
     if (retcode != 200) {
         if (cleanup)
             curl_easy_cleanup(curl_handle);
-        throw_std_runtime_error("Error retrieving information from " + URL + " HTTP return code: " + std::to_string(retcode));
+        throw_std_runtime_error("Error retrieving information from " + URL + " HTTP return code: " + fmt::to_string(retcode));
     }
 
     res = curl_easy_getinfo(curl_handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);

--- a/src/web/auth.cc
+++ b/src/web/auth.cc
@@ -48,7 +48,7 @@ static std::string generate_token()
 {
     const time_t expiration = get_time() + LOGIN_TIMEOUT;
     std::string salt = generateRandomId();
-    return std::to_string(expiration) + '_' + salt;
+    return fmt::to_string(expiration) + '_' + salt;
 }
 
 static bool check_token(const std::string& token, const std::string& password, const std::string& encPassword)

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -157,7 +157,7 @@ void web::autoscan::autoscan2XML(const std::shared_ptr<AutoscanDirectory>& adir,
         element->append_child("scan_mode").append_child(pugi::node_pcdata).set_value(AutoscanDirectory::mapScanmode(adir->getScanMode()).c_str());
         element->append_child("recursive").append_child(pugi::node_pcdata).set_value(adir->getRecursive() ? "1" : "0");
         element->append_child("hidden").append_child(pugi::node_pcdata).set_value(adir->getHidden() ? "1" : "0");
-        element->append_child("interval").append_child(pugi::node_pcdata).set_value(std::to_string(adir->getInterval()).c_str());
+        element->append_child("interval").append_child(pugi::node_pcdata).set_value(fmt::to_string(adir->getInterval()).c_str());
         element->append_child("persistent").append_child(pugi::node_pcdata).set_value(adir->persistent() ? "1" : "0");
     }
 }

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -57,7 +57,7 @@ TEST_F(UpnpXmlTest, RenderObjectContainer)
     obj->setMetadata(M_UPNP_DATE, "2001-01-01");
     // albumArtURI
     database->findFolderImageMap.clear();
-    database->findFolderImageMap[std::to_string(obj->getID())] = "10";
+    database->findFolderImageMap[fmt::to_string(obj->getID())] = "10";
 
     std::ostringstream expectedXml;
     expectedXml << "<DIDL-Lite>\n";

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -39,7 +39,7 @@ public:
 
     std::string findFolderImage(int id, std::string trackArtBase) override
     {
-        auto it = findFolderImageMap.find(std::to_string(id) + trackArtBase);
+        auto it = findFolderImageMap.find(fmt::to_string(id) + trackArtBase);
         if (it != findFolderImageMap.end())
             return it->second;
         return "";


### PR DESCRIPTION
The former is faster. More info: https://github.com/fmtlib/fmt/issues/326

Signed-off-by: Rosen Penev <rosenp@gmail.com>

I am not sure whether or not this is worth it. Thoughts?