### PR TITLE
clang-tidy: C to C++ headers

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -35,6 +35,8 @@
 /// running "doxygen doxygen.conf" from the mediatomb/doc/ directory.
 
 #include <csignal>
+#include <cstdio>
+#include <cstdlib>
 #include <filesystem>
 #include <mutex>
 #include <spdlog/sinks/basic_file_sink.h>
@@ -55,9 +57,6 @@
 #include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Found with modernize-deprecated-headers

Signed-off-by: Rosen Penev <rosenp@gmail.com>