### PR TITLE
Synchronize threads properly

### DIFF
--- a/src/content/onlineservice/task_processor.cc
+++ b/src/content/onlineservice/task_processor.cc
@@ -39,6 +39,9 @@ void TaskProcessor::run()
 {
     threadRunner = std::make_unique<StdThreadRunner>("TaskProcessorThread", TaskProcessor::staticThreadProc, this, config);
 
+    // wait for thread to become ready
+    threadRunner->waitForReady();
+
     if (!threadRunner->isAlive())
         throw_std_runtime_error("Failed to task processor thread");
 }
@@ -60,8 +63,12 @@ void* TaskProcessor::staticThreadProc(void* arg)
 
 void TaskProcessor::threadProc()
 {
+    StdThreadRunner::waitFor("TaskProcessor", [this] { return threadRunner != nullptr; });
+
     std::shared_ptr<GenericTask> task;
-    auto lock = threadRunner->uniqueLock();
+    auto lock = threadRunner->uniqueLockS("threadProc");
+    // tell run() that we are ready
+    threadRunner->setReady();
     working = true;
 
     while (!shutdownFlag) {

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -73,6 +73,8 @@ public:
 
     virtual ~SLTask() = default;
 
+    virtual std::string_view taskType() const = 0;
+
 protected:
     /// \brief true as long as the task is not finished
     ///
@@ -98,6 +100,8 @@ public:
     explicit SLInitTask(std::shared_ptr<Config> config);
     void run(sqlite3** db, Sqlite3Database* sl) override;
 
+    std::string_view taskType() const override { return "InitTask"; }
+
 protected:
     std::shared_ptr<Config> config;
 };
@@ -110,6 +114,8 @@ public:
     explicit SLSelectTask(const char* query);
     void run(sqlite3** db, Sqlite3Database* sl) override;
     [[nodiscard]] std::shared_ptr<SQLResult> getResult() const { return std::static_pointer_cast<SQLResult>(pres); }
+
+    std::string_view taskType() const override { return "SelectTask"; }
 
 protected:
     /// \brief The SQL query string
@@ -127,6 +133,8 @@ public:
     void run(sqlite3** db, Sqlite3Database* sl) override;
     int getLastInsertId() const { return lastInsertId; }
 
+    std::string_view taskType() const override { return "ExecTask"; }
+
 protected:
     /// \brief The SQL query string
     const char* query;
@@ -141,6 +149,8 @@ public:
     /// \brief Constructor for the sqlite3 backup task
     SLBackupTask(std::shared_ptr<Config> config, bool restore);
     void run(sqlite3** db, Sqlite3Database* sl) override;
+
+    std::string_view taskType() const override { return "BackupTask"; }
 
 protected:
     std::shared_ptr<Config> config;

--- a/src/main.cc
+++ b/src/main.cc
@@ -101,6 +101,10 @@ static void signalHandler(int signum)
         return;
     }
 
+    if (signum == SIGSEGV) {
+        log_error("This should never happen {}:{}, killing Gerbera!", errno, std::strerror(errno));
+        exit(EXIT_FAILURE);
+    }
     if ((signum == SIGINT) || (signum == SIGTERM)) {
         _ctx.shutdown_flag++;
         if (_ctx.shutdown_flag == 1) {
@@ -126,6 +130,10 @@ static void installSignalHandler()
     action.sa_handler = signalHandler;
     action.sa_flags = 0;
     sigfillset(&action.sa_mask);
+    if (sigaction(SIGSEGV, &action, nullptr) < 0) {
+        log_error("Could not register SIGSEGV handler!");
+    }
+
     if (sigaction(SIGINT, &action, nullptr) < 0) {
         log_error("Could not register SIGINT handler!");
     }

--- a/src/server.cc
+++ b/src/server.cc
@@ -97,11 +97,19 @@ void Server::run()
 {
     log_debug("Starting...");
 
+    // run what is needed
+    try {
+        content->run();
+    } catch (const std::runtime_error& ex) {
+        log_error("Activating ContentService failed {}", ex.what());
+        throw UpnpException(500, fmt::format("run: Activating ContentService failed {}", ex.what()));
+    }
+
     std::string iface = config->getOption(CFG_SERVER_NETWORK_INTERFACE);
-    std::string ip = config->getOption(CFG_SERVER_IP);
+    ip = config->getOption(CFG_SERVER_IP);
 
     if (!ip.empty() && !iface.empty())
-        throw_std_runtime_error("You can not specify interface and IP at the same time");
+        throw_std_runtime_error("You cannot specify interface {} and IP {} at the same time", iface, ip);
 
     if (iface.empty())
         iface = ipToInterface(ip);
@@ -109,47 +117,20 @@ void Server::run()
     if (!ip.empty() && iface.empty())
         throw_std_runtime_error("Could not find IP: {}", ip.c_str());
 
-    auto port = in_port_t(config->getIntOption(CFG_SERVER_PORT));
-
-    log_info("Initialising libupnp with interface: {}, port: {}", iface.empty() ? "<unset>" : iface, port == 0 ? "<unset>" : fmt::to_string(port));
-    const char* IfName = iface.empty() ? nullptr : iface.c_str();
-
-    int ret = UPNP_E_INIT_FAILED;
-    for (int attempt = 0; ret != UPNP_E_SUCCESS; attempt++) {
-        ret = UpnpInit2(IfName, port);
-        if (ret != UPNP_E_SUCCESS) {
-            if (attempt > 3) {
-                throw UpnpException(ret, "UpnpInit failed");
-            }
-#ifdef UPNP_HAVE_TOOLS
-            log_warning("UPnP Init failed: {} ({}). Retrying in {} seconds...", UpnpGetErrorMessage(ret), ret, attempt + 1);
-#else
-            log_warning("UPnP Init failed: ({}). Retrying in {} seconds...", ret, attempt + 1);
-#endif
-            std::this_thread::sleep_for(std::chrono::seconds(attempt + 1));
-        }
+    // check webroot directory
+    std::string web_root = config->getOption(CFG_SERVER_WEBROOT);
+    if (web_root.empty()) {
+        throw_std_runtime_error("Invalid web server root directory {}", web_root);
     }
 
-    port = UpnpGetServerPort();
-    /* The IP libupnp picks is not always the same as passed into config, as we map it to an interface */
-    ip = UpnpGetServerIpAddress();
-
-    log_info("IPv4: Server bound to: {}:{}", ip, port);
-    log_info("IPv6: Server bound to: {}:{}", UpnpGetServerIp6Address(), UpnpGetServerPort6());
-    log_info("IPv6 ULA/GLA: Server bound to: {}:{}", UpnpGetServerUlaGuaIp6Address(), UpnpGetServerUlaGuaPort6());
-
-    virtualUrl = fmt::format("http://{}:{}/{}", ip, port, virtual_directory);
-
-    // next set webroot directory
-    std::string web_root = config->getOption(CFG_SERVER_WEBROOT);
-
-    if (web_root.empty()) {
-        throw_std_runtime_error("Invalid web server root directory");
+    auto ret = startupInterface(iface, in_port_t(config->getIntOption(CFG_SERVER_PORT)));
+    if (ret != UPNP_E_SUCCESS) {
+        throw UpnpException(ret, fmt::format("run: UpnpInit failed {} {}", iface, port));
     }
 
     ret = UpnpSetWebServerRootDir(web_root.c_str());
     if (ret != UPNP_E_SUCCESS) {
-        throw UpnpException(ret, "UpnpSetWebServerRootDir failed");
+        throw UpnpException(ret, fmt::format("run: UpnpSetWebServerRootDir failed {}", web_root));
     }
 
     log_debug("webroot: {}", web_root.c_str());
@@ -157,26 +138,16 @@ void Server::run()
     log_debug("Setting virtual dir to: {}", virtual_directory.c_str());
     ret = UpnpAddVirtualDir(virtual_directory.c_str(), this, nullptr);
     if (ret != UPNP_E_SUCCESS) {
-        throw UpnpException(ret, "UpnpAddVirtualDir failed");
+        throw UpnpException(ret, fmt::format("run: UpnpAddVirtualDir failed {}", virtual_directory));
     }
 
     ret = registerVirtualDirCallbacks();
 
     if (ret != UPNP_E_SUCCESS) {
-        throw UpnpException(ret, "UpnpSetVirtualDirCallbacks failed");
+        throw UpnpException(ret, "run: UpnpSetVirtualDirCallbacks failed");
     }
 
-    std::string presentationURL = config->getOption(CFG_SERVER_PRESENTATION_URL);
-    if (presentationURL.empty()) {
-        presentationURL = fmt::format("http://{}:{}/", ip, port);
-    } else {
-        std::string appendto = config->getOption(CFG_SERVER_APPEND_PRESENTATION_URL_TO);
-        if (appendto == "ip") {
-            presentationURL = fmt::format("http://{}:{}", ip, presentationURL);
-        } else if (appendto == "port") {
-            presentationURL = fmt::format("http://{}:{}/{}", ip, port, presentationURL);
-        } // else appendto is none and we take the URL as it entered by user
-    }
+    std::string presentationURL = getPresentationUrl();
 
     log_debug("Creating UpnpXMLBuilder");
     xmlbuilder = std::make_unique<UpnpXMLBuilder>(context, virtualUrl, presentationURL);
@@ -224,11 +195,8 @@ void Server::run()
     log_debug("Sending UPnP Alive advertisements every {} seconds", (aliveAdvertisementInterval / 2) - 30);
     ret = UpnpSendAdvertisement(rootDeviceHandle, aliveAdvertisementInterval);
     if (ret != UPNP_E_SUCCESS) {
-        throw UpnpException(ret, "run: UpnpSendAdvertisement failed");
+        throw UpnpException(ret, fmt::format("run: UpnpSendAdvertisement {} failed", aliveAdvertisementInterval));
     }
-
-    // run what is needed
-    content->run();
 
     std::string url = config->getOption(CFG_VIRTUAL_URL);
     if (url.empty()) {
@@ -239,6 +207,57 @@ void Server::run()
     }
     writeBookmark(url);
     log_info("The Web UI can be reached by following this link: {}/", url);
+}
+
+int Server::startupInterface(std::string iface, in_port_t inPort)
+{
+    log_info("Initialising UPnP with interface: {}, port: {}",
+        iface.empty() ? "<unset>" : iface, inPort == 0 ? "<unset>" : fmt::to_string(inPort));
+    const char* ifName = iface.empty() ? nullptr : iface.c_str();
+
+    int ret = UPNP_E_INIT_FAILED;
+    for (int attempt = 0; ret != UPNP_E_SUCCESS; attempt++) {
+        ret = UpnpInit2(ifName, inPort);
+        if (ret != UPNP_E_SUCCESS) {
+            if (attempt > 3) {
+                throw UpnpException(ret, fmt::format("run: UpnpInit failed with {} {}", ifName, inPort));
+            }
+#ifdef UPNP_HAVE_TOOLS
+            log_warning("UPnP Init {}:{} failed: {} ({}). Retrying in {} seconds...", ifName, inPort, UpnpGetErrorMessage(ret), ret, attempt + 1);
+#else
+            log_warning("UPnP Init {}:{} failed: ({}). Retrying in {} seconds...", ifName, inPort, ret, attempt + 1);
+#endif
+            std::this_thread::sleep_for(std::chrono::seconds(attempt + 1));
+        }
+    }
+
+    port = UpnpGetServerPort();
+    /* The IP libupnp picks is not always the same as passed into config, as we map it to an interface */
+    ip = UpnpGetServerIpAddress();
+
+    log_info("IPv4: Server bound to: {}:{}", ip, port);
+    log_info("IPv6: Server bound to: {}:{}", UpnpGetServerIp6Address(), UpnpGetServerPort6());
+    log_info("IPv6 ULA/GLA: Server bound to: {}:{}", UpnpGetServerUlaGuaIp6Address(), UpnpGetServerUlaGuaPort6());
+
+    virtualUrl = fmt::format("http://{}:{}/{}", ip, port, virtual_directory);
+
+    return ret;
+}
+
+std::string Server::getPresentationUrl()
+{
+    std::string presentationURL = config->getOption(CFG_SERVER_PRESENTATION_URL);
+    if (presentationURL.empty()) {
+        presentationURL = fmt::format("http://{}:{}/", ip, port);
+    } else {
+        std::string appendto = config->getOption(CFG_SERVER_APPEND_PRESENTATION_URL_TO);
+        if (appendto == "ip") {
+            presentationURL = fmt::format("http://{}:{}", ip, presentationURL);
+        } else if (appendto == "port") {
+            presentationURL = fmt::format("http://{}:{}/{}", ip, port, presentationURL);
+        } // else appendto is none and we take the URL as it entered by user
+    }
+    return presentationURL;
 }
 
 void Server::writeBookmark(const std::string& addr)
@@ -485,9 +504,9 @@ std::unique_ptr<RequestHandler> Server::createRequestHandler(const char* filenam
 
     std::unique_ptr<RequestHandler> ret = nullptr;
 
-    if (startswith(link, std::string("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_MEDIA_HANDLER)) {
+    if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, CONTENT_MEDIA_HANDLER))) {
         ret = std::make_unique<FileRequestHandler>(content, xmlbuilder.get());
-    } else if (startswith(link, std::string("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_UI_HANDLER)) {
+    } else if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, CONTENT_UI_HANDLER))) {
         std::string parameters;
         std::string path;
         RequestHandler::splitUrl(filename, URL_UI_PARAM_SEPARATOR, path, parameters);
@@ -499,9 +518,9 @@ std::unique_ptr<RequestHandler> Server::createRequestHandler(const char* filenam
         std::string r_type = it != params.end() && !it->second.empty() ? it->second : "index";
 
         ret = web::createWebRequestHandler(content, r_type);
-    } else if (startswith(link, std::string("/") + SERVER_VIRTUAL_DIR + "/" + DEVICE_DESCRIPTION_PATH)) {
+    } else if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, DEVICE_DESCRIPTION_PATH))) {
         ret = std::make_unique<DeviceDescriptionHandler>(content, xmlbuilder.get());
-    } else if (startswith(link, std::string("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_SERVE_HANDLER)) {
+    } else if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, CONTENT_SERVE_HANDLER))) {
         if (config->getOption(CFG_SERVER_SERVEDIR).empty())
             throw_std_runtime_error("Serving directories is not enabled in configuration");
 
@@ -509,7 +528,7 @@ std::unique_ptr<RequestHandler> Server::createRequestHandler(const char* filenam
     }
 
 #if defined(HAVE_CURL)
-    else if (startswith(link, std::string("/") + SERVER_VIRTUAL_DIR + "/" + CONTENT_ONLINE_HANDLER)) {
+    else if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, CONTENT_ONLINE_HANDLER))) {
         ret = std::make_unique<URLRequestHandler>(content);
     }
 #endif

--- a/src/server.h
+++ b/src/server.h
@@ -101,6 +101,9 @@ protected:
     std::shared_ptr<Timer> timer;
     std::shared_ptr<ContentManager> content;
 
+    std::string ip;
+    in_port_t port;
+
     /// \brief This flag is set to true by the upnp_cleanup() function.
     bool server_shutdown_flag;
 
@@ -227,6 +230,9 @@ protected:
     /// instance
     void writeBookmark(const std::string& addr);
     void emptyBookmark();
+
+    std::string getPresentationUrl();
+    int startupInterface(std::string iface, in_port_t port);
 };
 
 #endif // __SERVER_H__

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -310,7 +310,7 @@ void ContentDirectoryService::processSubscriptionRequest(const std::unique_ptr<S
     property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     auto obj = database->loadObject(0);
     auto cont = std::static_pointer_cast<CdsContainer>(obj);
-    property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(fmt::format("0,{}", +cont->getUpdateID()).c_str());
+    property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(fmt::format("0,{}", cont->getUpdateID()).c_str());
 
     std::ostringstream buf;
     propset->print(buf, "", 0);


### PR DESCRIPTION
Depending on startup order either `threadRunner` property may be uninitialized
or lock was released before thread blocked on condition.

I hope the witch hunt is over and my random crashes on startup are gone. 

fixes #1405 