### PR TITLE
add support for Cygwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,14 @@ set(STATIC_LIBUPNP 0 CACHE BOOL "Link to libupnp statically")
 # Leverage a modern C++
 # Set defaults here before we create targets
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-set(CMAKE_CXX_EXTENSIONS NO)
+# Cygwin requires extensions for a lot of the networking stuff.
+if(CYGWIN)
+	set(CMAKE_CXX_STANDARD_REQUIRED NO)
+	set(CMAKE_CXX_EXTENSIONS YES)
+else(CYGWIN)
+	set(CMAKE_CXX_STANDARD_REQUIRED YES)
+	set(CMAKE_CXX_EXTENSIONS NO)
+endif(CYGWIN)
 
 add_library(libgerbera STATIC
         src/action_request.cc

--- a/src/main.cc
+++ b/src/main.cc
@@ -262,7 +262,7 @@ int main(int argc, char** argv, char** envp)
 // mac os x does this differently, setgid and setuid are basically doing the same
 // as setresuid and setresgid on linux: setting all of real{u,g}id, effective{u,g}id and saved-set{u,g}id
 // Solaroid systems are likewise missing setresgid and setresuid
-#if defined(__APPLE__) || defined(SOLARIS)
+#if defined(__APPLE__) || defined(SOLARIS) || defined(__CYGWIN__)
             // set group-ids, then add. groups, last user-ids, all need to succeed
             if (0 != setgid(user_id->pw_gid) || 0 != initgroups(user_id->pw_name, user_id->pw_gid) || 0 != setuid(user_id->pw_uid)) {
 #else


### PR DESCRIPTION
std needs the GNU variants for kill(), a bunch of netdb.h stuff, fo
functions, and maybe some others.

Signed-off-by: Rosen Penev <rosenp@gmail.com>