### PR TITLE
Allow search for albums and genre and other containers

### DIFF
--- a/doc/supported-devices.rst
+++ b/doc/supported-devices.rst
@@ -86,6 +86,8 @@ Denon
 -  AVR-4308
 -  S-52
 -  ASD-3N
+-  RCD-N9
+-  HEOS Multiroom, all devices with buildin HEOS by Denon or Marantz
 
 D-Link
 ~~~~~~

--- a/scripts/js/common.js
+++ b/scripts/js/common.js
@@ -358,6 +358,7 @@ function addAudio(obj) {
     chain.album.meta[M_ALBUM] = album;
     chain.artist.meta[M_ARTIST] = artist;
     chain.artist.meta[M_ALBUMARTIST] = artist;
+    chain.genre.meta[M_GENRE] = genre;
     chain.year.meta[M_DATE] = date;
     chain.composer.meta[M_COMPOSER] = composer;
 

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1074,6 +1074,7 @@ std::pair<int, bool> ContentManager::addContainerTree(const std::vector<std::sha
             tree = std::regex_replace(tree, std::regex(key), val);
         }
         if (containerMap.find(tree) == containerMap.end()) {
+            item->setMetadata(M_TITLE, item->getTitle());
             database->addContainerChain(tree, item->getClass(), INVALID_OBJECT_ID, &result, createdIds, item->getMetadata());
             auto container = std::dynamic_pointer_cast<CdsContainer>(database->loadObject(result));
             containerMap[tree] = container;
@@ -1123,6 +1124,7 @@ std::pair<int, bool> ContentManager::addContainerChain(const std::string& chain,
     int containerID = INVALID_OBJECT_ID;
     std::vector<std::shared_ptr<CdsContainer>> containerList;
     if (containerMap.find(newChain) == containerMap.end()) {
+        lastMetadata[MetadataHandler::getMetaFieldName(M_TITLE)] = splitString(newChain, '/').back();
         database->addContainerChain(newChain, lastClass, lastRefID, &containerID, updateID, lastMetadata);
 
         for (const auto& contId : updateID) {

--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -501,7 +501,7 @@ std::string DefaultSQLEmitter::emit(const ASTStringOperator* node, const std::st
     } else if (lcOperator == "derivedfrom") {
         sqlFragment << "c.upnp_class "
                     << "like"
-                    << " lower('" << value << ".%')";
+                    << " lower('" << value << "%')";
     }
     return sqlFragment.str();
 }

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -607,7 +607,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::search(const std::unique_pt
         throw_std_runtime_error("failed to generate SQL for search");
 
     std::ostringstream countSQL;
-    countSQL << "select count(*) " << searchSQL << ';';
+    countSQL << "select count(*) " << searchSQL;
     auto sqlResult = select(countSQL);
     std::unique_ptr<SQLRow> countRow = sqlResult->nextRow();
     if (countRow != nullptr) {
@@ -622,7 +622,6 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::search(const std::unique_pt
                      << " limit " << (requestedCount == 0 ? 10000000000 : requestedCount)
                      << " offset " << startingIndex;
     }
-    retrievalSQL << ';';
 
     log_debug("Search resolves to SQL [{}]", retrievalSQL.str().c_str());
     sqlResult = select(retrievalSQL);
@@ -1036,7 +1035,7 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
         }
 
         item->setTrackNumber(stoiString(row->col(to_underlying(SearchCol::track_number))));
-    } else {
+    } else if (!obj->isContainer()) {
         throw DatabaseException("", fmt::format("Unknown object type: {}", objectType));
     }
 

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -171,11 +171,12 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
             bool artAdded = renderContainerImage(virtualURL, cont, url);
             if (artAdded) {
                 result.append_child(MetadataHandler::getMetaFieldName(M_ALBUMARTURI).c_str()).append_child(pugi::node_pcdata).set_value(url.c_str());
-                return;
             }
         }
     }
-    // log_debug("Rendered DIDL: {}", result->print().c_str());
+    // std::ostringstream osr;
+    // result.print(osr, "  ");
+    // log_debug("Rendered DIDL: {}", osr.str());
 }
 
 std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createEventPropertySet()

--- a/test/core/test_searchhandler.cc
+++ b/test/core/test_searchhandler.cc
@@ -372,11 +372,11 @@ TEST(SearchParser, SearchCriteriaWithExtendsOperator)
     DefaultSQLEmitter sqlEmitter;
     // derivedfromOpExpr
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:class derivedfrom \"object.item.audioItem\"",
-        "c.upnp_class like lower('object.item.audioItem.%')"));
+        "c.upnp_class like lower('object.item.audioItem%')"));
 
     // derivedfromOpExpr and (containsOpExpr or containsOpExpr)
-    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:class derivedfrom \"object.item.audioItem\" and (dc:title contains \"britain\" or dc:creator contains \"britain\"", "c.upnp_class like lower('object.item.audioItem.%') and ((m.property_name='dc:title' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null) or (m.property_name='dc:creator' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null))"));
+    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:class derivedfrom \"object.item.audioItem\" and (dc:title contains \"britain\" or dc:creator contains \"britain\"", "c.upnp_class like lower('object.item.audioItem%') and ((m.property_name='dc:title' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null) or (m.property_name='dc:creator' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null))"));
 
     // derivedFromOpExpr and (containsOpExpr or containsOpExpr)
-    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:class derivedFrom \"object.item.audioItem\" and (dc:title contains \"britain\" or dc:creator contains \"britain\"", "c.upnp_class like lower('object.item.audioItem.%') and ((m.property_name='dc:title' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null) or (m.property_name='dc:creator' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null))"));
+    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:class derivedFrom \"object.item.audioItem\" and (dc:title contains \"britain\" or dc:creator contains \"britain\"", "c.upnp_class like lower('object.item.audioItem%') and ((m.property_name='dc:title' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null) or (m.property_name='dc:creator' and lower(m.property_value) like lower('%britain%') and c.upnp_class is not null))"));
 }


### PR DESCRIPTION
Container search is looking for 'dc:title' which has to be set on import

Search operator `derivedfrom` should also match base class (e.g. object.container.album.musicAlbum)

fixes #1287 
fixes #1281 