### PR TITLE
pass SearchLexer by value

### DIFF
--- a/src/database/search_handler.h
+++ b/src/database/search_handler.h
@@ -75,8 +75,8 @@ protected:
 
 class SearchLexer {
 public:
-    explicit SearchLexer(const std::string& input)
-        : input(input)
+    explicit SearchLexer(std::string input)
+        : input(std::move(input))
     {
     }
     virtual ~SearchLexer() = default;
@@ -91,7 +91,7 @@ protected:
     static std::unique_ptr<SearchToken> makeToken(const std::string& tokenStr);
     std::string getQuotedValue(const std::string& input);
 
-    const std::string& input;
+    std::string input;
     unsigned currentPos {};
     bool inQuotes {};
 };


### PR DESCRIPTION
There's no need for it to be a const reference. GCC's -fanalyzer also
complains about it when used with make_unique.

Signed-off-by: Rosen Penev <rosenp@gmail.com>