### PR TITLE
Revert "replace find() end() comparisons with count()"

### DIFF
--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -94,7 +94,7 @@ std::shared_ptr<ClientConfig> ClientConfigList::get(size_t id, bool edit)
 
         return list[id];
     }
-    if (indexMap.count(id)) {
+    if (indexMap.find(id) != indexMap.end()) {
         return indexMap[id];
     }
     return nullptr;
@@ -113,7 +113,7 @@ void ClientConfigList::remove(size_t id, bool edit)
         list.erase(list.begin() + id);
         log_debug("ID {} removed!", id);
     } else {
-        if (!indexMap.count(id)) {
+        if (indexMap.find(id) == indexMap.end()) {
             log_debug("No such index ID {}!", id);
             return;
         }

--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -32,7 +32,7 @@
 
 std::shared_ptr<pugi::xml_node> ConfigGenerator::init()
 {
-    if (!generated.count("")) {
+    if (generated.find("") == generated.end()) {
         auto config = doc.append_child("config");
         generated[""] = std::make_shared<pugi::xml_node>(config);
     }
@@ -41,7 +41,7 @@ std::shared_ptr<pugi::xml_node> ConfigGenerator::init()
 
 std::shared_ptr<pugi::xml_node> ConfigGenerator::getNode(const std::string& tag)
 {
-    log_debug("reading '{}' -> {}", tag, !generated.count(tag));
+    log_debug("reading '{}' -> {}", tag, generated.find(tag) == generated.end());
     return generated[tag];
 }
 
@@ -56,7 +56,7 @@ std::shared_ptr<pugi::xml_node> ConfigGenerator::setValue(const std::string& tag
 
         for (auto&& part : split) {
             nodeKey += "/" + part;
-            if (!generated.count(nodeKey)) {
+            if (generated.find(nodeKey) == generated.end()) {
                 if (part.substr(0, ConfigSetup::ATTRIBUTE.size()) == ConfigSetup::ATTRIBUTE) {
                     attribute = part.substr(ConfigSetup::ATTRIBUTE.size()); // last attribute gets the value
                 } else {

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -975,7 +975,7 @@ std::shared_ptr<ConfigSetup> ConfigManager::findConfigSetupByPath(const std::str
         if (attrKey.find_first_of("attribute::") != std::string::npos) {
             attrKey = attrKey.substr(attrKey.find_first_of("attribute::") + 11);
         }
-        co = std::find_if(complexOptions.begin(), complexOptions.end(), [&](auto&& s) { return s->getUniquePath() == attrKey && (!parentOptions.count(s->option) || parentOptions.at(s->option).end() != std::find_if(parentOptions.at(s->option).begin(), parentOptions.at(s->option).end(), [&](auto&& o) { return o == s->option; })); });
+        co = std::find_if(complexOptions.begin(), complexOptions.end(), [&](auto&& s) { return s->getUniquePath() == attrKey && (parentOptions.find(s->option) == parentOptions.end() || parentOptions.at(s->option).end() != std::find(parentOptions.at(s->option).begin(), parentOptions.at(s->option).end(), s->option)); });
 
         if (co != complexOptions.end()) {
             log_debug("Config: attribute option found: '{}'", (*co)->xpath);
@@ -1510,7 +1510,7 @@ void ConfigManager::updateConfigFromDatabase(std::shared_ptr<Database> database)
 
 void ConfigManager::setOrigValue(const std::string& item, const std::string& value)
 {
-    if (!origValues.count(item)) {
+    if (origValues.find(item) == origValues.end()) {
         log_debug("Caching {}='{}'", item, value);
         origValues[item] = value;
     }

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -136,12 +136,12 @@ public:
 
     bool hasOrigValue(const std::string& item) const override
     {
-        return origValues.count(item);
+        return origValues.find(item) != origValues.end();
     }
 
     std::string getOrigValue(const std::string& item) const override
     {
-        return origValues.count(item) ? origValues.at(item) : "";
+        return (origValues.find(item) == origValues.end()) ? "" : origValues.at(item);
     }
 
     void setOrigValue(const std::string& item, const std::string& value) override;

--- a/src/config/config_options.cc
+++ b/src/config/config_options.cc
@@ -64,7 +64,7 @@ void DictionaryOption::setKey(size_t keyIndex, const std::string& newKey)
             option[newKey] = oldValue;
         } else {
             for (size_t i = getEditSize() - 1; i >= origSize; i--) {
-                if (indexMap.count(i) && indexMap[keyIndex].empty()) {
+                if (indexMap.find(i) != indexMap.end() && indexMap[keyIndex].empty()) {
                     option.erase(indexMap[i]);
                 } else {
                     break;
@@ -100,7 +100,7 @@ std::vector<std::string> ArrayOption::getArrayOption(bool forEdit) const
 void ArrayOption::setItem(size_t index, const std::string& value)
 {
     auto editSize = getEditSize();
-    if (indexMap.count(index) && value.empty()) {
+    if (indexMap.find(index) != indexMap.end() && value.empty()) {
         option.erase(option.begin() + indexMap[index]);
         indexMap[index] = std::numeric_limits<std::size_t>::max();
         for (size_t i = index + 1; i < editSize; i++) {
@@ -115,7 +115,7 @@ void ArrayOption::setItem(size_t index, const std::string& value)
                 break;
             }
         }
-    } else if (indexMap.count(index)) {
+    } else if (indexMap.find(index) != indexMap.end()) {
         if (indexMap[index] == std::numeric_limits<std::size_t>::max()) {
             for (size_t i = editSize - 1; i > index; i--) {
                 if (indexMap[i] < std::numeric_limits<std::size_t>::max()) {
@@ -135,7 +135,7 @@ void ArrayOption::setItem(size_t index, const std::string& value)
             }
             option.insert(option.begin() + indexMap[index], value);
         } else {
-            if (!indexMap.count(index) || indexMap[index] == std::numeric_limits<std::size_t>::max() || indexMap[index] >= option.size()) {
+            if (indexMap.find(index) == indexMap.end() || indexMap[index] == std::numeric_limits<std::size_t>::max() || indexMap[index] >= option.size()) {
                 indexMap[index] = option.size();
                 option.push_back(value);
             } else {

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -155,7 +155,7 @@ const std::string_view ConfigSetup::ATTRIBUTE = "attribute::";
 void ConfigStringSetup::makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {
     bool trim = true;
-    if (arguments != nullptr && arguments->count("trim")) {
+    if (arguments != nullptr && arguments->find("trim") != arguments->end()) {
         trim = arguments->at("trim") == "true";
     }
     newOption(getXmlContent(root, trim));
@@ -251,16 +251,16 @@ fs::path ConfigPathSetup::resolvePath(fs::path path) const
 void ConfigPathSetup::loadArguments(const std::map<std::string, std::string>* arguments)
 {
     if (arguments != nullptr) {
-        if (arguments->count("isFile")) {
+        if (arguments->find("isFile") != arguments->end()) {
             isFile = arguments->at("isFile") == "true";
         }
-        if (arguments->count("mustExist")) {
+        if (arguments->find("mustExist") != arguments->end()) {
             mustExist = arguments->at("mustExist") == "true";
         }
-        if (arguments->count("notEmpty")) {
+        if (arguments->find("notEmpty") != arguments->end()) {
             notEmpty = arguments->at("notEmpty") == "true";
         }
-        if (arguments->count("resolveEmpty")) {
+        if (arguments->find("resolveEmpty") != arguments->end()) {
             resolveEmpty = arguments->at("resolveEmpty") == "true";
         }
     }
@@ -581,7 +581,7 @@ bool ConfigArraySetup::updateDetail(const std::string& optItem, std::string& opt
             if (updateItem(i, optItem, config, value, optValue)) {
                 return true;
             }
-            std::string status = arguments != nullptr && arguments->count("status") ? arguments->at("status") : "";
+            std::string status = arguments != nullptr && arguments->find("status") != arguments->end() ? arguments->at("status") : "";
             if (status == STATUS_REMOVED && updateItem(i, optItem, config, value, "", status)) {
                 return true;
             }
@@ -727,7 +727,7 @@ bool ConfigDictionarySetup::createDictionaryFromNode(const pugi::xml_node& optVa
 
 void ConfigDictionarySetup::makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {
-    if (arguments != nullptr && arguments->count("tolower")) {
+    if (arguments != nullptr && arguments->find("tolower") != arguments->end()) {
         tolower = arguments->at("tolower") == "true";
     }
     newOption(getXmlContent(getXmlElement(root)));
@@ -772,7 +772,7 @@ bool ConfigDictionarySetup::updateDetail(const std::string& optItem, std::string
             if (updateItem(i, optItem, config, value, value->getKey(i), optValue)) {
                 return true;
             }
-            std::string status = arguments != nullptr && arguments->count("status") ? arguments->at("status") : "";
+            std::string status = arguments != nullptr && arguments->find("status") != arguments->end() ? arguments->at("status") : "";
             if (status == STATUS_REMOVED) {
                 if (updateItem(i, optItem, config, value, value->getKey(i), "", status)) {
                     return true;
@@ -955,7 +955,7 @@ bool ConfigAutoscanSetup::updateDetail(const std::string& optItem, std::string& 
 
         if (i < std::numeric_limits<std::size_t>::max()) {
             auto entry = list->get(i, true);
-            std::string status = arguments != nullptr && arguments->count("status") ? arguments->at("status") : "";
+            std::string status = arguments != nullptr && arguments->find("status") != arguments->end() ? arguments->at("status") : "";
             if (entry == nullptr && (status == STATUS_ADDED || status == STATUS_MANUAL)) {
                 entry = std::make_shared<AutoscanDirectory>();
                 entry->setScanMode(scanMode);
@@ -984,7 +984,7 @@ bool ConfigAutoscanSetup::updateDetail(const std::string& optItem, std::string& 
 
 void ConfigAutoscanSetup::makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {
-    if (arguments != nullptr && arguments->count("hiddenFiles")) {
+    if (arguments != nullptr && arguments->find("hiddenFiles") != arguments->end()) {
         hiddenFiles = arguments->at("hiddenFiles") == "true";
     }
     newOption(getXmlElement(root));
@@ -1135,7 +1135,7 @@ bool ConfigTranscodingSetup::createTranscodingProfileListFromNode(const pugi::xm
 
     auto tpl = result->getList();
     for (auto&& [key, val] : mt_mappings) {
-        if (!tpl.count(key)) {
+        if (tpl.find(key) == tpl.end()) {
             log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but the profile \"{}\" for mimetype \"{}\" does not exists", val.c_str(), key.c_str());
             if (!findConfigSetup<ConfigBoolSetup>(CFG_TRANSCODING_MIMETYPE_PROF_MAP_ALLOW_UNUSED)->getXmlContent(root)) {
                 return false;
@@ -1147,7 +1147,7 @@ bool ConfigTranscodingSetup::createTranscodingProfileListFromNode(const pugi::xm
 
 void ConfigTranscodingSetup::makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {
-    if (arguments != nullptr && arguments->count("isEnabled")) {
+    if (arguments != nullptr && arguments->find("isEnabled") != arguments->end()) {
         isEnabled = arguments->at("isEnabled") == "true";
     }
     newOption(getXmlElement(root));
@@ -1430,7 +1430,7 @@ bool ConfigClientSetup::createClientConfigListFromNode(const pugi::xml_node& ele
 
 void ConfigClientSetup::makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {
-    if (arguments != nullptr && arguments->count("isEnabled")) {
+    if (arguments != nullptr && arguments->find("isEnabled") != arguments->end()) {
         isEnabled = arguments->at("isEnabled") == "true";
     }
     newOption(getXmlElement(root));
@@ -1487,7 +1487,7 @@ bool ConfigClientSetup::updateDetail(const std::string& optItem, std::string& op
 
         if (index < std::numeric_limits<std::size_t>::max()) {
             auto entry = list->get(index, true);
-            std::string status = arguments != nullptr && arguments->count("status") ? arguments->at("status") : "";
+            std::string status = arguments != nullptr && arguments->find("status") != arguments->end() ? arguments->at("status") : "";
 
             if (entry == nullptr && (status == STATUS_ADDED || status == STATUS_MANUAL)) {
                 entry = std::make_shared<ClientConfig>();
@@ -1715,7 +1715,7 @@ bool ConfigDirectorySetup::updateDetail(const std::string& optItem, std::string&
 
         if (index < std::numeric_limits<std::size_t>::max()) {
             auto entry = list->get(index, true);
-            std::string status = arguments != nullptr && arguments->count("status") ? arguments->at("status") : "";
+            std::string status = arguments != nullptr && arguments->find("status") != arguments->end() ? arguments->at("status") : "";
 
             if (entry == nullptr && (status == STATUS_ADDED || status == STATUS_MANUAL)) {
                 entry = std::make_shared<DirectoryTweak>();

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -244,7 +244,7 @@ public:
 
     void makeOption(const pugi::xml_node& root, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments = nullptr) override
     {
-        if (arguments != nullptr && arguments->count("notEmpty")) {
+        if (arguments != nullptr && arguments->find("notEmpty") != arguments->end()) {
             notEmpty = arguments->find("notEmpty")->second == "true";
         }
         newOption(ConfigSetup::getXmlContent(root, true));
@@ -253,7 +253,7 @@ public:
 
     bool checkEnumValue(const std::string& value, En& result) const
     {
-        if (valueMap.count(value)) {
+        if (valueMap.find(value) != valueMap.end()) {
             result = valueMap.at(value);
             return true;
         }

--- a/src/config/directory_tweak.cc
+++ b/src/config/directory_tweak.cc
@@ -94,7 +94,7 @@ std::shared_ptr<DirectoryTweak> DirectoryConfigList::get(size_t id, bool edit)
 
         return list[id];
     }
-    if (indexMap.count(id)) {
+    if (indexMap.find(id) != indexMap.end()) {
         return indexMap[id];
     }
     return nullptr;
@@ -126,7 +126,7 @@ void DirectoryConfigList::remove(size_t id, bool edit)
         list.erase(list.begin() + id);
         log_debug("ID {} removed!", id);
     } else {
-        if (!indexMap.count(id)) {
+        if (indexMap.find(id) == indexMap.end()) {
             log_debug("No such index ID {}!", id);
             return;
         }

--- a/src/config/directory_tweak.h
+++ b/src/config/directory_tweak.h
@@ -108,35 +108,35 @@ public:
     bool getOrig() const { return isOrig; }
 
     void setRecursive(bool recursive) { this->flags["Recursive"] = recursive; }
-    bool hasRecursive() const { return flags.count("Recursive"); }
+    bool hasRecursive() const { return flags.find("Recursive") != flags.end(); }
     bool getRecursive() const { return flags.at("Recursive"); }
 
     void setHidden(bool hidden) { this->flags["Hidden"] = hidden; }
-    bool hasHidden() const { return flags.count("Hidden"); }
+    bool hasHidden() const { return flags.find("Hidden") != flags.end(); }
     bool getHidden() const { return flags.at("Hidden"); }
 
     void setCaseSensitive(bool caseSensitive) { this->flags["CaseSens"] = caseSensitive; }
-    bool hasCaseSensitive() const { return flags.count("CaseSens"); }
+    bool hasCaseSensitive() const { return flags.find("CaseSens") != flags.end(); }
     bool getCaseSensitive() const { return flags.at("CaseSens"); }
 
     void setFollowSymlinks(bool followSymlinks) { this->flags["FollowSymlinks"] = followSymlinks; }
-    bool hasFollowSymlinks() const { return flags.count("FollowSymlinks"); }
+    bool hasFollowSymlinks() const { return flags.find("FollowSymlinks") != flags.end(); }
     bool getFollowSymlinks() const { return flags.at("FollowSymlinks"); }
 
     void setMetaCharset(const std::string& metaCharset) { this->resourceFiles["MetaCharset"] = metaCharset; }
-    bool hasMetaCharset() const { return resourceFiles.count("MetaCharset"); }
+    bool hasMetaCharset() const { return resourceFiles.find("MetaCharset") != resourceFiles.end(); }
     std::string getMetaCharset() const { return resourceFiles.at("MetaCharset"); }
 
     void setFanArtFile(const std::string& fanArtFile) { this->resourceFiles["FanArt"] = fanArtFile; }
-    bool hasFanArtFile() const { return resourceFiles.count("FanArt"); }
+    bool hasFanArtFile() const { return resourceFiles.find("FanArt") != resourceFiles.end(); }
     std::string getFanArtFile() const { return resourceFiles.at("FanArt"); }
 
     void setSubTitleFile(const std::string& subTitleFile) { this->resourceFiles["SubTitle"] = subTitleFile; }
-    bool hasSubTitleFile() const { return resourceFiles.count("SubTitle"); }
+    bool hasSubTitleFile() const { return resourceFiles.find("SubTitle") != resourceFiles.end(); }
     std::string getSubTitleFile() const { return resourceFiles.at("SubTitle"); }
 
     void setResourceFile(const std::string& resourceFile) { this->resourceFiles["Resource"] = resourceFile; }
-    bool hasResourceFile() const { return resourceFiles.count("Resource"); }
+    bool hasResourceFile() const { return resourceFiles.find("Resource") != resourceFiles.end(); }
     std::string getResourceFile() const { return resourceFiles.at("Resource"); }
 
 protected:

--- a/src/content/autoscan_list.cc
+++ b/src/content/autoscan_list.cc
@@ -100,7 +100,7 @@ std::shared_ptr<AutoscanDirectory> AutoscanList::get(size_t id, bool edit)
 
         return list[id];
     }
-    if (indexMap.count(id)) {
+    if (indexMap.find(id) != indexMap.end()) {
         return indexMap[id];
     }
     return nullptr;
@@ -137,7 +137,7 @@ void AutoscanList::remove(size_t id, bool edit)
         list.erase(list.begin() + id);
         log_debug("ID {} removed!", id);
     } else {
-        if (!indexMap.count(id)) {
+        if (indexMap.find(id) == indexMap.end()) {
             log_debug("No such index ID {}!", id);
             return;
         }

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1096,7 +1096,7 @@ std::pair<int, bool> ContentManager::addContainerTree(const std::vector<std::sha
         for (auto&& [key, val] : config->getDictionaryOption(CFG_IMPORT_LAYOUT_MAPPING)) {
             tree = std::regex_replace(tree, std::regex(key), val);
         }
-        if (!containerMap.count(tree)) {
+        if (containerMap.find(tree) == containerMap.end()) {
             item->setMetadata(M_TITLE, item->getTitle());
             database->addContainerChain(tree, item->getClass(), INVALID_OBJECT_ID, &result, createdIds, item->getMetadata());
             auto container = std::dynamic_pointer_cast<CdsContainer>(database->loadObject(result));
@@ -1146,7 +1146,7 @@ std::pair<int, bool> ContentManager::addContainerChain(const std::string& chain,
     }
     int containerID = INVALID_OBJECT_ID;
     std::vector<std::shared_ptr<CdsContainer>> containerList;
-    if (!containerMap.count(newChain)) {
+    if (containerMap.find(newChain) == containerMap.end()) {
         lastMetadata[MetadataHandler::getMetaFieldName(M_TITLE)] = splitString(newChain, '/').back();
         database->addContainerChain(newChain, lastClass, lastRefID, &containerID, updateID, lastMetadata);
 

--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -515,7 +515,7 @@ const static std::map<std::string, std::string> logicOperator = {
 std::pair<std::string, std::string> DefaultSQLEmitter::getPropertyStatement(const std::string& property) const
 {
     if (property[0] == '@' || property.substr(0, 3) == "res") {
-        if (propertyStatement.count(property) && propertyLowerStatement.count(property)) {
+        if (propertyStatement.find(property) != propertyStatement.end() && propertyLowerStatement.find(property) != propertyLowerStatement.end()) {
             return {
                 fmt::format(propertyStatement.at(property), tabQuote, metaAlias, tableAlias, property),
                 fmt::format(propertyLowerStatement.at(property), tabQuote, metaAlias, tableAlias, property)
@@ -544,7 +544,7 @@ std::string DefaultSQLEmitter::emit(const ASTCompareOperator* node, const std::s
 std::string DefaultSQLEmitter::emit(const ASTStringOperator* node, const std::string& property, const std::string& value) const
 {
     auto stringOperator = aslowercase(node->getValue());
-    if (!logicOperator.count(stringOperator)) {
+    if (logicOperator.find(stringOperator) == logicOperator.end()) {
         throw_std_runtime_error("Operation '{}' not yet supported", stringOperator);
     }
     auto prpStmnt = getPropertyStatement(property);

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -2214,14 +2214,14 @@ void SQLDatabase::generateMetadataDBOperations(const std::shared_ptr<CdsObject>&
         // get current metadata from DB: if only it really was a dictionary...
         auto dbMetadata = retrieveMetadataForObject(obj->getID());
         for (auto&& [key, val] : dict) {
-            Operation operation = dbMetadata.count(key) ? Operation::Update : Operation::Insert;
+            Operation operation = dbMetadata.find(key) == dbMetadata.end() ? Operation::Insert : Operation::Update;
             std::map<std::string, std::string> metadataSql;
             metadataSql["property_name"] = quote(key);
             metadataSql["property_value"] = quote(val);
             operations.push_back(std::make_shared<AddUpdateTable>(METADATA_TABLE, metadataSql, operation));
         }
         for (auto&& [key, val] : dbMetadata) {
-            if (!dict.count(key)) {
+            if (dict.find(key) == dict.end()) {
                 // key in db metadata but not obj metadata, so needs a delete
                 std::map<std::string, std::string> metadataSql;
                 metadataSql["property_name"] = quote(key);

--- a/src/web/directories.cc
+++ b/src/web/directories.cc
@@ -78,9 +78,9 @@ void web::directories::process()
 
         if (!it.is_directory(ec))
             continue;
-        if (std::count(excludes_fullpath.begin(), excludes_fullpath.end(), filepath))
+        if (std::find(excludes_fullpath.begin(), excludes_fullpath.end(), filepath) != excludes_fullpath.end())
             continue;
-        if (std::count(excludes_dirname.begin(), excludes_dirname.end(), filepath.filename())
+        if (std::find(excludes_dirname.begin(), excludes_dirname.end(), filepath.filename()) != excludes_dirname.end()
             || (exclude_config_dirs && startswith(filepath.filename(), ".")))
             continue;
 


### PR DESCRIPTION
find() is faster than count as the loop is broken once an item is
encountered. Since all of these are used in boolean context, just revert
to doing find.

Also removed a lambda from a really long find_if.

Signed-off-by: Rosen Penev <rosenp@gmail.com>