### PR TITLE
clang-tidy: pass unique_ptr by value

### DIFF
--- a/src/content/onlineservice/atrailers_content_handler.cc
+++ b/src/content/onlineservice/atrailers_content_handler.cc
@@ -43,7 +43,7 @@ ATrailersContentHandler::ATrailersContentHandler(const std::shared_ptr<Context>&
 {
 }
 
-void ATrailersContentHandler::setServiceContent(std::unique_ptr<pugi::xml_document>& service)
+void ATrailersContentHandler::setServiceContent(std::unique_ptr<pugi::xml_document> service)
 {
     service_xml = std::move(service);
     auto root = service_xml->document_element();

--- a/src/content/onlineservice/atrailers_content_handler.h
+++ b/src/content/onlineservice/atrailers_content_handler.h
@@ -57,7 +57,7 @@ public:
 
     /// \brief Sets the service XML from which we will extract the objects.
     /// \return false if service XML contained an error status.
-    void setServiceContent(std::unique_ptr<pugi::xml_document>& service) override;
+    void setServiceContent(std::unique_ptr<pugi::xml_document> service) override;
 
     /// \brief retrieves an object from the service.
     ///

--- a/src/content/onlineservice/curl_online_service.cc
+++ b/src/content/onlineservice/curl_online_service.cc
@@ -118,7 +118,7 @@ bool CurlOnlineService::refreshServiceData(std::shared_ptr<Layout> layout)
     }
 
     auto sc = getContentHandler();
-    sc->setServiceContent(reply);
+    sc->setServiceContent(std::move(reply));
 
     std::shared_ptr<CdsObject> obj;
     do {

--- a/src/content/onlineservice/curl_online_service.h
+++ b/src/content/onlineservice/curl_online_service.h
@@ -50,7 +50,7 @@ public:
 
     /// \brief Sets the service XML from which we will extract the objects.
     /// \return false if service XML contained an error status.
-    virtual void setServiceContent(std::unique_ptr<pugi::xml_document>& service) = 0;
+    virtual void setServiceContent(std::unique_ptr<pugi::xml_document> service) = 0;
 
     /// \brief retrieves an object from the service.
     ///

--- a/src/content/onlineservice/sopcast_content_handler.cc
+++ b/src/content/onlineservice/sopcast_content_handler.cc
@@ -43,7 +43,7 @@ SopCastContentHandler::SopCastContentHandler(const std::shared_ptr<Context>& con
 {
 }
 
-void SopCastContentHandler::setServiceContent(std::unique_ptr<pugi::xml_document>& service)
+void SopCastContentHandler::setServiceContent(std::unique_ptr<pugi::xml_document> service)
 {
     service_xml = std::move(service);
     auto root = service_xml->document_element();

--- a/src/content/onlineservice/sopcast_content_handler.h
+++ b/src/content/onlineservice/sopcast_content_handler.h
@@ -61,7 +61,7 @@ public:
 
     /// \brief Sets the service XML from which we will extract the objects.
     /// \return false if service XML contained an error status.
-    void setServiceContent(std::unique_ptr<pugi::xml_document>& service) override;
+    void setServiceContent(std::unique_ptr<pugi::xml_document> service) override;
 
     /// \brief retrieves an object from the service.
     ///

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1617,7 +1617,7 @@ std::string SQLDatabase::toCSV(const std::vector<int>& input)
     return join(input, ",");
 }
 
-std::unique_ptr<Database::ChangedContainers> SQLDatabase::_purgeEmptyContainers(std::unique_ptr<ChangedContainers>& maybeEmpty)
+std::unique_ptr<Database::ChangedContainers> SQLDatabase::_purgeEmptyContainers(const std::unique_ptr<ChangedContainers>& maybeEmpty)
 {
     log_debug("start upnp: {}; ui: {}",
         join(maybeEmpty->upnp, ',').c_str(),

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -238,7 +238,7 @@ private:
         const std::vector<int32_t>& items,
         const std::vector<int32_t>& containers, bool all);
 
-    virtual std::unique_ptr<ChangedContainers> _purgeEmptyContainers(std::unique_ptr<ChangedContainers>& maybeEmpty);
+    virtual std::unique_ptr<ChangedContainers> _purgeEmptyContainers(const std::unique_ptr<ChangedContainers>& maybeEmpty);
 
     /* helpers for autoscan */
     void _removeAutoscanDirectory(int autoscanID);

--- a/src/iohandler/buffered_io_handler.cc
+++ b/src/iohandler/buffered_io_handler.cc
@@ -37,7 +37,7 @@
 
 class Config;
 
-BufferedIOHandler::BufferedIOHandler(std::shared_ptr<Config> config, std::unique_ptr<IOHandler>& underlyingHandler, size_t bufSize, size_t maxChunkSize, size_t initialFillSize)
+BufferedIOHandler::BufferedIOHandler(std::shared_ptr<Config> config, std::unique_ptr<IOHandler> underlyingHandler, size_t bufSize, size_t maxChunkSize, size_t initialFillSize)
     : IOHandlerBufferHelper(std::move(config), bufSize, initialFillSize)
 {
     if (underlyingHandler == nullptr)

--- a/src/iohandler/buffered_io_handler.h
+++ b/src/iohandler/buffered_io_handler.h
@@ -50,7 +50,7 @@ public:
     /// \param initialFillSize the number of bytes which have to be in the buffer
     /// before the first read at the very beginning or after a seek returns;
     /// 0 disables the delay
-    BufferedIOHandler(std::shared_ptr<Config> config, std::unique_ptr<IOHandler>& underlyingHandler, size_t bufSize, size_t maxChunkSize, size_t initialFillSize);
+    BufferedIOHandler(std::shared_ptr<Config> config, std::unique_ptr<IOHandler> underlyingHandler, size_t bufSize, size_t maxChunkSize, size_t initialFillSize);
 
     void open(enum UpnpOpenFileMode mode) override;
     void close() override;

--- a/src/iohandler/io_handler_chainer.cc
+++ b/src/iohandler/io_handler_chainer.cc
@@ -35,7 +35,7 @@
 
 #include "exceptions.h"
 
-IOHandlerChainer::IOHandlerChainer(std::unique_ptr<IOHandler>& readFrom, std::unique_ptr<IOHandler>& writeTo, int chunkSize)
+IOHandlerChainer::IOHandlerChainer(std::unique_ptr<IOHandler> readFrom, std::unique_ptr<IOHandler> writeTo, int chunkSize)
 {
     if (chunkSize <= 0)
         throw_std_runtime_error("chunkSize must be positive");

--- a/src/iohandler/io_handler_chainer.h
+++ b/src/iohandler/io_handler_chainer.h
@@ -50,7 +50,7 @@ public:
     /// \param writeTo the IOHandler to write to
     /// \param chunkSize the amount of bytes to read/write at once. a buffer of
     /// this size will be allocated
-    IOHandlerChainer(std::unique_ptr<IOHandler>& readFrom, std::unique_ptr<IOHandler>& writeTo, int chunkSize);
+    IOHandlerChainer(std::unique_ptr<IOHandler> readFrom, std::unique_ptr<IOHandler> writeTo, int chunkSize);
     ~IOHandlerChainer() override
     {
         if (buf != nullptr) {

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -140,7 +140,7 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(std::shared_pt
                     config->getIntOption(CFG_EXTERNAL_TRANSCODING_CURL_BUFFER_SIZE),
                     config->getIntOption(CFG_EXTERNAL_TRANSCODING_CURL_FILL_SIZE));
                 std::unique_ptr<IOHandler> p_ioh = std::make_unique<ProcessIOHandler>(content, location, nullptr);
-                auto ch = std::make_shared<IOHandlerChainer>(c_ioh, p_ioh, 16384);
+                auto ch = std::make_shared<IOHandlerChainer>(std::move(c_ioh), std::move(p_ioh), 16384);
                 auto pr_item = std::make_shared<ProcListItem>(ch);
                 proc_list.push_back(pr_item);
             } catch (const std::runtime_error& ex) {
@@ -195,6 +195,6 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(std::shared_pt
 
     std::unique_ptr<IOHandler> u_ioh = std::make_unique<ProcessIOHandler>(content, fifo_name, main_proc, proc_list);
     return std::make_unique<BufferedIOHandler>(
-        config, u_ioh,
+        config, std::move(u_ioh),
         profile->getBufferSize(), profile->getBufferChunkSize(), profile->getBufferInitialFillSize());
 }

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -286,7 +286,7 @@ void Clients::updateCache(const struct sockaddr_storage* addr, const std::string
     }
 }
 
-bool Clients::downloadDescription(const std::string& location, std::unique_ptr<pugi::xml_document>& xml)
+bool Clients::downloadDescription(const std::string& location, std::unique_ptr<pugi::xml_document> xml)
 {
 #if defined(USING_NPUPNP)
     std::string description, ct;

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -97,7 +97,7 @@ private:
     bool getInfoByCache(const struct sockaddr_storage* addr, const ClientInfo** ppInfo);
     void updateCache(const struct sockaddr_storage* addr, const std::string& userAgent, const ClientInfo* pInfo);
 
-    static bool downloadDescription(const std::string& location, std::unique_ptr<pugi::xml_document>& xml);
+    static bool downloadDescription(const std::string& location, std::unique_ptr<pugi::xml_document> xml);
 
 private:
     std::mutex mutex;

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -43,7 +43,7 @@ Quirks::Quirks(std::shared_ptr<Context> context, const struct sockaddr_storage* 
     this->context->getClients()->getInfo(addr, userAgent, &pClientInfo);
 }
 
-void Quirks::addCaptionInfo(const std::shared_ptr<CdsItem>& item, std::unique_ptr<Headers>& headers) const
+void Quirks::addCaptionInfo(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Headers>& headers) const
 {
     if ((pClientInfo->flags & QUIRK_FLAG_SAMSUNG) == 0)
         return;

--- a/src/util/upnp_quirks.h
+++ b/src/util/upnp_quirks.h
@@ -52,7 +52,7 @@ public:
 
     // Look for subtitle file and returns it's URL in CaptionInfo.sec response header.
     // To be more compliant with original Samsung server we should check for getCaptionInfo.sec: 1 request header.
-    void addCaptionInfo(const std::shared_ptr<CdsItem>& item, std::unique_ptr<Headers>& headers) const;
+    void addCaptionInfo(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Headers>& headers) const;
 
     /** \brief Add Samsung specific bookmark information to the request's result.
      *


### PR DESCRIPTION
Since the copy stuff is deleted, this is safe to do.

Found with google-runtime-references.

Signed-off-by: Rosen Penev <rosenp@gmail.com>