### PR TITLE
Work around undefined syscalls on solaroid systems

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -253,7 +253,8 @@ int main(int argc, char** argv, char** envp)
             // set all uids, gids and add. groups
 // mac os x does this differently, setgid and setuid are basically doing the same
 // as setresuid and setresgid on linux: setting all of real{u,g}id, effective{u,g}id and saved-set{u,g}id
-#ifdef __APPLE__
+// Solaroid systems are likewise missing setresgid and setresuid
+#if defined(__APPLE__) || defined(SOLARIS)
             // set group-ids, then add. groups, last user-ids, all need to succeed
             if (0 != setgid(user_id->pw_gid) || 0 != initgroups(user_id->pw_name, user_id->pw_gid) || 0 != setuid(user_id->pw_uid)) {
 #else


### PR DESCRIPTION
setresgid() and setresuid() are not present on Illumos systems
Use the OS X codepath in this case

There may be other OSs where this is also an issue, FWIW