### PR TITLE
fs::path conversions

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -440,7 +440,7 @@ public:
     void setURL(const std::string& URL) { this->location = URL; }
 
     /// \brief Get the URL of the item.
-    std::string getURL() const { return location; }
+    std::string getURL() const { return location.string(); }
     /// \brief Copies all object properties to another object.
     /// \param obj target object (clone)
     //void copyTo(std::shared_ptr<CdsObject> obj) override;

--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -186,8 +186,8 @@ void ConfigGenerator::generateServer(const fs::path& userHome, const fs::path& c
     fs::path homepath = userHome / configDir;
     setValue(CFG_SERVER_HOME, homepath.string());
 
-    std::string webRoot = dataDir / DEFAULT_WEB_DIR;
-    setValue(CFG_SERVER_WEBROOT, webRoot);
+    fs::path webRoot = dataDir / DEFAULT_WEB_DIR;
+    setValue(CFG_SERVER_WEBROOT, webRoot.string());
 
     auto aliveinfo = server->append_child(pugi::node_comment);
     aliveinfo.set_value(fmt::format("\n\

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -1251,9 +1251,10 @@ void ConfigManager::load(const fs::path& userHome)
 
     temp = setOption(root, CFG_SERVER_APPEND_PRESENTATION_URL_TO)->getOption();
     if (((temp == "ip") || (temp == "port")) && getOption(CFG_SERVER_PRESENTATION_URL).empty()) {
-        throw std::runtime_error("Error in config file: \"append-to\" attribute "
-                                 "value in <presentationURL> tag is set to \""
-            + temp + "\" but no URL is specified");
+        throw_std_runtime_error("Error in config file: \"append-to\" attribute "
+                                "value in <presentationURL> tag is set to \"{}\""
+                                "but no URL is specified",
+            temp.c_str());
     }
 
 #ifdef HAVE_JS

--- a/src/content/layout/builtin_layout.cc
+++ b/src/content/layout/builtin_layout.cc
@@ -80,7 +80,7 @@ void BuiltinLayout::addVideo(const std::shared_ptr<CdsObject>& obj, const fs::pa
         obj->setRefID(obj->getID());
     }
 
-    std::string dir;
+    fs::path dir;
     if (!rootpath.empty()) {
         // make location relative to rootpath: "/home/.../Videos/Action/a.mkv" with rootpath "/home/.../Videos" -> "Action"
         dir = fs::relative(obj->getLocation().parent_path(), config->getBoolOption(CFG_IMPORT_LAYOUT_PARENT_PATH) ? rootpath.parent_path() : rootpath);
@@ -89,7 +89,7 @@ void BuiltinLayout::addVideo(const std::shared_ptr<CdsObject>& obj, const fs::pa
         dir = esc(f2i->convert(getLastPath(obj->getLocation())));
 
     if (!dir.empty()) {
-        id = content->addContainerChain(fmt::format("/Video/Directories/{}", dir));
+        id = content->addContainerChain(fmt::format("/Video/Directories/{}", dir.string().c_str()));
         add(obj, id);
     }
 }
@@ -134,7 +134,7 @@ void BuiltinLayout::addImage(const std::shared_ptr<CdsObject>& obj, const fs::pa
         add(obj, id);
     }
 
-    std::string dir;
+    fs::path dir;
     if (!rootpath.empty()) {
         // make location relative to rootpath: "/home/.../Photos/Action/a.mkv" with rootpath "/home/.../Photos" -> "Action"
         dir = fs::relative(obj->getLocation().parent_path(), config->getBoolOption(CFG_IMPORT_LAYOUT_PARENT_PATH) ? rootpath.parent_path() : rootpath);
@@ -143,7 +143,7 @@ void BuiltinLayout::addImage(const std::shared_ptr<CdsObject>& obj, const fs::pa
         dir = esc(f2i->convert(getLastPath(obj->getLocation())));
 
     if (!dir.empty()) {
-        id = content->addContainerChain(fmt::format("/Photos/Directories/{}", dir));
+        id = content->addContainerChain(fmt::format("/Photos/Directories/{}", dir.string().c_str()));
         add(obj, id);
     }
 }
@@ -278,7 +278,7 @@ void BuiltinLayout::addAudio(const std::shared_ptr<CdsObject>& obj, const fs::pa
     add(obj, id);
 
     obj->setTitle(title);
-    std::string dir;
+    fs::path dir;
     if (!rootpath.empty()) {
         // make location relative to rootpath: "/home/.../Audio/Action/a.mp3" with rootpath "/home/.../Audio" -> "Action"
         dir = fs::relative(obj->getLocation().parent_path(), config->getBoolOption(CFG_IMPORT_LAYOUT_PARENT_PATH) ? rootpath.parent_path() : rootpath);
@@ -287,7 +287,7 @@ void BuiltinLayout::addAudio(const std::shared_ptr<CdsObject>& obj, const fs::pa
         dir = esc(f2i->convert(getLastPath(obj->getLocation())));
 
     if (!dir.empty()) {
-        id = content->addContainerChain(fmt::format("/Audio/Directories/{}", dir));
+        id = content->addContainerChain(fmt::format("/Audio/Directories/{}", dir.string().c_str()));
         add(obj, id);
     }
 }

--- a/src/content/onlineservice/online_service_helper.cc
+++ b/src/content/onlineservice/online_service_helper.cc
@@ -45,25 +45,19 @@ std::string OnlineServiceHelper::resolveURL(const std::shared_ptr<CdsItemExterna
     if (service > OS_Max)
         throw_std_runtime_error("Invalid service id");
 
-    std::string url;
-
     switch (service) {
 #ifdef SOPCAST
     case OS_SopCast:
-        url = item->getLocation();
-        break;
+        return item->getLocation().string();
 #endif
 #ifdef ATRAILERS
     case OS_ATrailers:
-        url = item->getLocation();
-        break;
+        return item->getLocation().string();
 #endif
     case OS_Max:
     default:
         throw_std_runtime_error("No handler for this service");
     }
-
-    return url;
 }
 
 #endif //ONLINE_SERVICES


### PR DESCRIPTION
there are several places in the code that implicitly convert an
fs::path to an std::string. This breaks on platforms like Windows
where the paths are wstrings. Remove some of these implicit
conversions and make others explicit.

Signed-off-by: Rosen Penev <rosenp@gmail.com>