### PR TITLE
include <optional> header

### DIFF
--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -34,6 +34,7 @@
 #include <filesystem>
 #include <map>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <unordered_set>


### PR DESCRIPTION
Fixes build with gcc11
/src/util/tools.h:165:6: error: 'optional' in na
mespace 'std' does not name a template type
|   165 | std::optional<std::vector<std::byte>> readBinaryFile(const fs::path& path);
|       |      ^~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>