### PR TITLE
clang-tidy: initialize some members

### DIFF
--- a/src/config/client_config.h
+++ b/src/config/client_config.h
@@ -59,7 +59,7 @@ public:
     std::vector<std::shared_ptr<ClientConfig>> getArrayCopy();
 
 protected:
-    size_t origSize;
+    size_t origSize {};
     std::map<size_t, std::shared_ptr<ClientConfig>> indexMap;
 
     std::recursive_mutex mutex;

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -305,7 +305,7 @@ class ConfigIntSetup : public ConfigSetup {
 protected:
     IntCheckFunction valueCheck = nullptr;
     IntMinFunction minCheck = nullptr;
-    int minValue;
+    int minValue {};
 
 public:
     ConfigIntSetup(config_option_t option, const char* xpath, const char* help)
@@ -530,9 +530,9 @@ protected:
     bool updateItem(size_t i, const std::string& optItem, const std::shared_ptr<Config>& config, const std::shared_ptr<DictionaryOption>& value, const std::string& optKey, const std::string& optValue, const std::string& status = "") const;
 
 public:
-    config_option_t nodeOption;
-    config_option_t keyOption;
-    config_option_t valOption;
+    config_option_t nodeOption {};
+    config_option_t keyOption {};
+    config_option_t valOption {};
 
     explicit ConfigDictionarySetup(config_option_t option, const char* xpath, const char* help, DictionaryInitFunction init = nullptr,
         bool notEmpty = false, bool itemNotEmpty = false, bool required = false, const std::map<std::string, std::string>& defaultEntries = {})

--- a/src/config/directory_tweak.h
+++ b/src/config/directory_tweak.h
@@ -73,7 +73,7 @@ public:
     std::vector<std::shared_ptr<DirectoryTweak>> getArrayCopy();
 
 protected:
-    size_t origSize;
+    size_t origSize {};
     std::map<size_t, std::shared_ptr<DirectoryTweak>> indexMap;
 
     std::recursive_mutex mutex;

--- a/src/content/autoscan.h
+++ b/src/content/autoscan.h
@@ -148,11 +148,11 @@ public:
 
 protected:
     fs::path location;
-    ScanMode mode;
+    ScanMode mode {};
     bool isOrig { false };
-    bool recursive;
-    bool hidden;
-    bool persistent_flag;
+    bool recursive {};
+    bool hidden {};
+    bool persistent_flag {};
     std::chrono::seconds interval {};
     int taskCount { 0 };
     int scanID { INVALID_SCAN_ID };

--- a/src/content/onlineservice/online_service.cc
+++ b/src/content/onlineservice/online_service.cc
@@ -66,10 +66,7 @@ OnlineService::OnlineService(std::shared_ptr<ContentManager> content)
     : config(content->getContext()->getConfig())
     , database(content->getContext()->getDatabase())
     , content(std::move(content))
-    , taskCount(0)
 {
-    refresh_interval = {};
-    purge_interval = {};
 }
 
 char OnlineService::getDatabasePrefix(service_type_t service)

--- a/src/content/onlineservice/online_service.h
+++ b/src/content/onlineservice/online_service.h
@@ -132,9 +132,9 @@ protected:
     std::shared_ptr<Database> database;
     std::shared_ptr<ContentManager> content;
 
-    int taskCount;
-    std::chrono::seconds refresh_interval;
-    std::chrono::seconds purge_interval;
+    int taskCount {};
+    std::chrono::seconds refresh_interval {};
+    std::chrono::seconds purge_interval {};
     std::shared_ptr<Timer::Parameter> timer_parameter;
 };
 

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -139,7 +139,7 @@ protected:
     /// \brief The SQL query string
     const char* query;
 
-    int lastInsertId;
+    int lastInsertId {};
     bool getLastInsertIdFlag;
 };
 
@@ -208,7 +208,7 @@ private:
 
     /// \brief the tasks to be done by the sqlite3 thread
     std::queue<std::shared_ptr<SLTask>> taskQueue;
-    bool taskQueueOpen;
+    bool taskQueueOpen {};
 
     void threadCleanup() override { }
     bool threadCleanupRequired() const override { return false; }
@@ -216,7 +216,7 @@ private:
     bool dirty;
     bool dbInitDone;
     bool hasBackupTimer;
-    int sqliteStatus;
+    int sqliteStatus {};
 
     friend class SLSelectTask;
     friend class SLExecTask;

--- a/src/util/thread_executor.h
+++ b/src/util/thread_executor.h
@@ -60,7 +60,7 @@ public:
 protected:
     bool threadShutdown { false };
     /// \brief if the thread is currently running
-    bool threadRunning;
+    bool threadRunning {};
 
     std::condition_variable cond;
     std::mutex mutex;

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -135,7 +135,7 @@ protected:
         Subscriber* subscriber;
         std::chrono::milliseconds notifyInterval;
         std::shared_ptr<Parameter> parameter;
-        std::chrono::milliseconds nextNotify;
+        std::chrono::milliseconds nextNotify {};
         bool once;
     };
 

--- a/src/web/directories.cc
+++ b/src/web/directories.cc
@@ -40,10 +40,7 @@ web::directories::directories(std::shared_ptr<ContentManager> content)
 {
 }
 
-using dirInfo = struct {
-    fs::path filename;
-    bool hasContent;
-};
+using dirInfo = std::pair<fs::path, bool>;
 
 void web::directories::process()
 {
@@ -94,10 +91,11 @@ void web::directories::process()
 
     auto f2i = StringConverter::f2i(config);
     for (auto&& [key, val] : filesMap) {
+        auto&& [file, has] = val;
         auto ce = containers.append_child("container");
         ce.append_attribute("id") = key.c_str();
-        ce.append_attribute("child_count") = val.hasContent;
+        ce.append_attribute("child_count") = has;
 
-        ce.append_attribute("title") = f2i->convert(val.filename).c_str();
+        ce.append_attribute("title") = f2i->convert(file).c_str();
     }
 }

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -50,7 +50,7 @@ class SessionManager;
 /// \brief Authentication handler (used over AJAX)
 class auth : public WebRequestHandler {
 protected:
-    std::chrono::seconds timeout;
+    std::chrono::seconds timeout {};
 
 public:
     explicit auth(std::shared_ptr<ContentManager> content);

--- a/src/web/session_manager.h
+++ b/src/web/session_manager.h
@@ -112,7 +112,7 @@ protected:
     std::chrono::seconds timeout;
 
     /// \brief time of last access to the session, returned by getLastAccessTime()
-    std::chrono::seconds last_access;
+    std::chrono::seconds last_access {};
 
     /// \brief arbitrary but unique string representing the ID of the session (returned by getID())
     std::string sessionID;


### PR DESCRIPTION
Found with cppcoreguidelines-pro-type-member-init

Signed-off-by: Rosen Penev <rosenp@gmail.com>