### PR TITLE
fix MySQL initial setup

### DIFF
--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -209,10 +209,12 @@ void MySQLDatabase::init()
         log_debug("Loading initialisation SQL from: {}", sqlFilePath.c_str());
         auto sql = readTextFile(sqlFilePath);
 
-        for (const auto& statement : splitString(sql, ';')) {
+        for (auto& statement : splitString(sql, ';')) {
+            trimStringInPlace(statement);
             if (statement.empty()) {
                 continue;
             }
+            log_debug("executing statement: '{}'", statement);
             ret = mysql_real_query(&db, statement.c_str(), statement.size());
             if (ret) {
                 std::string myError = getError(&db);


### PR DESCRIPTION
Error during the very first startup when the DB tables should be created:
>Mysql: error while creating db: mysql_error (1065): "Query was empty"

The problem is that after the mysql.sql file content is split by `';'`, during the last loop the `statement` variable will only contain a newline character, which causes the mentioned MySQL error.

https://github.com/gerbera/gerbera/blob/d6e57d1211a813941ef23978f7a6a65c0b8a7cfb/src/database/mysql/mysql_database.cc#L212