### PR TITLE
initialize several unique_ptrs

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -70,19 +70,19 @@ std::shared_ptr<Quirks> ActionRequest::getQuirks() const
 
 std::unique_ptr<pugi::xml_document> ActionRequest::getRequest() const
 {
-    auto request = std::make_unique<pugi::xml_document>();
+    pugi::xml_document request;
 #if defined(USING_NPUPNP)
-    auto ret = request->load_string(upnp_request->xmlAction.c_str());
+    auto ret = request.load_string(upnp_request->xmlAction.c_str());
 #else
     DOMString cxml = ixmlPrintDocument(UpnpActionRequest_get_ActionRequest(upnp_request));
-    auto ret = request->load_string(cxml);
+    auto ret = request.load_string(cxml);
     ixmlFreeDOMString(cxml);
 #endif
 
     if (ret.status != pugi::xml_parse_status::status_ok)
         throw_std_runtime_error("Unable to parse ixml");
 
-    return request;
+    return std::make_unique<pugi::xml_document>(std::move(request));
 }
 
 void ActionRequest::setResponse(std::unique_ptr<pugi::xml_document> response)

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -129,7 +129,7 @@ void ConfigManager::load(const fs::path& userHome)
     std::shared_ptr<ConfigSetup> co;
 
     log_info("Loading configuration from: {}", filename.c_str());
-    pugi::xml_parse_result result = xmlDoc->load_file(filename.c_str());
+    auto result = xmlDoc->load_file(filename.c_str());
     if (result.status != pugi::xml_parse_status::status_ok) {
         throw ConfigParseException(result.description());
     }

--- a/src/content/onlineservice/curl_online_service.cc
+++ b/src/content/onlineservice/curl_online_service.cc
@@ -85,14 +85,14 @@ std::unique_ptr<pugi::xml_document> CurlOnlineService::getData()
         return nullptr;
 
     log_debug("GOT BUFFER{}", buffer.c_str());
-    auto doc = std::make_unique<pugi::xml_document>();
-    pugi::xml_parse_result result = doc->load_string(sc->convert(buffer).c_str());
+    pugi::xml_document doc;
+    auto result = doc.load_string(sc->convert(buffer).c_str());
     if (result.status != pugi::xml_parse_status::status_ok) {
         log_error("Error parsing {} XML: {}", serviceName, result.description());
         return nullptr;
     }
 
-    return doc;
+    return std::make_unique<pugi::xml_document>(std::move(doc));
 }
 
 bool CurlOnlineService::refreshServiceData(std::shared_ptr<Layout> layout)

--- a/src/content/onlineservice/online_service.h
+++ b/src/content/onlineservice/online_service.h
@@ -140,8 +140,6 @@ protected:
 
 class OnlineServiceList {
 public:
-    OnlineServiceList() = default;
-
     /// \brief Adds a service to the service list.
     void registerService(const std::shared_ptr<OnlineService>& service);
 

--- a/src/content/update_manager.cc
+++ b/src/content/update_manager.cc
@@ -50,7 +50,7 @@ UpdateManager::UpdateManager(std::shared_ptr<Config> config, std::shared_ptr<Dat
     : config(std::move(config))
     , database(std::move(database))
     , server(std::move(server))
-    , objectIDHash(std::make_unique<std::unordered_set<int>>())
+    , objectIDHash(std::make_unique<std::unordered_set<int>>(MAX_OBJECT_IDS - 1))
     , shutdownFlag(false)
     , flushPolicy(FLUSH_SPEC)
     , lastContainerChanged(INVALID_OBJECT_ID)

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -49,11 +49,11 @@ UpnpXMLBuilder::UpnpXMLBuilder(const std::shared_ptr<Context>& context,
 
 std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createResponse(const std::string& actionName, const std::string& serviceType)
 {
-    auto response = std::make_unique<pugi::xml_document>();
-    auto root = response->append_child(fmt::format("u:{}Response", actionName.c_str()).c_str());
+    pugi::xml_document response;
+    auto root = response.append_child(fmt::format("u:{}Response", actionName.c_str()).c_str());
     root.append_attribute("xmlns:u") = serviceType.c_str();
 
-    return response;
+    return std::make_unique<pugi::xml_document>(std::move(response));
 }
 
 metadata_fields_t UpnpXMLBuilder::remapMetaDataField(const std::string& fieldName)
@@ -183,25 +183,24 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
 
 std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createEventPropertySet()
 {
-    auto doc = std::make_unique<pugi::xml_document>();
+    pugi::xml_document doc;
 
-    auto propset = doc->append_child("e:propertyset");
+    auto propset = doc.append_child("e:propertyset");
     propset.append_attribute("xmlns:e") = "urn:schemas-upnp-org:event-1-0";
-
     propset.append_child("e:property");
 
-    return doc;
+    return std::make_unique<pugi::xml_document>(std::move(doc));
 }
 
 std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription()
 {
-    auto doc = std::make_unique<pugi::xml_document>();
+    pugi::xml_document doc;
 
-    auto decl = doc->prepend_child(pugi::node_declaration);
+    auto decl = doc.prepend_child(pugi::node_declaration);
     decl.append_attribute("version") = "1.0";
     decl.append_attribute("encoding") = "UTF-8";
 
-    auto root = doc->append_child("root");
+    auto root = doc.append_child("root");
     root.append_attribute("xmlns") = UPNP_DESC_DEVICE_NAMESPACE;
 
     auto specVersion = root.append_child("specVersion");
@@ -297,7 +296,7 @@ std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription()
         }
     }
 
-    return doc;
+    return std::make_unique<pugi::xml_document>(std::move(doc));
 }
 
 void UpnpXMLBuilder::renderResource(const std::string& URL, const std::map<std::string, std::string>& attributes, pugi::xml_node* parent)


### PR DESCRIPTION
GCC's -fanalyzer complains that null pointers are created otherwise.

Some cleanup posibilities showed up.

Signed-off-by: Rosen Penev <rosenp@gmail.com>