### PR TITLE
move resize option to constructor

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -72,11 +72,9 @@ ConfigManager::ConfigManager(fs::path filename,
     , interface(std::move(interface))
     , port(port)
     , xmlDoc(std::make_unique<pugi::xml_document>())
-    , options(std::make_unique<std::vector<std::shared_ptr<ConfigOption>>>())
+    , options(std::make_unique<std::vector<std::shared_ptr<ConfigOption>>>(CFG_MAX))
 {
     ConfigManager::debug = debug;
-
-    options->resize(CFG_MAX);
 
     if (this->filename.empty()) {
         // No config file path provided, so lets find one.

--- a/src/content/onlineservice/online_service.cc
+++ b/src/content/onlineservice/online_service.cc
@@ -42,11 +42,6 @@
 // NEW SERVICES!
 static constexpr auto service_prefixes = std::array { '\0', 'Y', 'S', 'W', 'T', '\0' };
 
-OnlineServiceList::OnlineServiceList()
-{
-    service_list.resize(OS_Max);
-}
-
 void OnlineServiceList::registerService(const std::shared_ptr<OnlineService>& service)
 {
     if (service == nullptr)

--- a/src/content/onlineservice/online_service.h
+++ b/src/content/onlineservice/online_service.h
@@ -140,7 +140,7 @@ protected:
 
 class OnlineServiceList {
 public:
-    OnlineServiceList();
+    OnlineServiceList() = default;
 
     /// \brief Adds a service to the service list.
     void registerService(const std::shared_ptr<OnlineService>& service);
@@ -149,7 +149,7 @@ public:
     std::shared_ptr<OnlineService> getService(service_type_t service);
 
 protected:
-    std::vector<std::shared_ptr<OnlineService>> service_list;
+    std::vector<std::shared_ptr<OnlineService>> service_list { OS_Max };
 };
 
 #endif //__ONLINE_SERVICE_H__


### PR DESCRIPTION
vector(x) and vector(); resize() are the same.

Also fixes some GCC -fanalyzer NULL pointer issue.

Signed-off-by: Rosen Penev <rosenp@gmail.com>