### PR TITLE
Fixed isMetaResource for VIDEO_SUB

### DIFF
--- a/src/cds_resource.h
+++ b/src/cds_resource.h
@@ -110,7 +110,7 @@ public:
     std::string getOption(const std::string& name) const;
     bool isMetaResource(const char* rct) const
     {
-        return ((handlerType == CH_ID3 || handlerType == CH_MP4 || handlerType == CH_FLAC || handlerType == CH_FANART || handlerType == CH_CONTAINERART) && getParameter(RESOURCE_CONTENT_TYPE) == rct) || (handlerType == CH_EXTURL && getOption(RESOURCE_CONTENT_TYPE) == rct);
+        return ((handlerType == CH_ID3 || handlerType == CH_MP4 || handlerType == CH_FLAC || handlerType == CH_FANART || handlerType == CH_CONTAINERART || handlerType == CH_SUBTITLE) && getParameter(RESOURCE_CONTENT_TYPE) == rct) || (handlerType == CH_EXTURL && getOption(RESOURCE_CONTENT_TYPE) == rct);
     }
 
     bool equals(const std::shared_ptr<CdsResource>& other) const;


### PR DESCRIPTION
Hi, I'm new here :-)

I noticed that external subtitles weren't working. After some digging and debugging I discovered that `isMetaResource(VIDEO_SUB)` [would yield false](https://github.com/gerbera/gerbera/blob/cc49b2b2323155a47b19726544ab6db4e766c7b9/src/upnp_xml.cc#L710). This PR adds the handler type for external subtitle resources to the disjunction within `isMetaResource`