### PR TITLE
Do make a homedir for the gerbera user in Debian postinst

### DIFF
--- a/scripts/debian/postinst
+++ b/scripts/debian/postinst
@@ -16,7 +16,6 @@ configure)
          --system \
          --ingroup gerbera \
          --home /var/lib/gerbera \
-         --no-create-home \
          --gecos "Gerbera Media Server" \
          --shell /usr/sbin/nologin \
          --disabled-login \


### PR DESCRIPTION
This commit removes the '--no-create-homedir' argument from the
adduser command in the postinst script used in the Debian package.
Without an existing homedir the Gerbera service won't start.

This is part of the fix for #1264.