### PR TITLE
src/util/mime.cc: fix build without magic

### DIFF
--- a/src/util/mime.cc
+++ b/src/util/mime.cc
@@ -55,10 +55,12 @@ Mime::Mime(const std::shared_ptr<Config>& config)
 
 Mime::~Mime()
 {
+#ifdef HAVE_MAGIC
     if (magicCookie) {
         magic_close(magicCookie);
         magicCookie = nullptr;
     }
+#endif
 }
 
 #ifdef HAVE_MAGIC


### PR DESCRIPTION
Fix the following build failure:

```
/home/fabrice/buildroot/output/build/gerbera-f10c11e8fd6ac9baf6b3d72995e9c6123b7210f1/src/util/mime.cc: In destructor 'virtual Mime::~Mime()':
/home/fabrice/buildroot/output/build/gerbera-f10c11e8fd6ac9baf6b3d72995e9c6123b7210f1/src/util/mime.cc:58:9: error: 'magicCookie' was not declared in this scope
   58 |     if (magicCookie) {
      |         ^~~~~~~~~~~
/home/fabrice/buildroot/output/build/gerbera-f10c11e8fd6ac9baf6b3d72995e9c6123b7210f1/src/util/mime.cc:59:9: error: 'magic_close' was not declared in this scope
   59 |         magic_close(magicCookie);
      |         ^~~~~~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>