### PR TITLE
import constexpr map library and replace pair arrays

### DIFF
--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -171,7 +171,7 @@ Script::Script(std::shared_ptr<ContentManager> content,
     /* initialize contstants */
     for (const auto& [field, sym] : ot_names) {
         duk_push_int(ctx, field);
-        duk_put_global_string(ctx, sym);
+        duk_put_global_string(ctx, sym.data());
     }
 #ifdef ONLINE_SERVICES
     duk_push_int(ctx, int(OS_None));
@@ -209,26 +209,26 @@ Script::Script(std::shared_ptr<ContentManager> content,
 #endif //ONLINE_SERVICES
 
     for (const auto& [field, sym] : mt_keys) {
-        duk_push_string(ctx, sym);
+        duk_push_string(ctx, sym.data());
         for (const auto& [f, s] : mt_names) {
             if (f == field) {
-                duk_put_global_string(ctx, s);
+                duk_put_global_string(ctx, s.data());
             }
         }
     }
 
     for (const auto& [field, sym] : res_keys) {
-        duk_push_string(ctx, sym);
+        duk_push_string(ctx, sym.data());
         for (const auto& [f, s] : res_names) {
             if (f == field) {
-                duk_put_global_string(ctx, s);
+                duk_put_global_string(ctx, s.data());
             }
         }
     }
 
     for (const auto& [field, sym] : upnp_classes) {
-        duk_push_string(ctx, field);
-        duk_put_global_string(ctx, sym);
+        duk_push_string(ctx, field.data());
+        duk_put_global_string(ctx, sym.data());
     }
 
     duk_push_object(ctx); // config
@@ -470,7 +470,7 @@ std::shared_ptr<CdsObject> Script::dukObject2cdsObject(const std::shared_ptr<Cds
         duk_to_object(ctx, -1);
         // only metadata enumerated in mt_keys is allowed
         for (const auto& [sym, upnp] : mt_keys) {
-            val = getProperty(upnp);
+            val = getProperty(upnp.data());
             if (!val.empty()) {
                 if (sym == M_TRACKNUMBER) {
                     int j = stoiString(val, 0);
@@ -525,7 +525,7 @@ std::shared_ptr<CdsObject> Script::dukObject2cdsObject(const std::shared_ptr<Cds
             for (const auto& res : obj->getResources()) {
                 // only attribute enumerated in res_keys is allowed
                 for (const auto& [key, upnp] : res_keys) {
-                    val = getProperty(resCount == 0 ? upnp : fmt::format("{}-{}", resCount, upnp));
+                    val = getProperty(resCount == 0 ? std::string(upnp) : fmt::format("{}-{}", resCount, upnp));
                     if (!val.empty()) {
                         val = sc->convert(val);
                         res->addAttribute(key, val);

--- a/src/content/scripting/script_names.h
+++ b/src/content/scripting/script_names.h
@@ -26,11 +26,10 @@
 #ifndef __SCRIPTING_SCRIPT_NAMES_H__
 #define __SCRIPTING_SCRIPT_NAMES_H__
 
-#include <array>
-
+#include "contrib/eternal.hpp"
 #include "metadata/metadata_handler.h"
 
-static constexpr auto res_names = std::array<std::pair<resource_attributes_t, const char*>, 11> { {
+static constexpr auto res_names = mapbox::eternal::map<resource_attributes_t, std::string_view>({
     { R_SIZE, "R_SIZE" },
     { R_DURATION, "R_DURATION" },
     { R_BITRATE, "R_BITRATE" },
@@ -42,9 +41,9 @@ static constexpr auto res_names = std::array<std::pair<resource_attributes_t, co
     { R_RESOURCE_FILE, "R_RESOURCE_FILE" },
     { R_BITS_PER_SAMPLE, "R_BITS_PER_SAMPLE" },
     { R_TYPE, "R_TYPE" },
-} };
+});
 
-static constexpr auto mt_names = std::array<std::pair<metadata_fields_t, const char*>, 22> { {
+static constexpr auto mt_names = mapbox::eternal::map<metadata_fields_t, std::string_view>({
     { M_TITLE, "M_TITLE" },
     { M_ARTIST, "M_ARTIST" },
     { M_ALBUM, "M_ALBUM" },
@@ -67,15 +66,15 @@ static constexpr auto mt_names = std::array<std::pair<metadata_fields_t, const c
     { M_COMPOSER, "M_COMPOSER" },
     { M_CONDUCTOR, "M_CONDUCTOR" },
     { M_ORCHESTRA, "M_ORCHESTRA" },
-} };
+});
 
-static constexpr auto ot_names = std::array<std::pair<int, const char*>, 5> { {
+static constexpr auto ot_names = mapbox::eternal::map<int, std::string_view>({
     { OBJECT_TYPE_CONTAINER, "OBJECT_TYPE_CONTAINER" },
     { OBJECT_TYPE_ITEM, "OBJECT_TYPE_ITEM" },
     { OBJECT_TYPE_ITEM_EXTERNAL_URL, "OBJECT_TYPE_ITEM_EXTERNAL_URL" },
-} };
+});
 
-static constexpr auto upnp_classes = std::array<std::pair<const char*, const char*>, 12> { {
+static constexpr auto upnp_classes = mapbox::eternal::map<std::string_view, std::string_view>({
     { UPNP_CLASS_MUSIC_ALBUM, "UPNP_CLASS_CONTAINER_MUSIC_ALBUM" },
     { UPNP_CLASS_MUSIC_ARTIST, "UPNP_CLASS_CONTAINER_MUSIC_ARTIST" },
     { UPNP_CLASS_MUSIC_GENRE, "UPNP_CLASS_CONTAINER_MUSIC_GENRE" },
@@ -88,6 +87,6 @@ static constexpr auto upnp_classes = std::array<std::pair<const char*, const cha
     { UPNP_CLASS_VIDEO_ITEM, "UPNP_CLASS_CONTAINER_ITEM_VIDEO" },
     { UPNP_CLASS_IMAGE_ITEM, "UPNP_CLASS_CONTAINER_ITEM_IMAGE" },
     { UPNP_CLASS_PLAYLIST_CONTAINER, "UPNP_CLASS_PLAYLIST_CONTAINER" },
-} };
+});
 
 #endif

--- a/src/contrib/eternal.hpp
+++ b/src/contrib/eternal.hpp
@@ -1,0 +1,468 @@
+#pragma once
+
+#include <functional>
+#include <utility>
+
+// GCC 4.9 compatibility
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 5
+
+#define MAPBOX_ETERNAL_IS_CONSTEXPR 0
+#define MAPBOX_ETERNAL_CONSTEXPR
+
+#else
+
+#define MAPBOX_ETERNAL_IS_CONSTEXPR 1
+#define MAPBOX_ETERNAL_CONSTEXPR constexpr
+
+#endif
+
+namespace mapbox {
+namespace eternal {
+    namespace impl {
+
+        template <typename T>
+        constexpr void swap(T& a, T& b) noexcept
+        {
+            T tmp { a };
+            a = b;
+            b = tmp;
+        }
+
+        template <typename Key>
+        class compare_key {
+        public:
+            const Key key;
+
+            constexpr compare_key(const Key& key_) noexcept
+                : key(key_)
+            {
+            }
+
+            template <typename Element>
+            constexpr bool operator<(const Element& rhs) const noexcept
+            {
+                return key < rhs->first;
+            }
+        };
+
+        template <typename Key, typename Value>
+        class element {
+        public:
+            using key_type = Key;
+            using mapped_type = Value;
+            using value_type = std::pair<key_type, mapped_type>;
+            using compare_key_type = compare_key<key_type>;
+
+            constexpr element(const key_type& key, const mapped_type& value) noexcept
+                : pair(key, value)
+            {
+            }
+
+            constexpr bool operator<(const element& rhs) const noexcept
+            {
+                return pair.first < rhs.pair.first;
+            }
+
+            constexpr bool operator<(const compare_key_type& rhs) const noexcept
+            {
+                return pair.first < rhs.key;
+            }
+
+            constexpr const auto& operator*() const noexcept
+            {
+                return pair;
+            }
+
+            constexpr const auto* operator->() const noexcept
+            {
+                return &pair;
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR void swap(element& rhs) noexcept
+            {
+                impl::swap(pair.first, rhs.pair.first);
+                impl::swap(pair.second, rhs.pair.second);
+            }
+
+        private:
+            value_type pair;
+        };
+
+        template <typename Key, typename Hasher = std::hash<Key>>
+        class compare_key_hash : public compare_key<Key> {
+            using base_type = compare_key<Key>;
+
+        public:
+            const std::size_t hash;
+
+            constexpr compare_key_hash(const Key& key_) noexcept
+                : base_type(key_)
+                , hash(Hasher()(key_))
+            {
+            }
+
+            template <typename Element>
+            constexpr bool operator<(const Element& rhs) const noexcept
+            {
+                return hash < rhs.hash || (!(rhs.hash < hash) && base_type::operator<(rhs));
+            }
+        };
+
+        template <typename Key, typename Value, typename Hasher = std::hash<Key>>
+        class element_hash : public element<Key, Value> {
+            using base_type = element<Key, Value>;
+
+        public:
+            using key_type = Key;
+            using mapped_type = Value;
+            using compare_key_type = compare_key_hash<key_type, Hasher>;
+
+            friend compare_key_type;
+
+            constexpr element_hash(const key_type& key, const mapped_type& value) noexcept
+                : base_type(key, value)
+                , hash(Hasher()(key))
+            {
+            }
+
+            template <typename T>
+            constexpr bool operator<(const T& rhs) const noexcept
+            {
+                return hash < rhs.hash || (!(rhs.hash < hash) && base_type::operator<(rhs));
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR void swap(element_hash& rhs) noexcept
+            {
+                impl::swap(hash, rhs.hash);
+                base_type::swap(rhs);
+            }
+
+        private:
+            std::size_t hash;
+        };
+
+    } // namespace impl
+
+    template <typename Element>
+    class iterator {
+    public:
+        constexpr iterator(const Element* pos_) noexcept
+            : pos(pos_)
+        {
+        }
+
+        constexpr bool operator==(const iterator& rhs) const noexcept
+        {
+            return pos == rhs.pos;
+        }
+
+        constexpr bool operator!=(const iterator& rhs) const noexcept
+        {
+            return pos != rhs.pos;
+        }
+
+        MAPBOX_ETERNAL_CONSTEXPR iterator& operator++() noexcept
+        {
+            ++pos;
+            return *this;
+        }
+
+        MAPBOX_ETERNAL_CONSTEXPR iterator& operator+=(std::size_t i) noexcept
+        {
+            pos += i;
+            return *this;
+        }
+
+        constexpr iterator operator+(std::size_t i) const noexcept
+        {
+            return pos + i;
+        }
+
+        MAPBOX_ETERNAL_CONSTEXPR iterator& operator--() noexcept
+        {
+            --pos;
+            return *this;
+        }
+
+        MAPBOX_ETERNAL_CONSTEXPR iterator& operator-=(std::size_t i) noexcept
+        {
+            pos -= i;
+            return *this;
+        }
+
+        constexpr std::size_t operator-(const iterator& rhs) const noexcept
+        {
+            return pos - rhs.pos;
+        }
+
+        constexpr const auto& operator*() const noexcept
+        {
+            return **pos;
+        }
+
+        constexpr const auto* operator->() const noexcept
+        {
+            return &**pos;
+        }
+
+    private:
+        const Element* pos;
+    };
+
+    namespace impl {
+
+        template <typename Compare, typename Iterator, typename Key>
+        MAPBOX_ETERNAL_CONSTEXPR auto bound(Iterator left, Iterator right, const Key& key) noexcept
+        {
+            std::size_t count = right - left;
+            while (count > 0) {
+                const std::size_t step = count / 2;
+                right = left + step;
+                if (Compare()(*right, key)) {
+                    left = ++right;
+                    count -= step + 1;
+                } else {
+                    count = step;
+                }
+            }
+            return left;
+        }
+
+        struct less {
+            template <typename A, typename B>
+            constexpr bool operator()(const A& a, const B& b) const noexcept
+            {
+                return a < b;
+            }
+        };
+
+        struct greater_equal {
+            template <typename A, typename B>
+            constexpr bool operator()(const A& a, const B& b) const noexcept
+            {
+                return !(b < a);
+            }
+        };
+
+        template <typename Element, std::size_t N>
+        class map {
+        private:
+            static_assert(N > 0, "map is empty");
+
+            Element data_[N];
+
+            template <typename T, std::size_t... I>
+            MAPBOX_ETERNAL_CONSTEXPR map(const T (&data)[N], std::index_sequence<I...>) noexcept
+                : data_ { { data[I].first, data[I].second }... }
+            {
+                static_assert(sizeof...(I) == N, "index_sequence has identical length");
+                // Yes, this is a bubblesort. It's usually evaluated at compile-time, it's fast for data
+                // that is already sorted (like static maps), it has a small code size, and it's stable.
+                for (auto left = data_, right = data_ + N - 1; data_ < right; right = left, left = data_) {
+                    for (auto it = data_; it < right; ++it) {
+                        if (it[1] < it[0]) {
+                            it[0].swap(it[1]);
+                            left = it;
+                        }
+                    }
+                }
+            }
+
+            using compare_key_type = typename Element::compare_key_type;
+
+        public:
+            template <typename T>
+            MAPBOX_ETERNAL_CONSTEXPR map(const T (&data)[N]) noexcept
+                : map(data, std::make_index_sequence<N>())
+            {
+            }
+
+            using key_type = typename Element::key_type;
+            using mapped_type = typename Element::mapped_type;
+            using value_type = typename Element::value_type;
+            using size_type = std::size_t;
+            using difference_type = std::ptrdiff_t;
+            using const_reference = const value_type&;
+            using const_pointer = const value_type*;
+            using const_iterator = iterator<Element>;
+
+            MAPBOX_ETERNAL_CONSTEXPR bool unique() const noexcept
+            {
+                for (auto right = data_ + N - 1, it = data_; it < right; ++it) {
+                    if (!(it[0] < it[1])) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR const mapped_type& at(const key_type& key) const noexcept
+            {
+                return find(key)->second;
+            }
+
+            constexpr std::size_t size() const noexcept
+            {
+                return N;
+            }
+
+            constexpr const_iterator begin() const noexcept
+            {
+                return data_;
+            }
+
+            constexpr const_iterator cbegin() const noexcept
+            {
+                return begin();
+            }
+
+            constexpr const_iterator end() const noexcept
+            {
+                return data_ + N;
+            }
+
+            constexpr const_iterator cend() const noexcept
+            {
+                return end();
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR const_iterator lower_bound(const key_type& key) const noexcept
+            {
+                return bound<less>(data_, data_ + N, compare_key_type { key });
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR const_iterator upper_bound(const key_type& key) const noexcept
+            {
+                return bound<greater_equal>(data_, data_ + N, compare_key_type { key });
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR std::pair<const_iterator, const_iterator> equal_range(const key_type& key) const noexcept
+            {
+                const compare_key_type compare_key { key };
+                auto first = bound<less>(data_, data_ + N, compare_key);
+                return { first, bound<greater_equal>(first, data_ + N, compare_key) };
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR std::size_t count(const key_type& key) const noexcept
+            {
+                const auto range = equal_range(key);
+                return range.second - range.first;
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR const_iterator find(const key_type& key) const noexcept
+            {
+                const compare_key_type compare_key { key };
+                auto it = bound<less>(data_, data_ + N, compare_key);
+                if (it != data_ + N && greater_equal()(*it, compare_key)) {
+                    return it;
+                } else {
+                    return end();
+                }
+            }
+
+            MAPBOX_ETERNAL_CONSTEXPR bool contains(const key_type& key) const noexcept
+            {
+                return find(key) != end();
+            }
+        };
+
+    } // namespace impl
+
+    template <typename Key, typename Value, std::size_t N>
+    static constexpr auto map(const std::pair<const Key, const Value> (&items)[N]) noexcept
+    {
+        return impl::map<impl::element<Key, Value>, N>(items);
+    }
+
+    template <typename Key, typename Value, std::size_t N>
+    static constexpr auto hash_map(const std::pair<const Key, const Value> (&items)[N]) noexcept
+    {
+        return impl::map<impl::element_hash<Key, Value>, N>(items);
+    }
+
+} // namespace eternal
+} // namespace mapbox
+
+// mapbox::eternal::string
+
+namespace mapbox {
+namespace eternal {
+    namespace impl {
+
+        // Use different constants for 32 bit vs. 64 bit size_t
+        constexpr std::size_t hash_offset = std::conditional_t<sizeof(std::size_t) < 8,
+            std::integral_constant<std::uint32_t, 0x811C9DC5>,
+            std::integral_constant<std::uint64_t, 0xCBF29CE484222325>>::value;
+        constexpr std::size_t hash_prime = std::conditional_t<sizeof(std::size_t) < 8,
+            std::integral_constant<std::uint32_t, 0x1000193>,
+            std::integral_constant<std::uint64_t, 0x100000001B3>>::value;
+
+        // FNV-1a hash
+        constexpr static std::size_t str_hash(const char* str,
+            const std::size_t value = hash_offset) noexcept
+        {
+            return *str ? str_hash(str + 1, (value ^ static_cast<std::size_t>(*str)) * hash_prime) : value;
+        }
+
+        constexpr bool str_less(const char* lhs, const char* rhs) noexcept
+        {
+            return *lhs && *rhs && *lhs == *rhs ? str_less(lhs + 1, rhs + 1) : *lhs < *rhs;
+        }
+
+        constexpr bool str_equal(const char* lhs, const char* rhs) noexcept
+        {
+            return *lhs == *rhs && (*lhs == '\0' || str_equal(lhs + 1, rhs + 1));
+        }
+
+    } // namespace impl
+
+    class string {
+    private:
+        const char* data_;
+
+    public:
+        constexpr string(char const* data) noexcept
+            : data_(data)
+        {
+        }
+
+        constexpr string(const string&) noexcept = default;
+        constexpr string(string&&) noexcept = default;
+        MAPBOX_ETERNAL_CONSTEXPR string& operator=(const string&) noexcept = default;
+        MAPBOX_ETERNAL_CONSTEXPR string& operator=(string&&) noexcept = default;
+
+        constexpr bool operator<(const string& rhs) const noexcept
+        {
+            return impl::str_less(data_, rhs.data_);
+        }
+
+        constexpr bool operator==(const string& rhs) const noexcept
+        {
+            return impl::str_equal(data_, rhs.data_);
+        }
+
+        constexpr const char* data() const noexcept
+        {
+            return data_;
+        }
+
+        constexpr const char* c_str() const noexcept
+        {
+            return data_;
+        }
+    };
+
+} // namespace eternal
+} // namespace mapbox
+
+namespace std {
+
+template <>
+struct hash<::mapbox::eternal::string> {
+    constexpr std::size_t operator()(const ::mapbox::eternal::string& str) const
+    {
+        return ::mapbox::eternal::impl::str_hash(str.data());
+    }
+};
+
+} // namespace std

--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -31,10 +31,11 @@
 #include <stack>
 
 #include "config/config_manager.h"
+#include "contrib/eternal.hpp"
 #include "database/database.h"
 #include "util/tools.h"
 
-static const std::unordered_map<std::string_view, TokenType> tokenTypes {
+static constexpr auto tokenTypes = mapbox::eternal::map<std::string_view, TokenType>({
     { "(", TokenType::LPAREN },
     { ")", TokenType::RPAREN },
     { "*", TokenType::ASTERISK },
@@ -53,8 +54,8 @@ static const std::unordered_map<std::string_view, TokenType> tokenTypes {
     { ">", TokenType::COMPAREOP },
     { ">=", TokenType::COMPAREOP },
     { "and", TokenType::AND },
-    { "or", TokenType::OR }
-};
+    { "or", TokenType::OR },
+});
 
 static std::string aslowercase(const std::string& src)
 {

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -30,6 +30,7 @@
 #include "cds_objects.h"
 #include "config/config.h"
 #include "config/directory_tweak.h"
+#include "contrib/eternal.hpp"
 #include "iohandler/file_io_handler.h"
 #include "util/mime.h"
 #include "util/tools.h"
@@ -78,13 +79,13 @@ fs::path MetacontentHandler::getContentPath(const std::vector<std::string>& name
     return "";
 }
 
-static constexpr std::array<std::pair<std::string_view, metadata_fields_t>, 5> metaTags { {
+static constexpr auto metaTags = mapbox::eternal::map<std::string_view, metadata_fields_t>({
     { "%album%", M_ALBUM },
     { "%albumArtist%", M_ALBUMARTIST },
     { "%artist%", M_ARTIST },
     { "%genre%", M_GENRE },
     { "%title%", M_TITLE },
-} };
+});
 bool MetacontentHandler::caseSensitive = true;
 
 std::string MetacontentHandler::expandName(const std::string& name, const std::shared_ptr<CdsObject>& obj)

--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -140,7 +140,7 @@ std::string MetadataHandler::getMetaFieldName(metadata_fields_t field)
 {
     for (const auto& [f, s] : mt_keys) {
         if (f == field) {
-            return s;
+            return s.data();
         }
     }
     return "unknown";
@@ -150,7 +150,7 @@ std::string MetadataHandler::getResAttrName(resource_attributes_t attr)
 {
     for (const auto& [f, s] : res_keys) {
         if (f == attr) {
-            return s;
+            return s.data();
         }
     }
     return "unknown";

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -38,6 +38,7 @@ namespace fs = std::filesystem;
 
 #include "common.h"
 #include "context.h"
+#include "contrib/eternal.hpp"
 
 // forward declaration
 class CdsItem;
@@ -118,7 +119,7 @@ enum metadata_fields_t {
     M_MAX
 };
 
-static constexpr auto mt_keys = std::array<std::pair<metadata_fields_t, const char*>, M_MAX> { {
+static constexpr auto mt_keys = mapbox::eternal::map<metadata_fields_t, std::string_view>({
     { M_TITLE, "dc:title" },
     { M_ARTIST, "upnp:artist" },
     { M_ALBUM, "upnp:album" },
@@ -141,7 +142,7 @@ static constexpr auto mt_keys = std::array<std::pair<metadata_fields_t, const ch
     { M_COMPOSER, "upnp:composer" },
     { M_CONDUCTOR, "upnp:conductor" },
     { M_ORCHESTRA, "upnp:orchestra" },
-} };
+});
 
 // res tag attributes
 enum resource_attributes_t {
@@ -161,7 +162,7 @@ enum resource_attributes_t {
     R_MAX
 };
 
-static constexpr auto res_keys = std::array<std::pair<resource_attributes_t, const char*>, R_MAX> { {
+static constexpr auto res_keys = mapbox::eternal::map<resource_attributes_t, std::string_view>({
     { R_SIZE, "size" },
     { R_DURATION, "duration" },
     { R_BITRATE, "bitrate" },
@@ -175,7 +176,7 @@ static constexpr auto res_keys = std::array<std::pair<resource_attributes_t, con
     { R_FANART_RES_ID, "fanArtResource" },
     { R_BITS_PER_SAMPLE, "bitsPerSample" },
     { R_TYPE, "type" },
-} };
+});
 
 /// \brief This class is responsible for providing access to metadata information
 /// of various media.

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -33,6 +33,7 @@
 
 #include "config/config_manager.h"
 #include "content/scripting/script_names.h"
+#include "contrib/eternal.hpp"
 #include "database/database.h"
 #include "metadata/metadata_handler.h"
 #include "request_handler.h"
@@ -219,7 +220,7 @@ std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription()
     else
         device.append_child("presentationURL").append_child(pugi::node_pcdata).set_value(presentationURL.c_str());
 
-    constexpr std::array<std::pair<const char*, config_option_t>, 9> deviceProperties { {
+    constexpr auto deviceProperties = mapbox::eternal::map<std::string_view, config_option_t>({
         // { "deviceType", {} },
         // { "presentationURL", {} },
         { "friendlyName", CFG_SERVER_NAME },
@@ -231,35 +232,35 @@ std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription()
         { "modelURL", CFG_SERVER_MODEL_URL },
         { "serialNumber", CFG_SERVER_SERIAL_NUMBER },
         { "UDN", CFG_SERVER_UDN },
-    } };
+    });
     for (const auto& [tag, field] : deviceProperties) {
-        device.append_child(tag).append_child(pugi::node_pcdata).set_value(config->getOption(field).c_str());
+        device.append_child(tag.data()).append_child(pugi::node_pcdata).set_value(config->getOption(field).c_str());
     }
 
     // add icons
     {
         auto iconList = device.append_child("iconList");
 
-        constexpr std::array<std::pair<const char*, const char*>, 3> iconDims { {
+        constexpr auto iconDims = mapbox::eternal::map<std::string_view, std::string_view>({
             { "120", "24" },
             { "48", "24" },
             { "32", "8" },
-        } };
+        });
 
-        constexpr std::array<std::pair<const char*, const char*>, 3> iconTypes { {
+        constexpr auto iconTypes = mapbox::eternal::map<std::string_view, std::string_view>({
             { UPNP_DESC_ICON_PNG_MIMETYPE, ".png" },
             { UPNP_DESC_ICON_BMP_MIMETYPE, ".bmp" },
             { UPNP_DESC_ICON_JPG_MIMETYPE, ".jpg" },
-        } };
+        });
 
         for (const auto& [dim, depth] : iconDims) {
             for (const auto& [mimetype, ext] : iconTypes) {
                 auto icon = iconList.append_child("icon");
-                icon.append_child("mimetype").append_child(pugi::node_pcdata).set_value(mimetype);
-                icon.append_child("width").append_child(pugi::node_pcdata).set_value(dim);
-                icon.append_child("height").append_child(pugi::node_pcdata).set_value(dim);
-                icon.append_child("depth").append_child(pugi::node_pcdata).set_value(depth);
-                std::string url = fmt::format("/icons/mt-icon{}{}", dim, ext);
+                icon.append_child("mimetype").append_child(pugi::node_pcdata).set_value(mimetype.data());
+                icon.append_child("width").append_child(pugi::node_pcdata).set_value(dim.data());
+                icon.append_child("height").append_child(pugi::node_pcdata).set_value(dim.data());
+                icon.append_child("depth").append_child(pugi::node_pcdata).set_value(depth.data());
+                std::string url = fmt::format("/icons/mt-icon{}{}", dim.data(), ext.data());
                 icon.append_child("url").append_child(pugi::node_pcdata).set_value(url.c_str());
             }
         }
@@ -276,7 +277,7 @@ std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription()
             const char* controlURL;
             const char* eventSubURL;
         };
-        constexpr std::array<ServiceInfo, 3> services { {
+        constexpr auto services = std::array<ServiceInfo, 3> { {
             // cm
             { UPNP_DESC_CM_SERVICE_TYPE, UPNP_DESC_CM_SERVICE_ID, UPNP_DESC_CM_SCPD_URL, UPNP_DESC_CM_CONTROL_URL, UPNP_DESC_CM_EVENT_URL },
             // cds

--- a/test/scripting/mock/script_test_fixture.cc
+++ b/test/scripting/mock/script_test_fixture.cc
@@ -130,28 +130,32 @@ duk_ret_t ScriptTestFixture::dukMockPlaylist(duk_context* ctx, string title, str
 
 void ScriptTestFixture::addGlobalFunctions(duk_context* ctx, const duk_function_list_entry* funcs)
 {
-    for (const auto& entry : mt_keys) {
-        duk_push_string(ctx, entry.second);
-        auto sym = std::find_if(mt_names.begin(), mt_names.end(), [=](const auto& n) { return n.first == entry.first; });
-        if (sym != mt_names.end())
-            duk_put_global_string(ctx, sym->second);
+    for (auto&& [field, sym] : mt_keys) {
+        duk_push_string(ctx, sym.data());
+        for (auto&& [f, s] : mt_names) {
+            if (f == field) {
+                duk_put_global_string(ctx, s.data());
+            }
+        }
     }
 
-    for (const auto& entry : res_keys) {
-        duk_push_string(ctx, entry.second);
-        auto sym = std::find_if(res_names.begin(), res_names.end(), [=](const auto& n) { return n.first == entry.first; });
-        if (sym != res_names.end())
-            duk_put_global_string(ctx, sym->second);
+    for (auto&& [field, sym] : res_keys) {
+        duk_push_string(ctx, sym.data());
+        for (auto&& [f, s] : res_names) {
+            if (f == field) {
+                duk_put_global_string(ctx, s.data());
+            }
+        }
     }
 
-    for (const auto& [field, sym] : ot_names) {
+    for (auto&& [field, sym] : ot_names) {
         duk_push_int(ctx, field);
-        duk_put_global_string(ctx, sym);
+        duk_put_global_string(ctx, sym.data());
     }
 
-    for (const auto& [field, sym] : upnp_classes) {
-        duk_push_string(ctx, field);
-        duk_put_global_string(ctx, sym);
+    for (auto&& [field, sym] : upnp_classes) {
+        duk_push_string(ctx, field.data());
+        duk_put_global_string(ctx, sym.data());
     }
 
     duk_push_object(ctx); // config


### PR DESCRIPTION
Avoids doing manual std::array<std::pair>>. Also supports normal methods
supported by std::map except for insertions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>