### PR TITLE
clang-tidy: fix some narrowing conversions

### DIFF
--- a/src/content/autoscan.h
+++ b/src/content/autoscan.h
@@ -134,7 +134,7 @@ public:
         last_mod_previous_scan = {};
         last_mod_current_scan = {};
     }
-    int getActiveScanCount() const { return activeScanCount; }
+    unsigned int getActiveScanCount() const { return activeScanCount; }
 
     /// \brief copies all properties to another object
     void copyTo(const std::shared_ptr<AutoscanDirectory>& copy) const;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -75,7 +75,7 @@ public:
     {
     }
 
-    int getFlags() const { return flags; }
+    unsigned int getFlags() const { return flags; }
     unsigned int getFlag(unsigned int mask) const { return flags & mask; }
     void setFlags(unsigned int flags) { this->flags = flags; }
     void setFlag(unsigned int mask) { flags |= mask; }

--- a/src/main.cc
+++ b/src/main.cc
@@ -316,7 +316,7 @@ int main(int argc, char** argv, char** envp)
                 exit(EXIT_FAILURE);
             }
             // close open filedescriptors belonging to a tty
-            for (int fd = sysconf(_SC_OPEN_MAX); fd >= 0; fd--) {
+            for (auto fd = int(sysconf(_SC_OPEN_MAX)); fd >= 0; fd--) {
                 if (isatty(fd))
                     close(fd);
             }


### PR DESCRIPTION
Found with cppcoreguidelines-narrowing-conversions

Signed-off-by: Rosen Penev <rosenp@gmail.com>