### PR TITLE
clang: remove CTAD in some places

### DIFF
--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -393,7 +393,7 @@ std::unique_ptr<IOHandler> FfmpegHandler::serveContent(std::shared_ptr<CdsObject
         }
     }
 
-    std::scoped_lock thumb_lock { thumb_mutex };
+    auto thumb_lock = std::scoped_lock<std::mutex>(thumb_mutex);
 
 #ifdef FFMPEGTHUMBNAILER_OLD_API
     auto th = wrap_unique_ptr<create_thumbnailer, destroy_thumbnailer>();

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -165,7 +165,7 @@ std::shared_ptr<Session> SessionManager::getSession(const std::string& sessionID
         return nullptr;
     }
 
-    std::unique_lock lock(mutex, std::defer_lock);
+    auto lock = std::unique_lock<std::mutex>(mutex, std::defer_lock);
     if (doLock)
         lock.lock();
 


### PR DESCRIPTION
This throws -Wctad-maybe-unsupported under clang as gcc's libstdc++
seems to not implement it properly.

Signed-off-by: Rosen Penev <rosenp@gmail.com>