### PR TITLE
remove push_back branch

### DIFF
--- a/src/config/config_options.cc
+++ b/src/config/config_options.cc
@@ -92,11 +92,7 @@ std::vector<std::string> ArrayOption::getArrayOption(bool forEdit) const
     std::vector<std::string> editOption;
     editOption.reserve(editSize);
     for (size_t i = 0; i < editSize; i++) {
-        if (indexMap.at(i) < std::numeric_limits<std::size_t>::max()) {
-            editOption.push_back(option[indexMap.at(i)]);
-        } else {
-            editOption.push_back("");
-        }
+        editOption.push_back(indexMap.at(i) < std::numeric_limits<std::size_t>::max() ? option[indexMap.at(i)] : "");
     }
     return editOption;
 }


### PR DESCRIPTION
clang-tidy gets confused by this if and recommends using emplace_back,
which is not the best idea. Just reduce to a single push_back.

Also add a reserve for efficiency.

Signed-off-by: Rosen Penev <rosenp@gmail.com>