### PR TITLE
Warn if blocking-tcp is not disabled in libupnp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,13 @@ else()
     Without this option Gerbera will be unable to restart with the same port number.]=])
     endif()
 
+    check_cxx_symbol_exists(UPNP_ENABLE_BLOCKING_TCP_CONNECTIONS "${UPNP_INCLUDE_DIR}/upnpconfig.h" UPNP_HAS_BLOCKING_TCP)
+    if (UPNP_HAS_BLOCKING_TCP)
+        message(WARNING [=[
+    !! It is strongly recommended to build libupnp with --disable-blocking-tcp-connections !!
+    Without this option non-responsive control points can cause libupnp to hang.]=])
+    endif()
+
     target_link_libraries(libgerbera PUBLIC pupnp::pupnp)
 endif()
 

--- a/scripts/install-pupnp.sh
+++ b/scripts/install-pupnp.sh
@@ -30,7 +30,7 @@ else
    extraFlags="--prefix=/usr/local"
 fi
 
-./configure $extraFlags --enable-ipv6 --enable-reuseaddr
+./configure $extraFlags --enable-ipv6 --enable-reuseaddr --disable-blocking-tcp-connections
 if command -v nproc >/dev/null 2>&1; then
     make "-j$(nproc)"
 else


### PR DESCRIPTION
If control points do not correctly unsubscribe this can result in
libupnp threads hanging.

https://github.com/pupnp/pupnp/discussions/245#discussioncomment-448988
https://github.com/pupnp/pupnp/commit/32cffb5bb55a650b1eb962c6fe2e58e6bf4fe2c5
