### PR TITLE
Fix crash in filetoMimeType and remove ancient Solaris hack

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -126,19 +126,6 @@ static void installSignalHandler()
 
 int main(int argc, char** argv, char** envp)
 {
-#ifdef SOLARIS
-    std::string ld_preload;
-    char* preload = getenv("LD_PRELOAD");
-    if (preload != nullptr)
-        ld_preload = std::string(preload);
-
-    if ((preload == nullptr) || (ld_preload.find("0@0") == -1)) {
-        printf("Gerbera: Solaris check failed!\n");
-        printf("Please set the environment to match glibc behaviour!\n");
-        printf("LD_PRELOAD=/usr/lib/0@0.so.1\n");
-        exit(EXIT_FAILURE);
-    }
-#endif
     cxxopts::Options options("gerbera", "Gerbera UPnP Media Server - https://gerbera.io");
 
     options.add_options() //

--- a/src/util/mime.cc
+++ b/src/util/mime.cc
@@ -74,7 +74,7 @@ Mime::~Mime()
 std::string Mime::fileToMimeType(const fs::path& path, const std::string& defval)
 {
     const char* mimeType = magic_file(magicCookie, path.c_str());
-    if (mimeType[0] == '\0') {
+    if (!mimeType || mimeType[0] == '\0') {
         return defval;
     }
 


### PR DESCRIPTION
13 years ago in the original mediatomb, a hack was done to allow printf() of a NULL pointer to print "NULL" rather than crash, on Solaris
That was done by mapping *0=0 behind the scenes, which makes a null dereference no longer an immediate crash, which it otherwise is on Solaroid machines, and quite deliberately
No, just, no - a nullptr dereference is a bug
Removed
And then I rather quickly found a crash which was hiding behind a totally messed up stack otherwise
Mime::fileToMimeType was blindly dereferencing a nullptr to see if it pointed to an empty string