### PR TITLE
fmt::format conversions

### DIFF
--- a/src/cds_objects.cc
+++ b/src/cds_objects.cc
@@ -126,7 +126,7 @@ std::shared_ptr<CdsObject> CdsObject::createObject(unsigned int objectType)
     } else if (IS_CDS_ITEM(objectType)) {
         obj = std::make_shared<CdsItem>();
     } else {
-        throw_std_runtime_error("invalid object type: " + fmt::to_string(objectType));
+        throw_std_runtime_error("invalid object type: {}", objectType);
     }
     return obj;
 }
@@ -176,7 +176,7 @@ void CdsItem::validate()
 
     std::error_code ec;
     if (!isRegularFile(location, ec))
-        throw_std_runtime_error("Item validation failed: file " + location.string() + " not found");
+        throw_std_runtime_error("Item validation failed: file {} not found", location.c_str());
 }
 
 //---------
@@ -243,5 +243,5 @@ std::string CdsObject::mapObjectType(unsigned int type)
         return STRING_OBJECT_TYPE_ITEM;
     if (IS_CDS_ITEM_EXTERNAL_URL(type))
         return STRING_OBJECT_TYPE_EXTERNAL_URL;
-    throw_std_runtime_error("illegal objectType: " + fmt::to_string(type));
+    throw_std_runtime_error("illegal objectType: {}", type);
 }

--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -207,7 +207,7 @@ ClientType ClientConfig::remapClientType(const std::string& clientType)
         return ClientType::Unknown;
     }
 
-    throw_std_runtime_error("clientType " + clientType + " invalid");
+    throw_std_runtime_error("clientType {} invalid", clientType.c_str());
 }
 
 int ClientConfig::remapFlag(const std::string& flag)

--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -147,9 +147,9 @@ std::string ConfigGenerator::generate(const fs::path& userHome, const fs::path& 
     auto config = init();
 
     config->append_attribute("version") = CONFIG_XML_VERSION;
-    config->append_attribute("xmlns") = (XML_XMLNS + fmt::to_string(CONFIG_XML_VERSION)).c_str();
+    config->append_attribute("xmlns") = fmt::format("{}{}", XML_XMLNS, CONFIG_XML_VERSION).c_str();
     config->append_attribute("xmlns:xsi") = XML_XMLNS_XSI;
-    config->append_attribute("xsi:schemaLocation") = (std::string(XML_XMLNS) + fmt::to_string(CONFIG_XML_VERSION) + " " + XML_XMLNS + fmt::to_string(CONFIG_XML_VERSION) + ".xsd").c_str();
+    config->append_attribute("xsi:schemaLocation") = fmt::format("{}{} {}{}.xsd", XML_XMLNS, CONFIG_XML_VERSION, XML_XMLNS, CONFIG_XML_VERSION).c_str();
 
     auto docinfo = config->append_child(pugi::node_comment);
     docinfo.set_value("\n\
@@ -181,17 +181,16 @@ void ConfigGenerator::generateServer(const fs::path& userHome, const fs::path& c
     setValue(CFG_SERVER_WEBROOT, webRoot);
 
     auto aliveinfo = server->append_child(pugi::node_comment);
-    aliveinfo.set_value(
-        ("\n\
+    aliveinfo.set_value(fmt::format("\n\
         How frequently (in seconds) to send ssdp:alive advertisements.\n\
-        Minimum alive value accepted is: "
-            + fmt::to_string(ALIVE_INTERVAL_MIN) + "\n\n\
+        Minimum alive value accepted is: {}\n\n\
         The advertisement will be sent every (A/2)-30 seconds,\n\
         and will have a cache-control max-age of A where A is\n\
         the value configured here. Ex: A value of 62 will result\n\
         in an SSDP advertisement being sent every second.\n\
-    ")
-            .c_str());
+    ",
+        ALIVE_INTERVAL_MIN)
+                            .c_str());
     setValue(CFG_SERVER_ALIVE_INTERVAL);
 
     generateDatabase();

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -797,7 +797,7 @@ std::shared_ptr<ConfigSetup> ConfigManager::findConfigSetup(config_option_t opti
     if (save)
         return nullptr;
 
-    throw std::runtime_error(fmt::format("Error in config code: {} tag not found", int(option)));
+    throw_std_runtime_error("Error in config code: {} tag not found", option);
 }
 
 std::shared_ptr<ConfigSetup> ConfigManager::findConfigSetupByPath(const std::string& key, bool save, const std::shared_ptr<ConfigSetup>& parent)
@@ -835,7 +835,7 @@ std::shared_ptr<ConfigSetup> ConfigManager::findConfigSetupByPath(const std::str
         return (co != complexOptions.end()) ? *co : nullptr;
     }
 
-    throw std::runtime_error(fmt::format("Error in config code: {} tag not found", key));
+    throw_std_runtime_error("Error in config code: {} tag not found", key);
 }
 
 std::shared_ptr<ConfigOption> ConfigManager::setOption(const pugi::xml_node& root, config_option_t option, const std::map<std::string, std::string>* arguments)
@@ -894,7 +894,7 @@ void ConfigManager::load(const fs::path& userHome)
     }
 
     if (!fs::is_directory(temp))
-        throw std::runtime_error(fmt::format("Directory '{}' does not exist", temp));
+        throw_std_runtime_error("Directory '{}' does not exist", temp);
     co->makeOption(temp, self);
     ConfigPathSetup::Home = temp;
 

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -51,7 +51,7 @@ pugi::xml_node ConfigSetup::getXmlElement(const pugi::xml_node& root) const
         xpathNode = root.select_node(xpath);
     }
     if (required && xpathNode.node() == nullptr) {
-        throw std::runtime_error(fmt::format("Error in config file: {}/{} tag not found", root.path(), xpath));
+        throw_std_runtime_error("Error in config file: {}/{} tag not found", root.path(), xpath);
     }
     return xpathNode.node();
 }
@@ -75,7 +75,7 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim) co
     if (xpathNode.node() != nullptr) {
         std::string optValue = trim ? trimString(xpathNode.node().text().as_string()) : xpathNode.node().text().as_string();
         if (!checkValue(optValue)) {
-            throw std::runtime_error(fmt::format("Invalid {}{} value '{}'", root.path(), xpath, optValue));
+            throw_std_runtime_error("Invalid {}{} value '{}'", root.path(), xpath, optValue.c_str());
         }
         return optValue;
     }
@@ -83,7 +83,7 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim) co
     if (xpathNode.attribute() != nullptr) {
         std::string optValue = trim ? trimString(xpathNode.attribute().value()) : xpathNode.attribute().value();
         if (!checkValue(optValue)) {
-            throw std::runtime_error(fmt::format("Invalid {}/attribute::{} value '{}'", root.path(), xpath, optValue));
+            throw_std_runtime_error("Invalid {}/attribute::{} value '{}'", root.path(), xpath, optValue.c_str());
         }
         return optValue;
     }
@@ -93,7 +93,7 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim) co
     if (root.attribute(xAttr.c_str()) != nullptr) {
         std::string optValue = trim ? trimString(root.attribute(xAttr.c_str()).as_string()) : root.attribute(xAttr.c_str()).as_string();
         if (!checkValue(optValue)) {
-            throw std::runtime_error(fmt::format("Invalid {}/attribute::{} value '{}'", root.path(), xAttr.c_str(), optValue));
+            throw_std_runtime_error("Invalid {}/attribute::{} value '{}'", root.path(), xAttr.c_str(), optValue.c_str());
         }
         return optValue;
     }
@@ -101,13 +101,13 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim) co
     if (root.child(xpath) != nullptr) {
         std::string optValue = trim ? trimString(root.child(xpath).text().as_string()) : root.child(xpath).text().as_string();
         if (!checkValue(optValue)) {
-            throw std::runtime_error(fmt::format("Invalid {}/{} value '{}'", root.path(), xpath, optValue));
+            throw_std_runtime_error("Invalid {}/{} value '{}'", root.path(), xpath, optValue.c_str());
         }
         return optValue;
     }
 
     if (required)
-        throw std::runtime_error(fmt::format("Error in config file: {}/{} not found", root.path(), xpath));
+        throw_std_runtime_error("Error in config file: {}/{} not found", root.path(), xpath);
 
     log_debug("Config: option not found: '{}/{}' using default value: '{}'", root.path(), xpath, defaultValue.c_str());
 
@@ -165,7 +165,7 @@ void ConfigStringSetup::makeOption(const pugi::xml_node& root, const std::shared
 std::shared_ptr<ConfigOption> ConfigStringSetup::newOption(const std::string& optValue)
 {
     if (notEmpty && optValue.empty()) {
-        throw std::runtime_error(fmt::format("Invalid {} empty value '{}'", xpath, optValue));
+        throw_std_runtime_error("Invalid {} empty value '{}'", xpath, optValue.c_str());
     }
     optionValue = std::make_shared<Option>(optValue);
     return optionValue;
@@ -278,7 +278,7 @@ std::shared_ptr<ConfigOption> ConfigPathSetup::newOption(std::string& optValue)
 {
     auto pathValue = optValue;
     if (!checkPathValue(optValue, pathValue)) {
-        throw std::runtime_error(fmt::format("Invalid {} resolves to empty value '{}'", xpath, optValue));
+        throw_std_runtime_error("Invalid {} resolves to empty value '{}'", xpath, optValue.c_str());
     }
     optionValue = std::make_shared<Option>(pathValue);
     return optionValue;
@@ -296,22 +296,22 @@ void ConfigIntSetup::makeOption(std::string optValue, const std::shared_ptr<Conf
 {
     if (rawCheck != nullptr) {
         if (!rawCheck(optValue)) {
-            throw std::runtime_error(fmt::format("Invalid {} value '{}'", xpath, optValue));
+            throw_std_runtime_error("Invalid {} value '{}'", xpath, optValue.c_str());
         }
     } else if (valueCheck != nullptr) {
         if (!valueCheck(std::stoi(optValue))) {
-            throw std::runtime_error(fmt::format("Invalid {} value '{}'", xpath, optValue));
+            throw_std_runtime_error("Invalid {} value '{}'", xpath, optValue.c_str());
         }
     } else if (minCheck != nullptr) {
         if (!minCheck(std::stoi(optValue), minValue)) {
-            throw std::runtime_error(fmt::format("Invalid {} value '{}', must be at least {}", xpath, optValue, minValue));
+            throw_std_runtime_error("Invalid {} value '{}', must be at least {}", xpath, optValue.c_str(), minValue);
         }
     }
     try {
         optionValue = std::make_shared<IntOption>(std::stoi(optValue));
         setOption(config);
     } catch (const std::runtime_error& e) {
-        throw std::runtime_error(fmt::format("Error in config file: {} unsupported int value '{}'", xpath, optValue).c_str());
+        throw_std_runtime_error("Error in config file: {} unsupported int value '{}'", xpath, optValue.c_str());
     }
 }
 
@@ -320,20 +320,20 @@ int ConfigIntSetup::checkIntValue(std::string& sVal, const std::string& pathName
     try {
         if (rawCheck != nullptr) {
             if (!rawCheck(sVal)) {
-                throw std::runtime_error(fmt::format("Invalid {}/{} value '{}'", pathName, xpath, sVal));
+                throw_std_runtime_error("Invalid {}/{} value '{}'", pathName, xpath, sVal);
             }
         } else if (valueCheck != nullptr) {
             if (!valueCheck(std::stoi(sVal))) {
-                throw std::runtime_error(fmt::format("Invalid {}/{} value {}", pathName, xpath, sVal));
+                throw_std_runtime_error("Invalid {}/{} value {}", pathName, xpath, sVal);
             }
         } else if (minCheck != nullptr) {
             if (!minCheck(std::stoi(sVal), minValue)) {
-                throw std::runtime_error(fmt::format("Invalid {}/{} value '{}', must be at least {}", pathName, xpath, sVal, minValue));
+                throw_std_runtime_error("Invalid {}/{} value '{}', must be at least {}", pathName, xpath, sVal, minValue);
             }
         }
         return std::stoi(sVal);
     } catch (const std::runtime_error& e) {
-        throw std::runtime_error(fmt::format("Error in config file: {}/{} unsupported int value '{}'", pathName, xpath, sVal).c_str());
+        throw_std_runtime_error("Error in config file: {}/{} unsupported int value '{}'", pathName, xpath, sVal);
     }
 }
 
@@ -347,10 +347,10 @@ int ConfigIntSetup::getXmlContent(const pugi::xml_node& root) const
 std::shared_ptr<ConfigOption> ConfigIntSetup::newOption(int optValue)
 {
     if (valueCheck != nullptr && !valueCheck(optValue)) {
-        throw std::runtime_error(fmt::format("Invalid {} value {}", xpath, optValue));
+        throw_std_runtime_error("Invalid {} value {}", xpath, optValue);
     }
     if (minCheck != nullptr && !minCheck(optValue, minValue)) {
-        throw std::runtime_error(fmt::format("Invalid {} value {}, must be at least {}", xpath, optValue, minValue));
+        throw_std_runtime_error("Invalid {} value {}, must be at least {}", xpath, optValue, minValue);
     }
     optionValue = std::make_shared<IntOption>(optValue);
     return optionValue;
@@ -421,7 +421,7 @@ static bool validateTrueFalse(const std::string& optValue)
 void ConfigBoolSetup::makeOption(std::string optValue, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {
     if (!validateTrueFalse(optValue) && !validateYesNo(optValue))
-        throw std::runtime_error(fmt::format("Invalid {} value {}", xpath, optValue));
+        throw_std_runtime_error("Invalid {} value {}", xpath, optValue.c_str());
     optionValue = std::make_shared<BoolOption>(optValue == YES || optValue == "true");
     setOption(config);
 };
@@ -436,12 +436,12 @@ bool ConfigBoolSetup::checkValue(std::string& optValue, const std::string& pathN
 {
     if (rawCheck != nullptr) {
         if (!rawCheck(optValue)) {
-            throw std::runtime_error(fmt::format("Invalid {}/{} value '{}'", pathName, xpath, optValue));
+            throw_std_runtime_error("Invalid {}/{} value '{}'", pathName, xpath, optValue.c_str());
         }
     }
 
     if (!validateTrueFalse(optValue) && !validateYesNo(optValue))
-        throw std::runtime_error(fmt::format("Invalid {}/{} value {}", pathName, xpath, optValue));
+        throw_std_runtime_error("Invalid {}/{} value {}", pathName, xpath, optValue.c_str());
     return optValue == YES || optValue == "true";
 }
 
@@ -530,7 +530,7 @@ bool ConfigArraySetup::createArrayFromNode(const pugi::xml_node& element, std::v
             const pugi::xml_node& child = it.node();
             std::string attrValue = attrOption != CFG_MAX ? child.attribute(removeAttribute(attrOption).c_str()).as_string() : child.text().as_string();
             if (itemNotEmpty && attrValue.empty()) {
-                throw std::runtime_error(fmt::format("Invalid array {} value {} empty '{}'", element.path(), xpath, attrValue));
+                throw_std_runtime_error("Invalid array {} value {} empty '{}'", element.path(), xpath, attrValue);
             }
             if (!attrValue.empty())
                 result.push_back(attrValue);
@@ -567,7 +567,7 @@ bool ConfigArraySetup::updateDetail(const std::string& optItem, std::string& opt
 {
     if (optItem.substr(0, strlen(xpath)) == xpath && optionValue != nullptr) {
         std::shared_ptr<ArrayOption> value = std::dynamic_pointer_cast<ArrayOption>(optionValue);
-        log_debug("Updating Array Detail {} {} {}", xpath, optItem, optValue);
+        log_debug("Updating Array Detail {} {} {}", xpath, optItem, optValue.c_str());
 
         size_t i = extractIndex(optItem);
         if (i < SIZE_MAX) {
@@ -598,15 +598,15 @@ std::vector<std::string> ConfigArraySetup::getXmlContent(const pugi::xml_node& o
     std::vector<std::string> result;
     if (initArray != nullptr) {
         if (!initArray(optValue, result, ConfigManager::mapConfigOption(nodeOption))) {
-            throw std::runtime_error(fmt::format("Invalid {} array value '{}'", xpath, optValue));
+            throw_std_runtime_error("Invalid {} array value '{}'", xpath, optValue);
         }
     } else {
         if (!createArrayFromNode(optValue, result)) {
-            throw std::runtime_error(fmt::format("Invalid {} array value '{}'", xpath, optValue));
+            throw_std_runtime_error("Invalid {} array value '{}'", xpath, optValue);
         }
     }
     if (notEmpty && result.empty()) {
-        throw std::runtime_error(fmt::format("Invalid array {} empty '{}'", xpath, optValue));
+        throw_std_runtime_error("Invalid array {} empty '{}'", xpath, optValue);
     }
     return result;
 }
@@ -757,7 +757,7 @@ bool ConfigDictionarySetup::updateItem(size_t i, const std::string& optItem, con
             value->setValue(i, config->getOrigValue(valIndex));
             log_debug("Reset Dictionary value {} {}", valIndex, config->getDictionaryOption(option)[optKey]);
         }
-        log_debug("New Dictionary key {} {}", keyIndex, optValue);
+        log_debug("New Dictionary key {} {}", keyIndex, optValue.c_str());
         return true;
     }
     if (optItem == valIndex) {
@@ -773,7 +773,7 @@ bool ConfigDictionarySetup::updateDetail(const std::string& optItem, std::string
 {
     if (optItem.substr(0, strlen(xpath)) == xpath && optionValue != nullptr) {
         std::shared_ptr<DictionaryOption> value = std::dynamic_pointer_cast<DictionaryOption>(optionValue);
-        log_debug("Updating Dictionary Detail {} {} {}", xpath, optItem, optValue);
+        log_debug("Updating Dictionary Detail {} {} {}", xpath, optItem, optValue.c_str());
 
         size_t i = extractIndex(optItem);
         if (i < SIZE_MAX) {
@@ -818,15 +818,15 @@ std::map<std::string, std::string> ConfigDictionarySetup::getXmlContent(const pu
     std::map<std::string, std::string> result;
     if (initDict != nullptr) {
         if (!initDict(optValue, result)) {
-            throw std::runtime_error(fmt::format("Init {} dictionary failed '{}'", xpath, optValue));
+            throw_std_runtime_error("Init {} dictionary failed '{}'", xpath, optValue);
         }
     } else {
         if (!createDictionaryFromNode(optValue, result)) {
-            throw std::runtime_error(fmt::format("Init {} dictionary failed '{}'", xpath, optValue));
+            throw_std_runtime_error("Init {} dictionary failed '{}'", xpath, optValue);
         }
     }
     if (notEmpty && result.empty()) {
-        throw std::runtime_error(fmt::format("Invalid dictionary {} empty '{}'", xpath, optValue));
+        throw_std_runtime_error("Invalid dictionary {} empty '{}'", xpath, optValue);
     }
     return result;
 }
@@ -948,7 +948,7 @@ bool ConfigAutoscanSetup::updateDetail(const std::string& optItem, std::string& 
 {
     auto uPath = getUniquePath();
     if (optItem.substr(0, uPath.length()) == uPath) {
-        log_debug("Updating Autoscan Detail {} {} {}", uPath, optItem, optValue);
+        log_debug("Updating Autoscan Detail {} {} {}", uPath, optItem, optValue.c_str());
         std::shared_ptr<AutoscanListOption> value = std::dynamic_pointer_cast<AutoscanListOption>(optionValue);
 
         auto list = value->getAutoscanListOption();
@@ -996,7 +996,7 @@ std::shared_ptr<ConfigOption> ConfigAutoscanSetup::newOption(const pugi::xml_nod
 {
     std::shared_ptr<AutoscanList> result = std::make_shared<AutoscanList>(nullptr);
     if (!createAutoscanListFromNode(optValue, result)) {
-        throw std::runtime_error(fmt::format("Init {} autoscan failed '{}'", xpath, optValue));
+        throw_std_runtime_error("Init {} autoscan failed '{}'", xpath, optValue);
     }
     optionValue = std::make_shared<AutoscanListOption>(result);
     return optionValue;
@@ -1192,7 +1192,7 @@ bool ConfigTranscodingSetup::updateDetail(const std::string& optItem, std::strin
 {
     if (optItem.substr(0, strlen(xpath)) == xpath) {
         std::shared_ptr<TranscodingProfileListOption> value = std::dynamic_pointer_cast<TranscodingProfileListOption>(optionValue);
-        log_debug("Updating Transcoding Detail {} {} {}", xpath, optItem, optValue);
+        log_debug("Updating Transcoding Detail {} {} {}", xpath, optItem, optValue.c_str());
         std::map<std::string, int> profiles;
         int i = 0;
         for (const auto& [key, val] : value->getTranscodingProfileListOption()->getList()) {
@@ -1406,7 +1406,7 @@ std::shared_ptr<ConfigOption> ConfigTranscodingSetup::newOption(const pugi::xml_
     std::shared_ptr<TranscodingProfileList> result = std::make_shared<TranscodingProfileList>();
 
     if (!createTranscodingProfileListFromNode(isEnabled ? optValue : pugi::xml_node(nullptr), result)) {
-        throw std::runtime_error(fmt::format("Init {} transcoding failed '{}'", xpath, optValue));
+        throw_std_runtime_error("Init {} transcoding failed '{}'", xpath, optValue);
     }
     optionValue = std::make_shared<TranscodingProfileListOption>(result);
     return optionValue;
@@ -1534,7 +1534,7 @@ std::shared_ptr<ConfigOption> ConfigClientSetup::newOption(const pugi::xml_node&
     std::shared_ptr<ClientConfigList> result = std::make_shared<ClientConfigList>();
 
     if (!createClientConfigListFromNode(isEnabled ? optValue : pugi::xml_node(nullptr), result)) {
-        throw std::runtime_error(fmt::format("Init {} client config failed '{}'", xpath, optValue));
+        throw_std_runtime_error("Init {} client config failed '{}'", xpath, optValue);
     }
     optionValue = std::make_shared<ClientConfigListOption>(result);
     return optionValue;
@@ -1762,7 +1762,7 @@ std::shared_ptr<ConfigOption> ConfigDirectorySetup::newOption(const pugi::xml_no
     std::shared_ptr<DirectoryConfigList> result = std::make_shared<DirectoryConfigList>();
 
     if (!createDirectoryTweakListFromNode(optValue, result)) {
-        throw std::runtime_error(fmt::format("Init {} DirectoryConfigList failed '{}'", xpath, optValue));
+        throw_std_runtime_error("Init {} DirectoryConfigList failed '{}'", xpath, optValue);
     }
     optionValue = std::make_shared<DirectoryTweakOption>(result);
     return optionValue;

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -109,8 +109,7 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim) co
     if (required)
         throw std::runtime_error(fmt::format("Error in config file: {}/{} not found", root.path(), xpath));
 
-    log_debug("Config: option not found: '{}/{}' using default value: '{}'",
-        root.path(), xpath, defaultValue.c_str());
+    log_debug("Config: option not found: '{}/{}' using default value: '{}'", root.path(), xpath, defaultValue.c_str());
 
     return defaultValue;
 }
@@ -119,9 +118,8 @@ pugi::xpath_node_set ConfigSetup::getXmlTree(const pugi::xml_node& element) cons
 {
     if (xpath[0] == '/') {
         return element.root().select_nodes(cpath.c_str());
-    } else {
-        return element.select_nodes(xpath);
     }
+    return element.select_nodes(xpath);
 }
 
 void ConfigSetup::makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
@@ -187,21 +185,21 @@ bool ConfigPathSetup::checkAgentPath(std::string& optValue)
     std::string tmp_path;
     if (fs::path(optValue).is_absolute()) {
         if (!isRegularFile(optValue) && !fs::is_symlink(optValue)) {
-            log_error("error in configuration, transcoding profile: could not find transcoding command \"" + optValue + "\"");
+            log_error("Error in configuration, transcoding profile: could not find transcoding command \"{}\"", optValue.c_str());
             return false;
         }
         tmp_path = optValue;
     } else {
         tmp_path = findInPath(optValue);
         if (tmp_path.empty()) {
-            log_error("error in configuration, transcoding profile: could not find transcoding command \"" + optValue + "\" in $PATH");
+            log_error("Error in configuration, transcoding profile: could not find transcoding command \"{}\" in $PATH", optValue.c_str());
             return false;
         }
     }
 
     int err = 0;
     if (!isExecutable(tmp_path, &err)) {
-        log_error("error in configuration, transcoding profile: transcoder " + optValue + "is not executable - " + strerror(err));
+        log_error("Error in configuration, transcoding profile: transcoder {} is not executable: {}", optValue.c_str(), std::strerror(err));
         return false;
     }
     return true;
@@ -885,7 +883,7 @@ bool ConfigAutoscanSetup::createAutoscanListFromNode(const pugi::xml_node& eleme
         try {
             result->add(dir);
         } catch (const std::runtime_error& e) {
-            log_error("Could not add " + location.string() + ": " + e.what());
+            log_error("Could not add {}: {}", location.c_str(), e.what());
             return false;
         }
     }
@@ -1115,13 +1113,11 @@ bool ConfigTranscodingSetup::createTranscodingProfileListFromNode(const pugi::xm
         size_t fill = findConfigSetup<ConfigIntSetup>(ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_FILL)->getXmlContent(sub);
 
         if (chunk > buffer) {
-            log_error("error in configuration: transcoding profile \""
-                + prof->getName() + "\" chunk size can not be greater than buffer size");
+            log_error("Error in configuration: transcoding profile \"{}\" chunk size can not be greater than buffer size", prof->getName().c_str());
             return false;
         }
         if (fill > buffer) {
-            log_error("error in configuration: transcoding profile \""
-                + prof->getName() + "\" fill size can not be greater than buffer size");
+            log_error("Error in configuration: transcoding profile \"{}\" fill size can not be greater than buffer size", prof->getName().c_str());
             return false;
         }
 
@@ -1136,9 +1132,7 @@ bool ConfigTranscodingSetup::createTranscodingProfileListFromNode(const pugi::xm
         }
 
         if (!set) {
-            log_error("error in configuration: you specified a mimetype to transcoding profile mapping, "
-                      "but no match for profile \""
-                + prof->getName() + "\" exists");
+            log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but no match for profile \"{}\" exists", prof->getName().c_str());
             if (!allow_unused_profiles) {
                 return false;
             }
@@ -1148,9 +1142,7 @@ bool ConfigTranscodingSetup::createTranscodingProfileListFromNode(const pugi::xm
     auto tpl = result->getList();
     for (const auto& [key, val] : mt_mappings) {
         if (tpl.find(key) == tpl.end()) {
-            log_error("error in configuration: you specified a mimetype to transcoding profile mapping, "
-                      "but the profile \""
-                + val + "\" for mimetype \"" + key + "\" does not exists");
+            log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but the profile \"{}\" for mimetype \"{}\" does not exists", val.c_str(), key.c_str());
             if (!findConfigSetup<ConfigBoolSetup>(CFG_TRANSCODING_MIMETYPE_PROF_MAP_ALLOW_UNUSED)->getXmlContent(root)) {
                 return false;
             }

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -183,7 +183,7 @@ public:
     {
         std::shared_ptr<CS> result = std::dynamic_pointer_cast<CS>(ConfigManager::findConfigSetup(option));
         if (result == nullptr) {
-            throw std::runtime_error(fmt::format("Error in config code: {} has wrong class", int(option)));
+            throw_std_runtime_error("Error in config code: {} has wrong class", option);
         }
         return result;
     }
@@ -261,11 +261,11 @@ public:
         std::string optValue = ConfigSetup::getXmlContent(root, true);
         log_debug("Config: option: '{}' value: '{}'", xpath, optValue.c_str());
         if (notEmpty && optValue.empty()) {
-            throw std::runtime_error(fmt::format("Error in config file: Invalid {}/{} empty value '{}'", root.path(), xpath, optValue));
+            throw_std_runtime_error("Error in config file: Invalid {}/{} empty value '{}'", root.path(), xpath, optValue);
         }
         En result;
         if (!checkEnumValue(optValue, result)) {
-            throw std::runtime_error(fmt::format("Error in config file: {}/{} unsupported Enum value '{}'", root.path(), xpath, optValue).c_str());
+            throw_std_runtime_error("Error in config file: {}/{} unsupported Enum value '{}'", root.path(), xpath, optValue);
         }
         return result;
     }
@@ -273,11 +273,11 @@ public:
     std::shared_ptr<ConfigOption> newOption(const std::string& optValue)
     {
         if (notEmpty && optValue.empty()) {
-            throw std::runtime_error(fmt::format("Invalid {} empty value '{}'", xpath, optValue));
+            throw_std_runtime_error("Invalid {} empty value '{}'", xpath, optValue);
         }
         En result;
         if (!checkEnumValue(optValue, result)) {
-            throw std::runtime_error(fmt::format("Error in config file: {} unsupported Enum value '{}'", xpath, optValue).c_str());
+            throw_std_runtime_error("Error in config file: {} unsupported Enum value '{}'", xpath, optValue);
         }
         optionValue = std::make_shared<Option>(optValue);
         return optionValue;

--- a/src/content/autoscan.cc
+++ b/src/content/autoscan.cc
@@ -119,7 +119,7 @@ std::string AutoscanDirectory::mapScanmode(ScanMode scanmode)
         scanmode_str = "inotify";
         break;
     default:
-        throw_std_runtime_error("illegal scanmode given to mapScanmode()");
+        throw_std_runtime_error("Illegal scanmode ({}) given to mapScanmode()", scanmode);
     }
     return scanmode_str;
 }
@@ -131,7 +131,7 @@ ScanMode AutoscanDirectory::remapScanmode(const std::string& scanmode)
     if (scanmode == "inotify")
         return ScanMode::INotify;
 
-    throw_std_runtime_error("illegal scanmode (" + scanmode + ") given to remapScanmode()");
+    throw_std_runtime_error("Illegal scanmode ({}) given to remapScanmode()", scanmode.c_str());
 }
 
 void AutoscanDirectory::copyTo(const std::shared_ptr<AutoscanDirectory>& copy) const

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -411,13 +411,13 @@ void ContentManager::addVirtualItem(const std::shared_ptr<CdsObject>& obj, bool 
 
     std::error_code ec;
     if (!isRegularFile(path, ec))
-        throw_std_runtime_error("Not a file: " + path.string());
+        throw_std_runtime_error("Not a file: {}", path.c_str());
 
     auto pcdir = database->findObjectByPath(path);
     if (pcdir == nullptr) {
         pcdir = createObjectFromFile(path, true, allow_fifo);
         if (pcdir == nullptr) {
-            throw_std_runtime_error("Could not add " + path.string());
+            throw_std_runtime_error("Could not add {}", path.c_str());
         }
         if (pcdir->isItem()) {
             this->addObject(pcdir);
@@ -633,7 +633,7 @@ void ContentManager::_rescanDirectory(std::shared_ptr<AutoscanDirectory>& adir, 
 
     DIR* dir = opendir(location.c_str());
     if (!dir) {
-        log_warning("Could not open {}: {}", location.c_str(), strerror(errno));
+        log_warning("Could not open {}: {}", location.c_str(), std::strerror(errno));
         if (adir->persistent()) {
             removeObject(adir, containerID, false);
             adir->setObjectID(INVALID_OBJECT_ID);
@@ -689,7 +689,7 @@ void ContentManager::_rescanDirectory(std::shared_ptr<AutoscanDirectory>& adir, 
         struct stat statbuf;
         int ret = stat(newPath.c_str(), &statbuf);
         if (ret != 0) {
-            log_error("Failed to stat {}, {}", newPath.c_str(), strerror(errno));
+            log_error("Failed to stat {}, {}", newPath.c_str(), std::strerror(errno));
             continue;
         }
 
@@ -810,7 +810,7 @@ void ContentManager::addRecursive(std::shared_ptr<AutoscanDirectory>& adir, cons
 
     DIR* dir = opendir(path.c_str());
     if (!dir) {
-        throw_std_runtime_error("could not list directory " + path.string() + " : " + strerror(errno));
+        throw_std_runtime_error("Could not list directory {} : {}", path.c_str(), std::strerror(errno));
     }
 
     int parentID = database->findObjectIDByPath(path);
@@ -862,12 +862,12 @@ void ContentManager::addRecursive(std::shared_ptr<AutoscanDirectory>& adir, cons
 
         // For the Web UI
         if (task != nullptr) {
-            task->setDescription("Importing: " + newPath.string());
+            task->setDescription(fmt::format("Importing: {}", newPath.c_str()));
         }
         struct stat statbuf;
         int ret = stat(newPath.c_str(), &statbuf);
         if (ret != 0) {
-            log_error("Failed to stat {}, {}", newPath.c_str(), strerror(errno));
+            log_error("Failed to stat {}, {}", newPath.c_str(), std::strerror(errno));
             continue;
         }
 
@@ -1133,7 +1133,7 @@ bool ContentManager::isLink(const fs::path& path, bool allowLinks)
         int lret = lstat(path.c_str(), &statbuf);
 
         if (lret != 0) {
-            log_warning("File or directory does not exist: {} ({})", path.string(), strerror(errno));
+            log_warning("File or directory does not exist: {} ({})", path.c_str(), std::strerror(errno));
             return true;
         }
 
@@ -1150,7 +1150,7 @@ std::shared_ptr<CdsObject> ContentManager::createObjectFromFile(const fs::path& 
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        log_warning("File or directory does not exist: {} ({})", path.string(), strerror(errno));
+        log_warning("File or directory does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
 
@@ -1214,7 +1214,7 @@ std::shared_ptr<CdsObject> ContentManager::createObjectFromFile(const fs::path& 
         */
     } else {
         // only regular files and directories are supported
-        throw_std_runtime_error("ContentManager: skipping file " + path.string());
+        throw_std_runtime_error("ContentManager: skipping file {}", path.c_str());
     }
     //    auto f2i = StringConverter::f2i();
     //    obj->setTitle(f2i->convert(filename));
@@ -1358,7 +1358,7 @@ int ContentManager::addFileInternal(
     if (async) {
         auto self = shared_from_this();
         auto task = std::make_shared<CMAddFileTask>(self, path, rootpath, asSetting, cancellable);
-        task->setDescription("Importing: " + path.string());
+        task->setDescription(fmt::format("Importing: {}", path.c_str()));
         task->setParentID(parentTaskID);
         addTask(task, lowPriority);
         return INVALID_OBJECT_ID;

--- a/src/content/onlineservice/atrailers_content_handler.cc
+++ b/src/content/onlineservice/atrailers_content_handler.cc
@@ -114,7 +114,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
         return nullptr;
     }
 
-    temp = fmt::to_string(OnlineService::getDatabasePrefix(OS_ATrailers)) + temp;
+    temp = fmt::format("{}{}", OnlineService::getDatabasePrefix(OS_ATrailers), temp);
     item->setServiceID(temp);
 
     auto preview = trailer.child("preview");

--- a/src/content/onlineservice/sopcast_content_handler.cc
+++ b/src/content/onlineservice/sopcast_content_handler.cc
@@ -125,9 +125,7 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& g
     auto resource = std::make_shared<CdsResource>(CH_DEFAULT);
     item->addResource(resource);
 
-    item->setAuxData(ONLINE_SERVICE_AUX_ID,
-        fmt::to_string(OS_SopCast));
-
+    item->setAuxData(ONLINE_SERVICE_AUX_ID, fmt::to_string(OS_SopCast));
     item->setAuxData(SOPCAST_AUXDATA_GROUP, groupName);
 
     std::string temp = channel.attribute("id").as_string();

--- a/src/content/scripting/playlist_parser_script.cc
+++ b/src/content/scripting/playlist_parser_script.cc
@@ -162,7 +162,7 @@ void PlaylistParserScript::processPlaylistObject(const std::shared_ptr<CdsObject
         currentObjectID = INVALID_OBJECT_ID;
         currentTask = nullptr;
         free(currentLine);
-        throw_std_runtime_error("failed to open file: " + obj->getLocation().string());
+        throw_std_runtime_error("Failed to open file: {}", obj->getLocation().c_str());
     }
 
     ScriptingRuntime::AutoLock lock(runtime->getMutex());

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -267,13 +267,13 @@ void Script::_load(const std::string& scriptPath)
     try {
         scriptText = j2i->convert(scriptText, true);
     } catch (const std::runtime_error& e) {
-        throw_std_runtime_error(std::string { "Failed to convert import script:" } + e.what());
+        throw_std_runtime_error("Failed to convert import script: {}", e.what());
     }
 
     duk_push_string(ctx, scriptPath.c_str());
     if (duk_pcompile_lstring_filename(ctx, 0, scriptText.c_str(), scriptText.length()) != 0) {
         log_error("Failed to load script: {}", duk_safe_to_string(ctx, -1));
-        throw_std_runtime_error("Scripting: failed to compile " + scriptPath);
+        throw_std_runtime_error("Scripting: failed to compile {}", scriptPath.c_str());
     }
 }
 
@@ -571,7 +571,7 @@ void Script::cdsObject2dukObject(const std::shared_ptr<CdsObject>& obj)
             for (const auto& res : obj->getResources()) {
                 auto attributes = res->getAttributes();
                 for (const auto& [key, val] : attributes) {
-                    setProperty(resCount == 0 ? key : (fmt::to_string(resCount) + "-" + key), val);
+                    setProperty(resCount == 0 ? key : fmt::format("{}-{}", resCount, key), val);
                 }
                 resCount++;
             }

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -56,7 +56,7 @@ std::shared_ptr<Database> Database::createInstance(const std::shared_ptr<Config>
 #endif
     else {
         // other database types...
-        throw_std_runtime_error("Unknown database type: " + type);
+        throw_std_runtime_error("Unknown database type: {}", type.c_str());
     }
 
     database->init();
@@ -68,7 +68,7 @@ std::shared_ptr<Database> Database::createInstance(const std::shared_ptr<Config>
 void Database::stripAndUnescapeVirtualContainerFromPath(std::string virtualPath, std::string& first, std::string& last)
 {
     if (virtualPath.at(0) != VIRTUAL_CONTAINER_SEPARATOR) {
-        throw_std_runtime_error(fmt::format("Got non-absolute virtual path; needs to start with: {}", VIRTUAL_CONTAINER_SEPARATOR));
+        throw_std_runtime_error("Got non-absolute virtual path; needs to start with: {}", VIRTUAL_CONTAINER_SEPARATOR);
     }
     size_t sep = virtualPath.rfind(VIRTUAL_CONTAINER_SEPARATOR);
     if (sep == 0) {

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -180,7 +180,7 @@ void MySQLDatabase::init()
         0 // flags
     );
     if (!res_mysql) {
-        throw_std_runtime_error("The connection to the MySQL database has failed: " + getError(&db));
+        throw_std_runtime_error("The connection to the MySQL database has failed: {}", getError(&db));
     }
 
     mysql_connection = true;
@@ -202,7 +202,7 @@ void MySQLDatabase::init()
             ret = mysql_real_query(&db, statement.c_str(), statement.size());
             if (ret) {
                 std::string myError = getError(&db);
-                throw DatabaseException(myError, "Mysql: error while creating db: " + myError);
+                throw DatabaseException(myError, fmt::format("Mysql: error while creating db: {}", myError));
             }
         }
 
@@ -273,7 +273,7 @@ void MySQLDatabase::init()
     }
 
     if (dbVersion != "7")
-        throw_std_runtime_error("The database seems to be from a newer version (database version " + dbVersion + ")");
+        throw_std_runtime_error("The database seems to be from a newer version (database version {})", dbVersion);
 
     lock.unlock();
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -387,7 +387,7 @@ void SQLDatabase::updateObject(std::shared_ptr<CdsObject> obj, int* changedConta
         data.push_back(std::make_shared<AddUpdateTable>(CDS_OBJECT_TABLE, cdsObjectSql, "update"));
     } else {
         if (IS_FORBIDDEN_CDS_ID(obj->getID()))
-            throw_std_runtime_error("tried to update an object with a forbidden ID (" + fmt::to_string(obj->getID()) + ")");
+            throw_std_runtime_error("Tried to update an object with a forbidden ID ({})", obj->getID());
         data = _addUpdateObject(obj, true, changedContainer);
     }
     for (const auto& addUpdateTable : data) {
@@ -418,7 +418,7 @@ std::shared_ptr<CdsObject> SQLDatabase::loadObject(int objectID)
     if (res != nullptr && (row = res->nextRow()) != nullptr) {
         return createObjectFromRow(row);
     }
-    throw ObjectNotFoundException("Object not found: " + fmt::to_string(objectID));
+    throw ObjectNotFoundException(fmt::format("Object not found: {}", objectID));
 }
 
 std::shared_ptr<CdsObject> SQLDatabase::loadObjectByServiceID(const std::string& serviceID)
@@ -477,7 +477,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::browse(const std::unique_pt
     if (res != nullptr && (row = res->nextRow()) != nullptr) {
         objectType = std::stoi(row->col(0));
     } else {
-        throw ObjectNotFoundException("Object not found: " + fmt::to_string(objectID));
+        throw ObjectNotFoundException(fmt::format("Object not found: {}", objectID));
     }
 
     row = nullptr;
@@ -674,7 +674,7 @@ std::shared_ptr<CdsObject> SQLDatabase::findObjectByPath(fs::path fullpath, bool
 
     auto res = select(qb);
     if (res == nullptr)
-        throw_std_runtime_error("error while doing select: " + qb.str());
+        throw_std_runtime_error("error while doing select: {}", qb.str());
 
     std::unique_ptr<SQLRow> row = res->nextRow();
     if (row == nullptr)
@@ -952,7 +952,7 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromRow(const std::unique_pt
     }
 
     if (!matched_types) {
-        throw DatabaseException("", "unknown object type: " + fmt::to_string(objectType));
+        throw DatabaseException("", fmt::format("Unknown object type: {}", objectType));
     }
 
     return obj;
@@ -999,7 +999,7 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
 
         item->setTrackNumber(stoiString(row->col(to_underlying(SearchCol::track_number))));
     } else {
-        throw DatabaseException("", "unknown object type: " + fmt::to_string(objectType));
+        throw DatabaseException("", fmt::format("Unknown object type: {}", objectType));
     }
 
     return obj;
@@ -1194,7 +1194,7 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::removeObjects(const st
 
     for (int id : *list) {
         if (IS_FORBIDDEN_CDS_ID(id)) {
-            throw_std_runtime_error("tried to delete a forbidden ID (" + fmt::to_string(id) + ")");
+            throw_std_runtime_error("Tried to delete a forbidden ID ({})", id);
         }
     }
 
@@ -1303,7 +1303,7 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::removeObject(int objec
         }
     }
     if (IS_FORBIDDEN_CDS_ID(objectID))
-        throw_std_runtime_error("tried to delete a forbidden ID (" + fmt::to_string(objectID) + ")");
+        throw_std_runtime_error("Tried to delete a forbidden ID ({})", objectID);
     std::vector<int32_t> itemIds;
     std::vector<int32_t> containerIds;
     if (isContainer) {
@@ -1952,7 +1952,7 @@ std::unique_ptr<std::vector<int>> SQLDatabase::_checkOverlappingAutoscans(const 
         if (obj == nullptr)
             throw_std_runtime_error("Referenced object (by Autoscan) not found.");
         log_error("There is already an Autoscan set on {}", obj->getLocation().c_str());
-        throw_std_runtime_error("There is already an Autoscan set on " + obj->getLocation().string());
+        throw_std_runtime_error("There is already an Autoscan set on {}", obj->getLocation().c_str());
     }
 
     if (adir->getRecursive()) {
@@ -1960,7 +1960,7 @@ std::unique_ptr<std::vector<int>> SQLDatabase::_checkOverlappingAutoscans(const 
         q << "SELECT " << TQ("obj_id")
           << " FROM " << TQ(AUTOSCAN_TABLE)
           << " WHERE " << TQ("path_ids") << " LIKE "
-          << quote("%," + fmt::to_string(checkObjectID) + ",%");
+          << quote(fmt::format("%,{},%", checkObjectID));
         if (databaseID >= 0)
             q << " AND " << TQ("id") << " != " << quote(databaseID);
         q << " LIMIT 1";
@@ -1977,7 +1977,7 @@ std::unique_ptr<std::vector<int>> SQLDatabase::_checkOverlappingAutoscans(const 
             if (obj == nullptr)
                 throw_std_runtime_error("Referenced object (by Autoscan) not found.");
             log_error("Overlapping Autoscans are not allowed. There is already an Autoscan set on {}", obj->getLocation().c_str());
-            throw_std_runtime_error("Overlapping Autoscans are not allowed. There is already an Autoscan set on " + obj->getLocation().string());
+            throw_std_runtime_error("Overlapping Autoscans are not allowed. There is already an Autoscan set on {}", obj->getLocation().c_str());
         }
     }
 
@@ -2005,7 +2005,7 @@ std::unique_ptr<std::vector<int>> SQLDatabase::_checkOverlappingAutoscans(const 
     if (obj == nullptr)
         throw_std_runtime_error("Referenced object (by Autoscan) not found.");
     log_error("Overlapping Autoscans are not allowed. There is already a recursive Autoscan set on {}", obj->getLocation().c_str());
-    throw_std_runtime_error("Overlapping Autoscans are not allowed. There is already a recursive Autoscan set on " + obj->getLocation().string());
+    throw_std_runtime_error("Overlapping Autoscans are not allowed. There is already a recursive Autoscan set on {}", obj->getLocation().c_str());
 }
 
 std::unique_ptr<std::vector<int>> SQLDatabase::getPathIDs(int objectID)

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -136,7 +136,7 @@ void Sqlite3Database::init()
 
     // check for db-file
     if (access(dbFilePath.c_str(), R_OK | W_OK) != 0 && errno != ENOENT)
-        throw DatabaseException("", fmt::format("Error while accessing sqlite database file ({}): {}", dbFilePath.c_str(), strerror(errno)));
+        throw DatabaseException("", fmt::format("Error while accessing sqlite database file ({}): {}", dbFilePath.c_str(), std::strerror(errno)));
 
     taskQueueOpen = true;
 
@@ -147,7 +147,7 @@ void Sqlite3Database::init()
         this);
 
     if (ret != 0) {
-        throw DatabaseException("", fmt::format("Could not start sqlite thread: {}", strerror(errno)));
+        throw DatabaseException("", fmt::format("Could not start sqlite thread: {}", std::strerror(errno)));
     }
 
     // wait for sqlite3 thread to become ready
@@ -193,7 +193,7 @@ void Sqlite3Database::init()
             dbVersion = getInternalSetting("db_version");
         } catch (const std::runtime_error& e) {
             shutdown();
-            throw_std_runtime_error(std::string { "error while creating database: " } + e.what());
+            throw_std_runtime_error("Error while creating database: {}", e.what());
         }
         log_info("database created successfully.");
     }
@@ -309,8 +309,7 @@ std::string Sqlite3Database::quote(std::string value) const
 
 std::string Sqlite3Database::getError(const std::string& query, const std::string& error, sqlite3* db)
 {
-    return std::string("SQLITE3: (") + fmt::to_string(sqlite3_errcode(db)) + " : " + fmt::to_string(sqlite3_extended_errcode(db)) + ") "
-        + sqlite3_errmsg(db) + "\nQuery:" + (query.empty() ? "unknown" : query) + "\nerror: " + (error.empty() ? "unknown" : error);
+    return fmt::format("SQLITE3: ({}, : {}) {}\nQuery: {}\nerror: {}", sqlite3_errcode(db), sqlite3_extended_errcode(db), sqlite3_errmsg(db), query.empty() ? "unknown" : query, error.empty() ? "unknown" : error);
 }
 
 std::shared_ptr<SQLResult> Sqlite3Database::select(const char* query, int length)

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -43,8 +43,7 @@
 #define PRETTY_FUNCTION __func__
 #endif
 
-#define throw_std_runtime_error(msg) throw std::runtime_error(std::string(msg) \
-    + " file:" + std::string(__FILE__) + " line:" + fmt::to_string(__LINE__) + " function:" + std::string(PRETTY_FUNCTION))
+#define throw_std_runtime_error(...) throw std::runtime_error(fmt::format("[{}:{}] {} Error: {}", __FILE__, __LINE__, PRETTY_FUNCTION, fmt::format(__VA_ARGS__)))
 
 class ConfigParseException : public std::runtime_error {
 public:

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -78,7 +78,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
         res_id = SIZE_MAX;
 
     if (!obj->isItem() && rh.empty()) {
-        throw_std_runtime_error(fmt::format("requested object {} is not an item", filename));
+        throw_std_runtime_error("Requested object {} is not an item", filename);
     }
 
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
@@ -112,9 +112,9 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     }
     if (ret != 0) {
         if (is_srt)
-            throw SubtitlesNotFoundException("Subtitle file " + path.string() + " is not available.");
+            throw SubtitlesNotFoundException(fmt::format("Subtitle file {} is not available.", path.c_str()));
 
-        throw_std_runtime_error("Failed to open " + path.string() + " - " + strerror(errno));
+        throw_std_runtime_error("Failed to open {}: {}", path.c_str(), std::strerror(errno));
     }
 
     if (access(path.c_str(), R_OK) == 0) {
@@ -126,7 +126,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     std::string header;
     log_debug("path: {}", path.c_str());
     if (!path.filename().empty()) {
-        header = "Content-Disposition: attachment; filename=\"" + path.filename().string() + "\"";
+        header = fmt::format("Content-Disposition: attachment; filename=\"{}\"", path.filename().c_str());
     }
 
     // for transcoded resourecs res_id will always be negative
@@ -168,9 +168,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
         auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
                       ->getByName(tr_profile);
         if (tp == nullptr)
-            throw_std_runtime_error("Transcoding of file " + path.string()
-                + " but no profile matching the name "
-                + tr_profile + " found");
+            throw_std_runtime_error("Transcoding of file {} but no profile matching the name {} found", path.c_str(), tr_profile.c_str());
 
         mimeType = tp->getTargetMimeType();
 
@@ -248,7 +246,7 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename, enum U
         res_id = SIZE_MAX;
 
     if (!obj->isItem() && rh.empty()) {
-        throw_std_runtime_error(fmt::format("requested object {} is not an item", filename));
+        throw_std_runtime_error("requested object {} is not an item", filename);
     }
 
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
@@ -279,9 +277,9 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename, enum U
     }
     if (ret != 0) {
         if (is_srt)
-            throw SubtitlesNotFoundException("Subtitle file " + path.string() + " is not available.");
+            throw SubtitlesNotFoundException(fmt::format("Subtitle file {} is not available.", path.c_str()));
 
-        throw_std_runtime_error("Failed to open " + path.string() + " - " + strerror(errno));
+        throw_std_runtime_error("Failed to open {}: {}", path.c_str(), std::strerror(errno));
     }
 
     // for transcoded resourecs res_id will always be negative

--- a/src/iohandler/curl_io_handler.cc
+++ b/src/iohandler/curl_io_handler.cc
@@ -41,7 +41,7 @@ CurlIOHandler::CurlIOHandler(const std::string& URL, CURL* curl_handle, size_t b
     if (URL.empty())
         throw_std_runtime_error("URL has not been set correctly");
     if (bufSize < CURL_MAX_WRITE_SIZE)
-        throw_std_runtime_error(fmt::format("bufSize must be at least CURL_MAX_WRITE_SIZE({})", CURL_MAX_WRITE_SIZE));
+        throw_std_runtime_error("bufSize must be at least CURL_MAX_WRITE_SIZE({})", CURL_MAX_WRITE_SIZE);
 
     this->URL = URL;
     this->external_curl_handle = (curl_handle != nullptr);

--- a/src/iohandler/file_io_handler.cc
+++ b/src/iohandler/file_io_handler.cc
@@ -54,7 +54,7 @@ void FileIOHandler::open(enum UpnpOpenFileMode mode)
     }
 
     if (f == nullptr) {
-        throw_std_runtime_error("failed to open: " + filename.string());
+        throw_std_runtime_error("Failed to open: {}", filename.c_str());
     }
 }
 

--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -121,7 +121,7 @@ ProcessIOHandler::ProcessIOHandler(std::shared_ptr<ContentManager> content,
     /*
     if (mkfifo(filename.c_str(), O_RDWR) == -1)
     {
-        log_error("Failed to create fifo: {}", strerror(errno));
+        log_error("Failed to create fifo: {}", std::strerror(errno));
         killAll();
         if (main_proc != nullptr)
             main_proc->kill();
@@ -156,14 +156,14 @@ void ProcessIOHandler::open(enum UpnpOpenFileMode mode)
 
     if (fd == -1) {
         if (errno == ENXIO) {
-            throw TryAgainException(std::string("open failed: ") + strerror(errno));
+            throw TryAgainException(fmt::format("open failed: {}", std::strerror(errno)));
         }
 
         killAll();
         if (mainProc != nullptr)
             mainProc->kill();
         unlink(filename.c_str());
-        throw_std_runtime_error("open: failed to open: " + filename.string());
+        throw_std_runtime_error("open: failed to open: {}", filename.c_str());
     }
 }
 

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -52,8 +52,6 @@
 
 #include <sys/stat.h>
 
-#include <fmt/ostream.h>
-
 extern "C" {
 
 #include <libavformat/avformat.h>
@@ -366,7 +364,7 @@ std::unique_ptr<IOHandler> FfmpegHandler::serveContent(std::shared_ptr<CdsObject
 
     if (cache_enabled) {
         if (auto data = readThumbnailCacheFile(item->getLocation())) {
-            log_debug("Returning cached thumbnail for file: {}", item->getLocation());
+            log_debug("Returning cached thumbnail for file: {}", item->getLocation().c_str());
             return std::make_unique<MemIOHandler>(data->data(), data->size());
         }
     }
@@ -392,7 +390,7 @@ std::unique_ptr<IOHandler> FfmpegHandler::serveContent(std::shared_ptr<CdsObject
     th->thumbnail_image_quality = config->getIntOption(CFG_SERVER_EXTOPTS_FFMPEGTHUMBNAILER_IMAGE_QUALITY);
     th->thumbnail_image_type = Jpeg;
 
-    log_debug("Generating thumbnail for file: {}", item->getLocation());
+    log_debug("Generating thumbnail for file: {}", item->getLocation().c_str());
 
 #ifdef FFMPEGTHUMBNAILER_OLD_API
     if (generate_thumbnail_to_buffer(th.get(), item->getLocation().c_str(), img.get()) != 0)
@@ -400,7 +398,7 @@ std::unique_ptr<IOHandler> FfmpegHandler::serveContent(std::shared_ptr<CdsObject
     if (video_thumbnailer_generate_thumbnail_to_buffer(th.get(), item->getLocation().c_str(), img.get()) != 0)
 #endif // old api
     {
-        throw_std_runtime_error(fmt::format("Could not generate thumbnail for {}", item->getLocation()));
+        throw_std_runtime_error("Could not generate thumbnail for {}", item->getLocation().c_str());
     }
     if (cache_enabled) {
         writeThumbnailCacheFile(item->getLocation(),

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -413,7 +413,7 @@ std::unique_ptr<IOHandler> LibExifHandler::serveContent(std::shared_ptr<CdsObjec
 
     std::string ctype = getValueOrDefault(res->getParameters(), RESOURCE_CONTENT_TYPE);
     if (ctype != EXIF_THUMBNAIL)
-        throw_std_runtime_error("got unknown content type: " + ctype);
+        throw_std_runtime_error("Got unknown content type: {}", ctype);
 
     ExifData* ed = exif_data_new_from_file(item->getLocation().c_str());
     if (!ed)

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -66,7 +66,7 @@ public:
         file = ::fopen(path, "rb");
 #endif
         if (file == nullptr) {
-            throw_std_runtime_error(std::string("Could not fopen ") + path);
+            throw_std_runtime_error("Could not fopen {}", path);
         }
     }
 

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -151,7 +151,7 @@ std::unique_ptr<IOHandler> FanArtHandler::serveContent(std::shared_ptr<CdsObject
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        log_warning("File does not exist: {} ({})", path.c_str(), strerror(errno));
+        log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
     auto io_handler = std::make_unique<FileIOHandler>(path);
@@ -210,7 +210,7 @@ std::unique_ptr<IOHandler> ContainerArtHandler::serveContent(std::shared_ptr<Cds
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        log_warning("File does not exist: {} ({})", path.c_str(), strerror(errno));
+        log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
     auto io_handler = std::make_unique<FileIOHandler>(path);
@@ -263,7 +263,7 @@ std::unique_ptr<IOHandler> SubtitleHandler::serveContent(std::shared_ptr<CdsObje
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        log_warning("File does not exist: {} ({})", path.c_str(), strerror(errno));
+        log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
     auto io_handler = std::make_unique<FileIOHandler>(path);
@@ -314,7 +314,7 @@ std::unique_ptr<IOHandler> ResourceHandler::serveContent(std::shared_ptr<CdsObje
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        log_warning("File does not exist: {} ({})", path.c_str(), strerror(errno));
+        log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
     auto io_handler = std::make_unique<FileIOHandler>(path);

--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -70,7 +70,7 @@ void MetadataHandler::setMetadata(const std::shared_ptr<Context>& context, const
     std::string location = item->getLocation();
     std::error_code ec;
     if (!isRegularFile(location, ec))
-        throw_std_runtime_error("Not a file: " + location);
+        throw_std_runtime_error("Not a file: {}", location.c_str());
     auto filesize = getFileSize(location);
 
     std::string mimetype = item->getMimeType();
@@ -181,7 +181,7 @@ std::unique_ptr<MetadataHandler> MetadataHandler::createHandler(const std::share
     case CH_RESOURCE:
         return std::make_unique<ResourceHandler>(context);
     default:
-        throw_std_runtime_error("unknown content handler ID: " + fmt::to_string(handlerType));
+        throw_std_runtime_error("Unknown content handler ID: {}", handlerType);
     }
 }
 

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -292,7 +292,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsObject
         TagLib::MPEG::File f(&roStream, TagLib::ID3v2::FrameFactory::instance());
 
         if (!f.isValid())
-            throw_std_runtime_error("could not open file: " + item->getLocation().string());
+            throw_std_runtime_error("Could not open file: {}", item->getLocation().c_str());
 
         if (!f.ID3v2Tag())
             throw_std_runtime_error("resource has no album information");
@@ -310,7 +310,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsObject
         TagLib::FLAC::File f(&roStream, TagLib::ID3v2::FrameFactory::instance());
 
         if (!f.isValid())
-            throw_std_runtime_error("could not open flac file: " + item->getLocation().string());
+            throw_std_runtime_error("Could not open flac file: {}", item->getLocation().c_str());
 
         if (f.pictureList().isEmpty())
             throw_std_runtime_error("flac resource has no picture information");
@@ -325,7 +325,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsObject
         TagLib::MP4::File f(&roStream);
 
         if (!f.isValid()) {
-            throw_std_runtime_error("could not open mp4 file: " + item->getLocation().string());
+            throw_std_runtime_error("Could not open mp4 file: {}", item->getLocation().c_str());
         }
 
         if (!f.hasMP4Tag()) {
@@ -354,7 +354,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsObject
         TagLib::ASF::File f(&roStream);
 
         if (!f.isValid())
-            throw_std_runtime_error("could not open flac file: " + item->getLocation().string());
+            throw_std_runtime_error("Could not open flac file: {}", item->getLocation().c_str());
 
         const TagLib::ASF::AttributeListMap& attrListMap = f.tag()->attributeListMap();
         if (!attrListMap.contains("WM/Picture"))
@@ -377,7 +377,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsObject
         TagLib::Ogg::Vorbis::File f(&roStream);
 
         if (!f.isValid() || !f.tag())
-            throw_std_runtime_error("could not open vorbis file: " + item->getLocation().string());
+            throw_std_runtime_error("Could not open vorbis file: {}", item->getLocation().c_str());
 
         const TagLib::List<TagLib::FLAC::Picture*> picList = f.tag()->pictureList();
         if (picList.isEmpty())
@@ -390,7 +390,7 @@ std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsObject
         return h;
     }
 
-    throw_std_runtime_error("Unsupported content_type: " + content_type);
+    throw_std_runtime_error("Unsupported content_type: {}", content_type.c_str());
 }
 
 void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr<CdsItem>& item) const
@@ -646,16 +646,14 @@ void TagLibHandler::extractMP4(TagLib::IOStream* roStream, const std::shared_ptr
     TagLib::MP4::File mp4(roStream);
 
     if (!mp4.isValid()) {
-        log_info("TagLibHandler {}: could not open mp4 file",
-            item->getLocation().c_str());
+        log_info("TagLibHandler {}: could not open mp4 file", item->getLocation().c_str());
         return;
     }
 
     populateGenericTags(item, mp4);
 
     if (!mp4.hasMP4Tag()) {
-        log_info("TagLibHandler {}: mp4 file has no tag information",
-            item->getLocation().c_str());
+        log_info("TagLibHandler {}: mp4 file has no tag information", item->getLocation().c_str());
         return;
     }
 

--- a/src/request_handler.cc
+++ b/src/request_handler.cc
@@ -59,7 +59,7 @@ void RequestHandler::splitUrl(const char* url, char separator, std::string& path
     else if (separator == '?')
         i1 = url_s.rfind(separator);
     else
-        throw_std_runtime_error(std::string("Forbidden separator: ") + separator);
+        throw_std_runtime_error("Forbidden separator: {}", separator);
 
     if (i1 == std::string::npos) {
         path = url_s;

--- a/src/serve_request_handler.cc
+++ b/src/serve_request_handler.cc
@@ -61,7 +61,7 @@ void ServeRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     size_t len = (std::string("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_SERVE_HANDLER).length();
 
     if (len > url_path.length()) {
-        throw_std_runtime_error("There is something wrong with the link " + url_path);
+        throw_std_runtime_error("There is something wrong with the link {}", url_path.c_str());
     }
 
     url_path = urlUnescape(url_path);
@@ -73,7 +73,7 @@ void ServeRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 
     ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        throw_std_runtime_error("Failed to stat " + path);
+        throw_std_runtime_error("Failed to stat {}", path.c_str());
     }
 
     if (S_ISREG(statbuf.st_mode)) // we have a regular file
@@ -100,7 +100,7 @@ void ServeRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
         UpnpFileInfo_set_ContentType(info, ixmlCloneDOMString(mimetype.c_str()));
 #endif
     } else {
-        throw_std_runtime_error("Not a regular file: " + path);
+        throw_std_runtime_error("Not a regular file: {}", path.c_str());
     }
 }
 
@@ -121,7 +121,7 @@ std::unique_ptr<IOHandler> ServeRequestHandler::open(const char* filename, enum 
 
     size_t len = (std::string("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_SERVE_HANDLER).length();
     if (len > url_path.length()) {
-        throw_std_runtime_error("There is something wrong with the link " + url_path);
+        throw_std_runtime_error("There is something wrong with the link {}", url_path.c_str());
     }
 
     std::string path = config->getOption(CFG_SERVER_SERVEDIR)
@@ -130,11 +130,11 @@ std::unique_ptr<IOHandler> ServeRequestHandler::open(const char* filename, enum 
     log_debug("Constructed new path: {}", path.c_str());
     ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        throw_std_runtime_error("Failed to stat " + path);
+        throw_std_runtime_error("Failed to stat {}", path.c_str());
     }
 
     if (!S_ISREG(statbuf.st_mode)) {
-        throw_std_runtime_error("Not a regular file: " + path);
+        throw_std_runtime_error("Not a regular file: {}", path.c_str());
     }
 
     auto io_handler = std::make_unique<FileIOHandler>(path);

--- a/src/server.cc
+++ b/src/server.cc
@@ -99,7 +99,7 @@ void Server::run()
         iface = ipToInterface(ip);
 
     if (!ip.empty() && iface.empty())
-        throw_std_runtime_error("Could not find ip: " + ip);
+        throw_std_runtime_error("Could not find ip: {}", ip.c_str());
 
     auto port = in_port_t(config->getIntOption(CFG_SERVER_PORT));
 
@@ -123,7 +123,7 @@ void Server::run()
 
     log_info("Server bound to: {}", ip.c_str());
 
-    virtualUrl = "http://" + ip + ":" + fmt::to_string(port) + "/" + virtual_directory;
+    virtualUrl = fmt::format("http://{}:{}/{}", ip, port, virtual_directory);
 
     // next set webroot directory
     std::string web_root = config->getOption(CFG_SERVER_WEBROOT);
@@ -153,13 +153,13 @@ void Server::run()
 
     std::string presentationURL = config->getOption(CFG_SERVER_PRESENTATION_URL);
     if (presentationURL.empty()) {
-        presentationURL = "http://" + ip + ":" + fmt::to_string(port) + "/";
+        presentationURL = fmt::format("http://{}:{}/", ip, port);
     } else {
         std::string appendto = config->getOption(CFG_SERVER_APPEND_PRESENTATION_URL_TO);
         if (appendto == "ip") {
-            presentationURL = "http://" + ip + ":" + presentationURL;
+            presentationURL = fmt::format("http://{}:{}", ip, presentationURL);
         } else if (appendto == "port") {
-            presentationURL = "http://" + ip + ":" + fmt::to_string(port) + "/" + presentationURL;
+            presentationURL = fmt::format("http://{}:{}/{}", ip, port, presentationURL);
         } // else appendto is none and we take the URL as it entered by user
     }
 
@@ -493,7 +493,7 @@ std::unique_ptr<RequestHandler> Server::createRequestHandler(const char* filenam
     }
 #endif
     else {
-        throw_std_runtime_error(std::string("no valid handler type in ") + filename);
+        throw_std_runtime_error("No valid handler type in {}", filename);
     }
 
     return ret;

--- a/src/transcoding/transcode_dispatcher.cc
+++ b/src/transcoding/transcode_dispatcher.cc
@@ -48,12 +48,12 @@ std::unique_ptr<IOHandler> TranscodeDispatcher::serveContent(std::shared_ptr<Tra
     const std::string& range)
 {
     if (profile == nullptr)
-        throw_std_runtime_error("Transcoding of file " + location + "requested but no profile given ");
+        throw_std_runtime_error("Transcoding of file {} requested but no profile given ", location.c_str());
 
     if (profile->getType() == TR_External) {
         auto tr_ext = std::make_unique<TranscodeExternalHandler>(content);
         return tr_ext->serveContent(profile, location, obj, range);
     }
 
-    throw_std_runtime_error("Unknown transcoding type for profile " + profile->getName());
+    throw_std_runtime_error("Unknown transcoding type for profile {}", profile->getName().c_str());
 }

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -49,7 +49,7 @@ UpnpXMLBuilder::UpnpXMLBuilder(const std::shared_ptr<Context>& context,
 std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createResponse(const std::string& actionName, const std::string& serviceType)
 {
     auto response = std::make_unique<pugi::xml_document>();
-    auto root = response->append_child(("u:" + actionName + "Response").c_str());
+    auto root = response->append_child(fmt::format("u:{}Response", actionName.c_str()).c_str());
     root.append_attribute("xmlns:u") = serviceType.c_str();
 
     return response;
@@ -359,9 +359,9 @@ std::string UpnpXMLBuilder::getFirstResourcePath(const std::shared_ptr<CdsItem>&
     if (item->isExternalItem() && !urlBase->addResID) { // a remote resource
         result = urlBase->pathBase;
     } else if (urlBase->addResID) { // a proxy, remote, resource
-        result = SERVER_VIRTUAL_DIR + urlBase->pathBase + fmt::to_string(0);
+        result = fmt::format(SERVER_VIRTUAL_DIR "{}0", urlBase->pathBase.c_str());
     } else { // a local resource
-        result = SERVER_VIRTUAL_DIR + urlBase->pathBase;
+        result = fmt::format(SERVER_VIRTUAL_DIR "{}", urlBase->pathBase.c_str());
     }
     return result;
 }
@@ -373,7 +373,7 @@ std::string UpnpXMLBuilder::getArtworkUrl(const std::shared_ptr<CdsItem>& item) 
 
     auto urlBase = getPathBase(item);
     if (urlBase->addResID) {
-        return virtualURL + urlBase->pathBase + fmt::to_string(1) + "/rct/aa";
+        return fmt::format("{}{}1/rct/aa", virtualURL, urlBase->pathBase);
     }
     return virtualURL + urlBase->pathBase;
 }
@@ -426,7 +426,7 @@ bool UpnpXMLBuilder::renderItemImage(const std::string& virtualURL, const std::s
             auto res_attrs = res->getAttributes();
             auto res_params = res->getParameters();
             if (urlBase->addResID) {
-                url = virtualURL + urlBase->pathBase + fmt::to_string(realCount) + _URL_PARAM_SEPARATOR;
+                url = fmt::format("{}{}{}{}", virtualURL.c_str(), urlBase->pathBase.c_str(), realCount, _URL_PARAM_SEPARATOR);
             } else
                 url = virtualURL + urlBase->pathBase;
 
@@ -451,7 +451,7 @@ bool UpnpXMLBuilder::renderSubtitle(const std::string& virtualURL, const std::sh
             auto res_attrs = res->getAttributes();
             auto res_params = res->getParameters();
             if (urlBase->addResID) {
-                url = virtualURL + urlBase->pathBase + fmt::to_string(realCount) + _URL_PARAM_SEPARATOR;
+                url = fmt::format("{}{}{}{}", virtualURL.c_str(), urlBase->pathBase, realCount, _URL_PARAM_SEPARATOR);
             } else
                 url = virtualURL + urlBase->pathBase;
 
@@ -579,11 +579,11 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
                     std::string frequency = item->getResource(0)->getAttribute(R_SAMPLEFREQUENCY);
                     if (!frequency.empty()) {
                         t_res->addAttribute(R_SAMPLEFREQUENCY, frequency);
-                        targetMimeType.append(";rate=").append(frequency);
+                        targetMimeType.append(fmt::format(";rate={}", frequency));
                     }
                 } else if (freq != OFF) {
                     t_res->addAttribute(R_SAMPLEFREQUENCY, fmt::to_string(freq));
-                    targetMimeType.append(";rate=").append(fmt::to_string(freq));
+                    targetMimeType.append(fmt::format(";rate={}", freq));
                 }
 
                 int chan = tp->getNumChannels();
@@ -591,11 +591,11 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
                     std::string nchannels = item->getResource(0)->getAttribute(R_NRAUDIOCHANNELS);
                     if (!nchannels.empty()) {
                         t_res->addAttribute(R_NRAUDIOCHANNELS, nchannels);
-                        targetMimeType.append(";channels=").append(nchannels);
+                        targetMimeType.append(fmt::format(";channels={}", nchannels));
                     }
                 } else if (chan != OFF) {
                     t_res->addAttribute(R_NRAUDIOCHANNELS, fmt::to_string(chan));
-                    targetMimeType.append(";channels=").append(fmt::to_string(chan));
+                    targetMimeType.append(fmt::format(";channels={}", chan));
                 }
             }
 
@@ -659,7 +659,7 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
         bool transcoded = (getValueOrDefault(res_params, URL_PARAM_TRANSCODE) == URL_VALUE_TRANSCODE);
         if (!transcoded) {
             if (urlBase->addResID) {
-                url = urlBase->pathBase + fmt::to_string(realCount);
+                url = fmt::format("{}{}", urlBase->pathBase, realCount);
             } else
                 url = urlBase->pathBase;
 
@@ -718,10 +718,7 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
             // content type here and that we will not limit ourselves to the
             // first resource
             if (!skipURL) {
-                if (transcoded)
-                    url.append(renderExtension(contentType, ""));
-                else
-                    url.append(renderExtension(contentType, item->getLocation()));
+                url.append(renderExtension(contentType, transcoded ? "" : item->getLocation()));
             }
         }
 
@@ -750,13 +747,12 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
         // we do not support seeking at all, so 00
         // and the media is converted, so set CI to 1
         if (!isExtThumbnail && transcoded) {
-            extend.append(fmt::format("{}={};", UPNP_DLNA_OP, UPNP_DLNA_OP_SEEK_DISABLED)).append(fmt::format("{}={}", UPNP_DLNA_CONVERSION_INDICATOR, UPNP_DLNA_CONVERSION));
+            extend.append(fmt::format("{}={};{}={}", UPNP_DLNA_OP, UPNP_DLNA_OP_SEEK_DISABLED, UPNP_DLNA_CONVERSION_INDICATOR, UPNP_DLNA_CONVERSION));
 
             if (startswith(mimeType, "audio") || startswith(mimeType, "video"))
                 extend.append(";" UPNP_DLNA_FLAGS "=" UPNP_DLNA_ORG_FLAGS_AV);
         } else {
-            extend.append(fmt::format("{}={};", UPNP_DLNA_OP, UPNP_DLNA_OP_SEEK_RANGE));
-            extend.append(UPNP_DLNA_CONVERSION_INDICATOR).append("=").append(UPNP_DLNA_NO_CONVERSION);
+            extend.append(fmt::format("{}={};{}={}", UPNP_DLNA_OP, UPNP_DLNA_OP_SEEK_RANGE, UPNP_DLNA_CONVERSION_INDICATOR, UPNP_DLNA_NO_CONVERSION));
         }
 
         protocolInfo = protocolInfo.substr(0, protocolInfo.rfind(':') + 1).append(extend);

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -71,8 +71,7 @@ void URLRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
         auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
                       ->getByName(tr_profile);
         if (tp == nullptr)
-            throw_std_runtime_error("Transcoding requested but no profile matching the name "
-                + tr_profile + " found");
+            throw_std_runtime_error("Transcoding requested but no profile matching the name {} found", tr_profile.c_str());
 
         mimeType = tp->getTargetMimeType();
         UpnpFileInfo_set_FileLength(info, -1);
@@ -160,7 +159,7 @@ std::unique_ptr<IOHandler> URLRequestHandler::open(const char* filename, enum Up
         auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
                       ->getByName(tr_profile);
         if (tp == nullptr)
-            throw_std_runtime_error("Transcoding of file " + url + " but no profile matching the name " + tr_profile + " found");
+            throw_std_runtime_error("Transcoding of file {} but no profile matching the name {} found", url.c_str(), tr_profile.c_str());
 
         auto tr_d = std::make_unique<TranscodeDispatcher>(content);
         auto io_handler = tr_d->serveContent(tp, url, item, "");

--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -175,5 +175,5 @@ std::string get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh)
     }
     ioh->close();
 
-    return fmt::to_string(w) + "x" + fmt::to_string(h);
+    return fmt::format("{}x{}", w, h);
 }

--- a/src/util/mime.cc
+++ b/src/util/mime.cc
@@ -45,10 +45,10 @@ Mime::Mime(const std::shared_ptr<Config>& config)
     std::string optMagicFile = config->getOption(CFG_IMPORT_MAGIC_FILE);
     const char* magicFile = !optMagicFile.empty() ? optMagicFile.c_str() : nullptr;
     if (magic_load(magicCookie, magicFile) == -1) {
-        std::string errMsg = std::string(magic_error(magicCookie));
+        auto errMsg = magic_error(magicCookie);
         magic_close(magicCookie);
         magicCookie = nullptr;
-        throw_std_runtime_error("magic_load failed: " + errMsg);
+        throw_std_runtime_error("magic_load failed: {}", errMsg);
     }
 #endif // HAVE_MAGIC
 }

--- a/src/util/mt_inotify.cc
+++ b/src/util/mt_inotify.cc
@@ -103,10 +103,10 @@ int Inotify::addWatch(const fs::path& path, int events) const
         if (errno == ENOSPC)
             throw_std_runtime_error("The user limit on the total number of inotify watches was reached or the kernel failed to allocate a needed resource.");
         if (errno == EACCES) {
-            log_warning("Cannot add inotify watch for {}: {}", path.c_str(), strerror(errno));
+            log_warning("Cannot add inotify watch for {}: {}", path.c_str(), std::strerror(errno));
             return -1;
         }
-        throw_std_runtime_error(strerror(errno));
+        throw_std_runtime_error(std::strerror(errno));
     }
     return wd;
 }
@@ -114,7 +114,7 @@ int Inotify::addWatch(const fs::path& path, int events) const
 void Inotify::removeWatch(int wd) const
 {
     if (inotify_rm_watch(inotify_fd, wd) < 0) {
-        log_debug("Error removing watch: {}", strerror(errno));
+        log_debug("Error removing watch: {}", std::strerror(errno));
     }
 }
 
@@ -188,7 +188,7 @@ struct inotify_event* Inotify::nextEvent()
     if (FD_ISSET(stop_fd_read, &read_fds)) {
         char buf;
         if (read(stop_fd_read, &buf, 1) == -1) {
-            log_error("Inotify: could not read stop: {}", strerror(errno));
+            log_error("Inotify: could not read stop: {}", std::strerror(errno));
         }
     }
 
@@ -233,7 +233,7 @@ void Inotify::stop() const
 {
     char stop = 's';
     if (write(stop_fd_write, &stop, 1) == -1) {
-        log_error("inotify: could not send stop: {}", strerror(errno));
+        log_error("inotify: could not send stop: {}", std::strerror(errno));
     }
 }
 

--- a/src/util/process.cc
+++ b/src/util/process.cc
@@ -63,17 +63,15 @@ std::string run_simple_process(const std::shared_ptr<Config>& cfg, const std::st
     fd = open(input_file.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 #endif
     if (fd == -1) {
-        log_debug("Failed to open input file {}: {}", input_file.c_str(),
-            strerror(errno));
-        throw_std_runtime_error("Failed to open input file " + input_file + " " + strerror(errno));
+        log_debug("Failed to open input file {}: {}", input_file.c_str(), std::strerror(errno));
+        throw_std_runtime_error("Failed to open input file {}: {}", input_file.c_str(), std::strerror(errno));
     }
     size_t ret = write(fd, input.c_str(), input.length());
     close(fd);
     if (ret < input.length()) {
 
-        log_debug("Failed to write to {}: {}", input.c_str(),
-            strerror(errno));
-        throw_std_runtime_error("Failed to write to " + input + ": " + strerror(errno));
+        log_debug("Failed to write to {}: {}", input.c_str(), std::strerror(errno));
+        throw_std_runtime_error("Failed to write to {}: {}", input.c_str(), std::strerror(errno));
     }
 
     /* touching output file */
@@ -84,9 +82,8 @@ std::string run_simple_process(const std::shared_ptr<Config>& cfg, const std::st
     fd = open(output_file.c_str(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 #endif
     if (fd == -1) {
-        log_debug("Failed to open output file {}: {}", output_file.c_str(),
-            strerror(errno));
-        throw_std_runtime_error("Failed to open output file " + input_file + " " + strerror(errno));
+        log_debug("Failed to open output file {}: {}", output_file.c_str(), std::strerror(errno));
+        throw_std_runtime_error("Failed to open output file {}: {}", output_file.c_str(), std::strerror(errno));
     }
     close(fd);
 
@@ -96,7 +93,7 @@ std::string run_simple_process(const std::shared_ptr<Config>& cfg, const std::st
     int sysret = system(command.c_str());
     if (sysret == -1) {
         log_debug("Failed to execute: {}", command.c_str());
-        throw_std_runtime_error("Failed to execute: " + command);
+        throw_std_runtime_error("Failed to execute: {}", command.c_str());
     }
 
     /* reading output file */
@@ -106,9 +103,8 @@ std::string run_simple_process(const std::shared_ptr<Config>& cfg, const std::st
     file = ::fopen(output_file.c_str(), "r");
 #endif
     if (!file) {
-        log_debug("Could not open output file {}: {}", output_file.c_str(),
-            strerror(errno));
-        throw_std_runtime_error("Failed to open output file " + output_file + " " + strerror(errno));
+        log_debug("Could not open output file {}: {}", output_file.c_str(), std::strerror(errno));
+        throw_std_runtime_error("Failed to open output file {}: {}", output_file.c_str(), std::strerror(errno));
     }
     std::ostringstream output;
 

--- a/src/util/process_executor.cc
+++ b/src/util/process_executor.cc
@@ -59,7 +59,7 @@ ProcessExecutor::ProcessExecutor(const std::string& command, const std::vector<s
 
     switch (process_id) {
     case -1:
-        throw_std_runtime_error("Failed to launch process " + command);
+        throw_std_runtime_error("Failed to launch process {}", command.c_str());
 
     case 0:
         sigset_t mask_set;

--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -42,7 +42,7 @@ StringConverter::StringConverter(const std::string& from, const std::string& to)
 
     if (!cd) {
         cd = {};
-        throw_std_runtime_error(std::string("iconv: ") + strerror(errno));
+        throw_std_runtime_error("iconv: {}", std::strerror(errno));
     }
 }
 
@@ -129,7 +129,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
 #endif
 
     if (ret == -1) {
-        log_error("iconv: {}", strerror(errno));
+        log_error("iconv: {}", std::strerror(errno));
         std::string err;
         switch (errno) {
         case EILSEQ:
@@ -155,7 +155,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
             err = "iconv: Insufficient space in output buffer";
             break;
         default:
-            err = std::string("iconv: ") + strerror(errno);
+            err = fmt::format("iconv: {}", std::strerror(errno));
             break;
         }
         *output_copy = 0;

--- a/src/util/timer.cc
+++ b/src/util/timer.cc
@@ -48,7 +48,7 @@ void Timer::run()
         this);
 
     if (ret)
-        throw_std_runtime_error("failed to start timer thread: " + fmt::to_string(ret));
+        throw_std_runtime_error("failed to start timer thread: {}", ret);
 }
 
 void* Timer::staticThreadProc(void* arg)
@@ -69,7 +69,7 @@ void Timer::addTimerSubscriber(Subscriber* timerSubscriber, unsigned int notifyI
 {
     log_debug("Adding subscriber... interval: {} once: {} ", notifyInterval, once);
     if (notifyInterval == 0)
-        throw_std_runtime_error(fmt::format("Tried to add timer with illegal notifyInterval: {}", notifyInterval));
+        throw_std_runtime_error("Tried to add timer with illegal notifyInterval: {}", notifyInterval);
 
     AutoLock lock(mutex);
     TimerSubscriberElement element(timerSubscriber, notifyInterval, std::move(parameter), once);

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -62,8 +62,6 @@
 #include <sys/sockio.h>
 #endif
 
-#include <fmt/ostream.h>
-
 #include "cds_objects.h"
 #include "config/config_manager.h"
 #include "contrib/md5.h"
@@ -175,7 +173,7 @@ time_t getLastWriteTime(const fs::path& path)
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        throw_std_runtime_error(fmt::format("{}: {}", strerror(errno), path.string()));
+        throw_std_runtime_error("{}: {}", std::strerror(errno), path.c_str());
     }
 
     return statbuf.st_mtime;
@@ -188,7 +186,7 @@ bool isRegularFile(const fs::path& path)
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        throw_std_runtime_error(fmt::format("{}: {}", strerror(errno), path.string()));
+        throw_std_runtime_error("{}: {}", std::strerror(errno), path.c_str());
     }
 
     return S_ISREG(statbuf.st_mode);
@@ -222,7 +220,7 @@ off_t getFileSize(const fs::path& path)
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        throw_std_runtime_error(fmt::format("{}: {}", strerror(errno), path.string()));
+        throw_std_runtime_error("{}: {}", std::strerror(errno), path);
     }
 
     return statbuf.st_size;
@@ -508,7 +506,7 @@ std::string readTextFile(const fs::path& path)
     auto f = ::fopen(path.c_str(), "rt");
 #endif
     if (!f) {
-        throw_std_runtime_error("could not open " + path.string() + " : " + strerror(errno));
+        throw_std_runtime_error("Could not open {}: {}", path.c_str(), std::strerror(errno));
     }
     std::ostringstream buf;
     std::array<char, 1024> buffer;
@@ -528,14 +526,14 @@ void writeTextFile(const fs::path& path, const std::string& contents)
     auto f = ::fopen(path.c_str(), "wt");
 #endif
     if (!f) {
-        throw_std_runtime_error("could not open " + path.string() + " : " + strerror(errno));
+        throw_std_runtime_error("Could not open {}: {}", path.c_str(), std::strerror(errno));
     }
 
     size_t bytesWritten = std::fwrite(contents.c_str(), 1, contents.length(), f);
     if (bytesWritten < contents.length()) {
         fclose(f);
 
-        throw_std_runtime_error("error writing to " + path.string() + " : " + strerror(errno));
+        throw_std_runtime_error("Error writing to {}: {}", path.c_str(), std::strerror(errno));
     }
     fclose(f);
 }
@@ -556,14 +554,14 @@ std::optional<std::vector<std::byte>> readBinaryFile(const fs::path& path)
     // and no line conversion happens (therefore lseek returns result close to file size).
     auto size = fb.pubseekoff(0, std::ios::end);
     if (size < 0)
-        throw_std_runtime_error(fmt::format("Can't determine file size of {}", path));
+        throw_std_runtime_error("Can't determine file size of {}", path.c_str());
 
     fb.pubseekoff(0, std::ios::beg);
 
     std::vector<std::byte> result(size);
     size = fb.sgetn(reinterpret_cast<char*>(result.data()), size);
     if (size < 0 || !file)
-        throw_std_runtime_error(fmt::format("Failed to read from file {}", path));
+        throw_std_runtime_error("Failed to read from file {}", path.c_str());
 
     result.resize(size);
 
@@ -576,12 +574,12 @@ void writeBinaryFile(const fs::path& path, const std::byte* data, std::size_t si
 
     std::ofstream file { path, std::ios::out | std::ios::binary | std::ios::trunc };
     if (!file)
-        throw_std_runtime_error(fmt::format("Failed to open {}", path));
+        throw_std_runtime_error("Failed to open {}", path.c_str());
 
     file.rdbuf()->sputn(reinterpret_cast<const char*>(data), size);
 
     if (!file)
-        throw_std_runtime_error(fmt::format("Failed to write to file {}", path));
+        throw_std_runtime_error("Failed to write to file {}", path.c_str());
 }
 
 std::string renderProtocolInfo(const std::string& mimetype, const std::string& protocol, const std::string& extend)
@@ -765,7 +763,7 @@ std::string toCSV(const std::shared_ptr<std::unordered_set<int>>& array)
 void getTimespecNow(struct timespec* ts)
 {
     if (timespec_get(ts, TIME_UTC) == 0)
-        throw_std_runtime_error(fmt::format("timespec_get failed: {}", strerror(errno)));
+        throw_std_runtime_error("timespec_get failed: {}", std::strerror(errno));
 }
 
 long getDeltaMillis(struct timespec* first)
@@ -811,7 +809,7 @@ std::string ipToInterface(const std::string& ip)
     char host[NI_MAXHOST];
 
     if (getifaddrs(&ifaddr) == -1) {
-        log_error("Could not getifaddrs: {}", strerror(errno));
+        log_error("Could not getifaddrs: {}", std::strerror(errno));
     }
 
     for (ifa = ifaddr, n = 0; ifa != nullptr; ifa = ifa->ifa_next, n++) {
@@ -973,12 +971,12 @@ bool isTheora(const fs::path& ogg_filename)
     auto f = ::fopen(ogg_filename.c_str(), "rb");
 #endif
     if (!f) {
-        throw_std_runtime_error("Error opening " + ogg_filename.string() + " : " + strerror(errno));
+        throw_std_runtime_error("Error opening {}: {}", ogg_filename.c_str(), std::strerror(errno));
     }
 
     if (std::fread(buffer, 1, 4, f) != 4) {
         fclose(f);
-        throw_std_runtime_error("Error reading " + ogg_filename.string());
+        throw_std_runtime_error("Error reading {}", ogg_filename.c_str());
     }
 
     if (memcmp(buffer, "OggS", 4) != 0) {
@@ -988,12 +986,12 @@ bool isTheora(const fs::path& ogg_filename)
 
     if (fseek(f, 28, SEEK_SET) != 0) {
         fclose(f);
-        throw_std_runtime_error("Incomplete file " + ogg_filename.string());
+        throw_std_runtime_error("Incomplete file {}", ogg_filename.c_str());
     }
 
     if (std::fread(buffer, 1, 7, f) != 7) {
         fclose(f);
-        throw_std_runtime_error("Error reading " + ogg_filename.string());
+        throw_std_runtime_error("Error reading {}", ogg_filename.c_str());
     }
 
     if (memcmp(buffer, "\x80theora", 7) != 0) {
@@ -1107,7 +1105,7 @@ std::string getAVIFourCC(const fs::path& avi_filename)
     auto f = ::fopen(avi_filename.c_str(), "rb");
 #endif
     if (!f)
-        throw_std_runtime_error("could not open file " + avi_filename.native() + " : " + strerror(errno));
+        throw_std_runtime_error("Could not open file {}: {}", avi_filename.c_str(), std::strerror(errno));
 
     buffer = new char[FCC_OFFSET + 6];
 
@@ -1115,7 +1113,7 @@ std::string getAVIFourCC(const fs::path& avi_filename)
     fclose(f);
     if (rb != FCC_OFFSET + 4) {
         delete[] buffer;
-        throw_std_runtime_error("could not read header of " + avi_filename.native() + " : " + strerror(errno));
+        throw_std_runtime_error("Could not read header of {}: {}", avi_filename.c_str(), std::strerror(errno));
     }
 
     buffer[FCC_OFFSET + 5] = '\0';
@@ -1144,7 +1142,7 @@ std::string getHostName(const struct sockaddr* addr)
     int len = addr->sa_family == AF_INET6 ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
     int ret = getnameinfo(addr, len, hoststr, sizeof(hoststr), portstr, sizeof(portstr), NI_NOFQDN);
     if (ret != 0) {
-        log_debug("could not determine getnameinfo: {}", strerror(errno));
+        log_debug("could not determine getnameinfo: {}", std::strerror(errno));
     }
 
     return hoststr;
@@ -1163,7 +1161,7 @@ int sockAddrCmpAddr(const struct sockaddr* sa, const struct sockaddr* sb)
         return memcmp(reinterpret_cast<const char*>(&(SOCK_ADDR_IN6_ADDR(sa))), reinterpret_cast<const char*>(&(SOCK_ADDR_IN6_ADDR(sb))), sizeof(SOCK_ADDR_IN6_ADDR(sa)));
     }
 
-    throw_std_runtime_error("unsupported address family :" + fmt::to_string(sa->sa_family));
+    throw_std_runtime_error("Unsupported address family: {}", sa->sa_family);
 }
 
 std::string sockAddrGetNameInfo(const struct sockaddr* sa)
@@ -1173,7 +1171,7 @@ std::string sockAddrGetNameInfo(const struct sockaddr* sa)
     int len = sa->sa_family == AF_INET6 ? sizeof(struct sockaddr_in6) : sizeof(struct sockaddr_in);
     int ret = getnameinfo(sa, len, hoststr, sizeof(hoststr), portstr, sizeof(portstr), NI_NUMERICHOST | NI_NUMERICSERV);
     if (ret != 0) {
-        throw_std_runtime_error(fmt::format("could not determine getnameinfo: {}", strerror(errno)));
+        throw_std_runtime_error("could not determine getnameinfo: {}", std::strerror(errno));
     }
 
     return std::string(hoststr) + ":" + std::string(portstr);
@@ -1199,7 +1197,7 @@ int find_local_port(in_port_t range_min, in_port_t range_max)
 
         fd = socket(AF_INET, SOCK_STREAM, 0);
         if (fd < 0) {
-            log_error("could not determine free port: error creating socket: {}", strerror(errno));
+            log_error("could not determine free port: error creating socket: {}", std::strerror(errno));
             return -1;
         }
 

--- a/src/util/url.cc
+++ b/src/util/url.cc
@@ -134,7 +134,7 @@ std::unique_ptr<URL::Stat> URL::getInfo(const std::string& URL, CURL* curl_handl
     if (retcode != 200) {
         if (cleanup)
             curl_easy_cleanup(curl_handle);
-        throw_std_runtime_error("Error retrieving information from " + URL + " HTTP return code: " + fmt::to_string(retcode));
+        throw_std_runtime_error("Error retrieving information from {} - HTTP return code: {}", URL.c_str(), retcode);
     }
 
     res = curl_easy_getinfo(curl_handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);

--- a/src/web/add_object.cc
+++ b/src/web/add_object.cc
@@ -143,7 +143,7 @@ void web::addObject::process()
             throw_std_runtime_error("No URL given");
         obj = this->addUrl(parentID, std::make_shared<CdsItemExternalURL>(), true);
     } else {
-        throw_std_runtime_error("unknown object type: " + obj_type);
+        throw_std_runtime_error("Unknown object type: {}", obj_type.c_str());
     }
 
     if (obj != nullptr) {

--- a/src/web/auth.cc
+++ b/src/web/auth.cc
@@ -48,7 +48,7 @@ static std::string generate_token()
 {
     const time_t expiration = get_time() + LOGIN_TIMEOUT;
     std::string salt = generateRandomId();
-    return fmt::to_string(expiration) + '_' + salt;
+    return fmt::format("{}_{}", expiration, salt);
 }
 
 static bool check_token(const std::string& token, const std::string& password, const std::string& encPassword)

--- a/src/web/config_save.cc
+++ b/src/web/config_save.cc
@@ -168,7 +168,7 @@ void web::configSave::process()
             auto autoScans = content->getAutoscanDirectories();
             for (const auto& autoscan : autoScans) {
                 content->rescanDirectory(autoscan, autoscan->getObjectID());
-                log_info("Rescanning directory {}", autoscan->getLocation().string().c_str());
+                log_info("Rescanning directory {}", autoscan->getLocation().c_str());
             }
         }
     }

--- a/src/web/pages.cc
+++ b/src/web/pages.cc
@@ -72,7 +72,7 @@ std::unique_ptr<WebRequestHandler> createWebRequestHandler(
     if (page == "config_save")
         return std::make_unique<web::configSave>(content);
 
-    throw_std_runtime_error("Unknown page: " + page);
+    throw_std_runtime_error("Unknown page: {}", page.c_str());
 }
 
 } // namespace web

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -150,7 +150,7 @@ std::shared_ptr<Session> SessionManager::createSession(long timeout)
     do {
         sessionID = generateRandomId();
         if (count++ > 100)
-            throw_std_runtime_error("There seems to be something wrong with the random numbers. I tried to get a unique id 100 times and failed. last sessionID: " + sessionID);
+            throw_std_runtime_error("There seems to be something wrong with the random numbers. I tried to get a unique id 100 times and failed. last sessionID: {}", sessionID);
     } while (getSession(sessionID, false) != nullptr); // for the rare case, where we get a random id, that is already taken
 
     newSession->setID(sessionID);

--- a/test/config/test_configmanager.cc
+++ b/test/config/test_configmanager.cc
@@ -67,7 +67,7 @@ public:
     void create_directory(fs::path dir)
     {
         if (mkdir(dir.c_str(), 0777) < 0) {
-            throw_std_runtime_error(fmt::format("Failed to create test_config temporary directory for testing: {}", dir.c_str()));
+            throw_std_runtime_error("Failed to create test_config temporary directory for testing: {}", dir.c_str());
         };
     }
 

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -39,7 +39,7 @@ public:
 
     std::string findFolderImage(int id, std::string trackArtBase) override
     {
-        auto it = findFolderImageMap.find(fmt::to_string(id) + trackArtBase);
+        auto it = findFolderImageMap.find(fmt::format("{}{}", id, trackArtBase));
         if (it != findFolderImageMap.end())
             return it->second;
         return "";


### PR DESCRIPTION
using std::string's append is inefficient and costs performance. format
is also cleaner.

Signed-off-by: Rosen Penev <rosenp@gmail.com>