### PR TITLE
clang: add missing moves

### DIFF
--- a/src/cds_objects.cc
+++ b/src/cds_objects.cc
@@ -115,18 +115,19 @@ void CdsObject::validate()
 
 std::shared_ptr<CdsObject> CdsObject::createObject(unsigned int objectType)
 {
-    std::shared_ptr<CdsObject> obj;
-
     if (IS_CDS_CONTAINER(objectType)) {
-        obj = std::make_shared<CdsContainer>();
-    } else if (IS_CDS_ITEM_EXTERNAL_URL(objectType)) {
-        obj = std::make_shared<CdsItemExternalURL>();
-    } else if (IS_CDS_ITEM(objectType)) {
-        obj = std::make_shared<CdsItem>();
-    } else {
-        throw_std_runtime_error("invalid object type: {}", objectType);
+        return std::make_shared<CdsContainer>();
     }
-    return obj;
+
+    if (IS_CDS_ITEM_EXTERNAL_URL(objectType)) {
+        return std::make_shared<CdsItemExternalURL>();
+    }
+
+    if (IS_CDS_ITEM(objectType)) {
+        return std::make_shared<CdsItem>();
+    }
+
+    throw_std_runtime_error("invalid object type: {}", objectType);
 }
 
 /* CdsItem */

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -990,7 +990,7 @@ void ConfigAutoscanSetup::makeOption(const pugi::xml_node& root, const std::shar
 
 std::shared_ptr<ConfigOption> ConfigAutoscanSetup::newOption(const pugi::xml_node& optValue)
 {
-    std::shared_ptr<AutoscanList> result = std::make_shared<AutoscanList>(nullptr);
+    auto result = std::make_shared<AutoscanList>(nullptr);
     if (!createAutoscanListFromNode(optValue, result)) {
         throw_std_runtime_error("Init {} autoscan failed '{}'", xpath, optValue);
     }
@@ -1387,7 +1387,7 @@ bool ConfigTranscodingSetup::updateDetail(const std::string& optItem, std::strin
 
 std::shared_ptr<ConfigOption> ConfigTranscodingSetup::newOption(const pugi::xml_node& optValue)
 {
-    std::shared_ptr<TranscodingProfileList> result = std::make_shared<TranscodingProfileList>();
+    auto result = std::make_shared<TranscodingProfileList>();
 
     if (!createTranscodingProfileListFromNode(isEnabled ? optValue : pugi::xml_node(nullptr), result)) {
         throw_std_runtime_error("Init {} transcoding failed '{}'", xpath, optValue);
@@ -1513,7 +1513,7 @@ bool ConfigClientSetup::updateDetail(const std::string& optItem, std::string& op
 
 std::shared_ptr<ConfigOption> ConfigClientSetup::newOption(const pugi::xml_node& optValue)
 {
-    std::shared_ptr<ClientConfigList> result = std::make_shared<ClientConfigList>();
+    auto result = std::make_shared<ClientConfigList>();
 
     if (!createClientConfigListFromNode(isEnabled ? optValue : pugi::xml_node(nullptr), result)) {
         throw_std_runtime_error("Init {} client config failed '{}'", xpath, optValue);
@@ -1741,7 +1741,7 @@ bool ConfigDirectorySetup::updateDetail(const std::string& optItem, std::string&
 
 std::shared_ptr<ConfigOption> ConfigDirectorySetup::newOption(const pugi::xml_node& optValue)
 {
-    std::shared_ptr<DirectoryConfigList> result = std::make_shared<DirectoryConfigList>();
+    auto result = std::make_shared<DirectoryConfigList>();
 
     if (!createDirectoryTweakListFromNode(optValue, result)) {
         throw_std_runtime_error("Init {} DirectoryConfigList failed '{}'", xpath, optValue);

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1300,8 +1300,7 @@ std::shared_ptr<CdsObject> ContentManager::createObjectFromFile(const fs::direct
 
         MetadataHandler::setMetadata(context, item, dirEnt);
     } else if (dirEnt.is_directory(ec)) {
-        auto cont = std::make_shared<CdsContainer>();
-        obj = cont;
+        obj = std::make_shared<CdsContainer>();
         /* adding containers is done by Database now
          * this exists only to inform the caller that
          * this is a container

--- a/src/content/onlineservice/atrailers_content_handler.cc
+++ b/src/content/onlineservice/atrailers_content_handler.cc
@@ -222,7 +222,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
     item->setFlag(OBJECT_FLAG_ONLINE_SERVICE);
     try {
         item->validate();
-        return item;
+        return std::move(item);
     } catch (const std::runtime_error& ex) {
         log_warning("Failed to validate newly created Trailer item: {}",
             ex.what());

--- a/src/content/onlineservice/sopcast_content_handler.cc
+++ b/src/content/onlineservice/sopcast_content_handler.cc
@@ -209,7 +209,7 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& g
 
     try {
         item->validate();
-        return item;
+        return std::move(item);
     } catch (const std::runtime_error& ex) {
         log_warning("Failed to validate newly created SopCast item: {}",
             ex.what());

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -516,7 +516,7 @@ std::shared_ptr<CdsObject> Script::dukObject2cdsObject(const std::shared_ptr<Cds
                     resCount = stoiString(sym);
                     i = getIntProperty(sym, -1);
                     if (i >= 0) {
-                        std::shared_ptr<CdsResource> res = std::make_shared<CdsResource>(i);
+                        auto res = std::make_shared<CdsResource>(i);
                         obj->addResource(res);
                     }
                 }

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -427,8 +427,7 @@ std::unique_ptr<SQLRow> MysqlResult::nextRow()
     MYSQL_ROW mysql_row;
     mysql_row = mysql_fetch_row(mysql_res);
     if (mysql_row) {
-        auto p = std::make_unique<MysqlRow>(mysql_row);
-        return p;
+        return std::make_unique<MysqlRow>(mysql_row);
     }
     nullRead = true;
     mysql_free_result(mysql_res);

--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -299,8 +299,8 @@ std::shared_ptr<ASTNode> SearchParser::parseRelationshipExpression()
     if (currentToken->getType() != TokenType::PROPERTY)
         throw_std_runtime_error("Failed to parse search criteria - expecting a property name");
 
-    std::shared_ptr<ASTNode> relationshipExpr = nullptr;
-    std::shared_ptr<ASTProperty> property = std::make_shared<ASTProperty>(sqlEmitter, currentToken->getValue());
+    auto relationshipExpr = std::shared_ptr<ASTNode>(nullptr);
+    auto property = std::make_shared<ASTProperty>(sqlEmitter, currentToken->getValue());
 
     getNextToken();
     if (currentToken->getType() == TokenType::COMPAREOP) {

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -759,7 +759,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::browse(const std::unique_pt
 
 std::vector<std::shared_ptr<CdsObject>> SQLDatabase::search(const std::unique_ptr<SearchParam>& param, int* numMatches)
 {
-    std::unique_ptr<SearchParser> searchParser = std::make_unique<SearchParser>(*sqlEmitter, param->searchCriteria());
+    auto searchParser = std::make_unique<SearchParser>(*sqlEmitter, param->searchCriteria());
     std::shared_ptr<ASTNode> rootNode = searchParser->parse();
     std::string searchSQL(rootNode->emitSQL());
     if (searchSQL.empty())

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -688,8 +688,7 @@ std::unique_ptr<SQLRow> Sqlite3Result::nextRow()
         row += ncolumn;
         cur_row++;
         if (cur_row <= nrow) {
-            auto p = std::make_unique<Sqlite3Row>(row);
-            return p;
+            return std::make_unique<Sqlite3Row>(row);
         }
         return nullptr;
     }

--- a/src/device_description_handler.cc
+++ b/src/device_description_handler.cc
@@ -56,5 +56,5 @@ std::unique_ptr<IOHandler> DeviceDescriptionHandler::open(const char* filename, 
 
     auto t = std::make_unique<MemIOHandler>(deviceDescription);
     t->open(mode);
-    return t;
+    return std::move(t);
 }

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -285,5 +285,5 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename, enum U
     content->triggerPlayHook(obj);
 
     log_debug("end");
-    return io_handler;
+    return std::move(io_handler);
 }

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -424,6 +424,6 @@ std::unique_ptr<IOHandler> LibExifHandler::serveContent(std::shared_ptr<CdsObjec
 
     auto h = std::make_unique<MemIOHandler>(ed->data, ed->size);
     exif_data_unref(ed);
-    return h;
+    return std::move(h);
 }
 #endif // HAVE_LIBEXIF

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -165,8 +165,7 @@ std::unique_ptr<IOHandler> FanArtHandler::serveContent(std::shared_ptr<CdsObject
         log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
-    auto io_handler = std::make_unique<FileIOHandler>(path);
-    return io_handler;
+    return std::make_unique<FileIOHandler>(path);
 }
 
 std::vector<std::string> ContainerArtHandler::names = {
@@ -229,8 +228,7 @@ std::unique_ptr<IOHandler> ContainerArtHandler::serveContent(std::shared_ptr<Cds
         log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
-    auto io_handler = std::make_unique<FileIOHandler>(path);
-    return io_handler;
+    return std::make_unique<FileIOHandler>(path);
 }
 
 std::vector<std::string> SubtitleHandler::names = {
@@ -289,8 +287,7 @@ std::unique_ptr<IOHandler> SubtitleHandler::serveContent(std::shared_ptr<CdsObje
         log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
-    auto io_handler = std::make_unique<FileIOHandler>(path);
-    return io_handler;
+    return std::make_unique<FileIOHandler>(path);
 }
 
 std::vector<std::string> ResourceHandler::names = {
@@ -340,6 +337,5 @@ std::unique_ptr<IOHandler> ResourceHandler::serveContent(std::shared_ptr<CdsObje
         log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
         return nullptr;
     }
-    auto io_handler = std::make_unique<FileIOHandler>(path);
-    return io_handler;
+    return std::make_unique<FileIOHandler>(path);
 }

--- a/src/serve_request_handler.cc
+++ b/src/serve_request_handler.cc
@@ -133,5 +133,5 @@ std::unique_ptr<IOHandler> ServeRequestHandler::open(const char* filename, enum 
 
     auto io_handler = std::make_unique<FileIOHandler>(path);
     io_handler->open(mode);
-    return io_handler;
+    return std::move(io_handler);
 }

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -194,8 +194,7 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(std::shared_pt
     content->triggerPlayHook(obj);
 
     std::unique_ptr<IOHandler> u_ioh = std::make_unique<ProcessIOHandler>(content, fifo_name, main_proc, proc_list);
-    auto io_handler = std::make_unique<BufferedIOHandler>(
+    return std::make_unique<BufferedIOHandler>(
         config, u_ioh,
         profile->getBufferSize(), profile->getBufferChunkSize(), profile->getBufferInitialFillSize());
-    return io_handler;
 }

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -173,7 +173,7 @@ std::unique_ptr<IOHandler> URLRequestHandler::open(const char* filename, enum Up
     auto io_handler = std::make_unique<CurlIOHandler>(config, url, nullptr, 1024 * 1024, 0);
     io_handler->open(mode);
     content->triggerPlayHook(obj);
-    return io_handler;
+    return std::move(io_handler);
 }
 
 #endif // HAVE_CURL

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -568,7 +568,7 @@ std::optional<std::vector<std::byte>> readBinaryFile(const fs::path& path)
 
     result.resize(size);
 
-    return result;
+    return std::move(result);
 }
 
 void writeBinaryFile(const fs::path& path, const std::byte* data, std::size_t size)

--- a/src/web/add_object.cc
+++ b/src/web/add_object.cc
@@ -70,7 +70,7 @@ std::shared_ptr<CdsObject> web::addObject::addItem(int parentID, std::shared_ptr
 
     item->setFlag(OBJECT_FLAG_USE_RESOURCE_REF);
 
-    return item;
+    return std::move(item);
 }
 
 std::shared_ptr<CdsObject> web::addObject::addUrl(int parentID, std::shared_ptr<CdsItemExternalURL> item, bool addProtocol)
@@ -106,7 +106,7 @@ std::shared_ptr<CdsObject> web::addObject::addUrl(int parentID, std::shared_ptr<
     resource->addAttribute(R_PROTOCOLINFO, protocolInfo);
     item->addResource(resource);
 
-    return item;
+    return std::move(item);
 }
 
 void web::addObject::process()

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -214,7 +214,7 @@ std::unique_ptr<IOHandler> WebRequestHandler::open(enum UpnpOpenFileMode mode)
 
     auto io_handler = std::make_unique<MemIOHandler>(output);
     io_handler->open(mode);
-    return io_handler;
+    return std::move(io_handler);
 }
 
 std::unique_ptr<IOHandler> WebRequestHandler::open(const char* filename, enum UpnpOpenFileMode mode)


### PR DESCRIPTION
Found with -Wreturn-std-move-in-c++11

Signed-off-by: Rosen Penev <rosenp@gmail.com>