### PR TITLE
Ensure sqlite is in correct mode for recovery and initialization

### DIFF
--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -155,6 +155,7 @@ public:
     Sqlite3Database(std::shared_ptr<Config> config, std::shared_ptr<Timer> timer);
 
 private:
+    void prepare();
     void init() override;
     void shutdownDriver() override;
     std::shared_ptr<Database> getSelf() override;


### PR DESCRIPTION
fixes #1272: This only happened when you first created the database or after recovery.