### PR TITLE
Concatenate multivalue field with entrySeparator

### DIFF
--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -445,7 +445,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
                 const auto textFrame = dynamic_cast<const TagLib::ID3v2::TextIdentificationFrame*>(frame);
                 if (textFrame == nullptr)
                     continue;
-                TagLib::String frameContents = textFrame->toString();
+                TagLib::String frameContents = textFrame->fieldList().toString(entrySeparator);
                 if (!value.empty())
                     value += entrySeparator;
                 if (!legacyEntrySeparator.empty())
@@ -466,12 +466,21 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
                 const auto textFrame = dynamic_cast<const TagLib::ID3v2::TextIdentificationFrame*>(frame);
                 if (textFrame == nullptr)
                     continue;
-                const TagLib::String frameContents = textFrame->toString();
-                std::string value(frameContents.toCString(true));
-
-                size_t subTagEnd = value.find(']');
-                std::string subTag = value.substr(1, subTagEnd - 1); // Cut out brackets
-                std::string content = value.substr(subTagEnd + 2); // Skip bracket and space
+                std::string content = "";
+                std::string subTag = "";
+                TagLib::StringList fieldList = textFrame->fieldList();
+                for(TagLib::StringList::ConstIterator idx = fieldList.begin(); idx != fieldList.end(); ++idx) {
+                    if (idx == fieldList.begin()){
+                        // first element is subTag name
+                        subTag = (*idx).toCString(true);
+                    } else {
+                        content += (*idx).toCString(true) + entrySeparator;
+                    }
+                }
+        
+                // remove entrySeparator at the end again
+                if (content.length() - entrySeparator.length() > 0)
+                    content = content.substr(0, content.length() - entrySeparator.length());
                 // log_debug("TXXX Tag: {}", subTag.c_str());
 
                 if (desiredSubTag == subTag) {

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -468,18 +468,17 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
                     continue;
                 std::string content = "";
                 std::string subTag = "";
-                TagLib::StringList fieldList = textFrame->fieldList();
-                for(TagLib::StringList::ConstIterator idx = fieldList.begin(); idx != fieldList.end(); ++idx) {
-                    if (idx == fieldList.begin()){
+                for (auto&& item : textFrame->fieldList()) {
+                    if (content.empty()) {
                         // first element is subTag name
-                        subTag = (*idx).toCString(true);
+                        subTag = item.toCString(true);
                     } else {
-                        content += (*idx).toCString(true) + entrySeparator;
+                        content = fmt::format("{}{}{}", content, item.toCString(true), entrySeparator);
                     }
                 }
-        
+
                 // remove entrySeparator at the end again
-                if (content.length() - entrySeparator.length() > 0)
+                if (content.length() > entrySeparator.length())
                     content = content.substr(0, content.length() - entrySeparator.length());
                 // log_debug("TXXX Tag: {}", subTag.c_str());
 

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -468,12 +468,12 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
                     continue;
                 std::string content = "";
                 std::string subTag = "";
-                for (auto&& item : textFrame->fieldList()) {
-                    if (content.empty()) {
+                for (auto&& field : textFrame->fieldList()) {
+                    if (subTag.empty()) {
                         // first element is subTag name
-                        subTag = item.toCString(true);
+                        subTag = field.toCString(true);
                     } else {
-                        content = fmt::format("{}{}{}", content, item.toCString(true), entrySeparator);
+                        content = fmt::format("{}{}{}", content, field.toCString(true), entrySeparator);
                     }
                 }
 


### PR DESCRIPTION
Fix: Concatenate multivalue field with entrySeparator and not space

In ID3v2.4 tags multiple values are allowed (see also #1425).
These values are stored as null separated list in the mp3 file tag.
If taglib is called with textFrame->toString() the multiple values are concatenated with a space.
To concatenate these values with the defined entrySeparater this call is changed to textFrame->fieldList().toString(entrySeparator).

For TXXX tags the first element in the fieldList is the subtag name and extracted separately. The other entries are concatenated with the entrySeparator.

Note: Unfortunately I'm not an C++ programmer, so please revise and correct my code if not optimal. Also I just did only a limited test depth regarding mp3 files and taglib versions.