### PR TITLE
Get rid of compiler warning on default constructor.

### DIFF
--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -192,7 +192,7 @@ bool Clients::getInfoByAddr(const struct sockaddr_storage* addr, const ClientInf
 
         if (c.match.find('.') != std::string::npos) {
             // IPv4
-            struct sockaddr_in clientAddr;
+            struct sockaddr_in clientAddr = {};
             clientAddr.sin_family = AF_INET;
             clientAddr.sin_addr.s_addr = inet_addr(c.match.c_str());
             if (sockAddrCmpAddr(reinterpret_cast<const struct sockaddr*>(&clientAddr), reinterpret_cast<const struct sockaddr*>(addr)) == 0) {
@@ -200,7 +200,7 @@ bool Clients::getInfoByAddr(const struct sockaddr_storage* addr, const ClientInf
             }
         } else if (c.match.find(':') != std::string::npos) {
             // IPv6
-            struct sockaddr_in6 clientAddr;
+            struct sockaddr_in6 clientAddr = {};
             clientAddr.sin6_family = AF_INET6;
             if (inet_pton(AF_INET6, c.match.c_str(), &clientAddr.sin6_addr) == 1) {
                 if (sockAddrCmpAddr(reinterpret_cast<const struct sockaddr*>(&clientAddr), reinterpret_cast<const struct sockaddr*>(addr)) == 0) {


### PR DESCRIPTION
Also avoids uninitialized struct memory.