### PR TITLE
clang-tidy: get rid of some long and short

### DIFF
--- a/src/iohandler/mem_io_handler.cc
+++ b/src/iohandler/mem_io_handler.cc
@@ -103,7 +103,7 @@ void MemIOHandler::seek(off_t offset, int whence)
 
         pos = offset;
     } else if (whence == SEEK_CUR) {
-        long temp = (pos == -1) ? length : pos;
+        off_t temp = (pos == -1) ? length : pos;
         //  (((temp + offset) > length) || ((temp + offset) < 0))
         if (offset > 0 && (length < offset || temp > length - offset)) {
             throw_std_runtime_error("seek failed: trying to seek past end of file");
@@ -115,7 +115,7 @@ void MemIOHandler::seek(off_t offset, int whence)
 
         pos = temp + offset;
     } else if (whence == SEEK_END) {
-        long temp = length;
+        off_t temp = length;
         //  (((temp + offset) > length) || ((temp + offset) < 0))
         if (offset > 0 && (length < offset || temp > length - offset)) {
             throw_std_runtime_error("seek failed: trying to seek past end of file");

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -1217,7 +1217,7 @@ int find_local_port(in_port_t range_min, in_port_t range_max)
 
         retry_count++;
 
-    } while (retry_count < std::numeric_limits<unsigned short>::max());
+    } while (retry_count < std::numeric_limits<uint16_t>::max());
 
     log_error("Could not find free port on localhost");
 


### PR DESCRIPTION
Found with google-runtime-int

Signed-off-by: Rosen Penev <rosenp@gmail.com>