### PR TITLE
Search query sign from beginning

### DIFF
--- a/src/request_handler.cc
+++ b/src/request_handler.cc
@@ -52,8 +52,10 @@ void RequestHandler::splitUrl(const char* url, char separator, std::string& path
 {
     const auto url_s = std::string { url };
     const auto i1 = size_t { [=]() {
-        if (separator == '/' || separator == '?')
+        if (separator == '/')
             return url_s.rfind(separator);
+        if (separator == '?')
+            return url_s.find(separator);
         throw_std_runtime_error("Forbidden separator: {}", separator);
     }() };
 


### PR DESCRIPTION
Fixes #1468 

broken in when replacing zmm::string with std::string

https://github.com/gerbera/gerbera/commit/a58d00030fd102b0083e3b133bbff321031134ef