### PR TITLE
clangh-tidy: non const reference removal

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -96,7 +96,7 @@ std::shared_ptr<pugi::xml_node> ConfigGenerator::setValue(config_option_t option
     return setValue(cs->xpath, value.empty() ? cs->getDefaultValue() : value);
 }
 
-std::shared_ptr<pugi::xml_node> ConfigGenerator::setValue(std::shared_ptr<pugi::xml_node>& parent, config_option_t option, const std::string& value)
+std::shared_ptr<pugi::xml_node> ConfigGenerator::setValue(const std::shared_ptr<pugi::xml_node>& parent, config_option_t option, const std::string& value)
 {
     auto cs = std::string(ConfigDefinition::mapConfigOption(option));
     if (cs.substr(0, ConfigDefinition::ATTRIBUTE.size()) == ConfigDefinition::ATTRIBUTE) {

--- a/src/config/config_generator.h
+++ b/src/config/config_generator.h
@@ -62,7 +62,7 @@ protected:
     std::shared_ptr<pugi::xml_node> setValue(config_option_t option, const std::string& key, const std::string& value);
     std::shared_ptr<pugi::xml_node> setValue(config_option_t option, config_option_t dict, config_option_t attr, const std::string& value);
 
-    static std::shared_ptr<pugi::xml_node> setValue(std::shared_ptr<pugi::xml_node>& parent, config_option_t option, const std::string& value);
+    static std::shared_ptr<pugi::xml_node> setValue(const std::shared_ptr<pugi::xml_node>& parent, config_option_t option, const std::string& value);
 };
 
 #endif //GERBERA_CONFIG_GENERATOR_H

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1871,12 +1871,12 @@ void ContentManager::triggerPlayHook(const std::shared_ptr<CdsObject>& obj)
 }
 
 CMAddFileTask::CMAddFileTask(std::shared_ptr<ContentManager> content,
-    fs::directory_entry dirEnt, fs::path rootpath, AutoScanSetting& asSetting, bool cancellable)
+    fs::directory_entry dirEnt, fs::path rootpath, AutoScanSetting asSetting, bool cancellable)
     : GenericTask(ContentManagerTask)
     , content(std::move(content))
     , dirEnt(std::move(dirEnt))
     , rootpath(std::move(rootpath))
-    , asSetting(asSetting)
+    , asSetting(std::move(asSetting))
 {
     this->cancellable = cancellable;
     this->taskType = AddFile;

--- a/src/content/content_manager.h
+++ b/src/content/content_manager.h
@@ -87,7 +87,7 @@ protected:
 
 public:
     CMAddFileTask(std::shared_ptr<ContentManager> content,
-        fs::directory_entry dirEnt, fs::path rootpath, AutoScanSetting& asSetting, bool cancellable = true);
+        fs::directory_entry dirEnt, fs::path rootpath, AutoScanSetting asSetting, bool cancellable = true);
     fs::path getPath();
     fs::path getRootPath();
     void run() override;

--- a/src/database/search_handler.h
+++ b/src/database/search_handler.h
@@ -500,9 +500,9 @@ private:
 
 class SortParser {
 public:
-    SortParser(std::shared_ptr<ColumnMapper> colMapper, const std::string& sortCriteria)
+    SortParser(std::shared_ptr<ColumnMapper> colMapper, std::string sortCriteria)
         : colMapper(std::move(colMapper))
-        , sortCrit(sortCriteria)
+        , sortCrit(std::move(sortCriteria))
     {
     }
     std::string parse();

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -328,7 +328,7 @@ void FfmpegHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
 
 #ifdef HAVE_FFMPEGTHUMBNAILER
 
-fs::path getThumbnailCacheBasePath(Config& config)
+fs::path getThumbnailCacheBasePath(const Config& config)
 {
     if (auto configuredDir = config.getOption(CFG_SERVER_EXTOPTS_FFMPEGTHUMBNAILER_CACHE_DIR);
         !configuredDir.empty()) {

--- a/src/metadata/ffmpeg_handler.h
+++ b/src/metadata/ffmpeg_handler.h
@@ -68,7 +68,7 @@ private:
     void writeThumbnailCacheFile(const fs::path& movie_filename, const std::byte* data, std::size_t size) const;
 };
 
-fs::path getThumbnailCacheBasePath(Config& config);
+fs::path getThumbnailCacheBasePath(const Config& config);
 fs::path getThumbnailCachePath(const fs::path& base, const fs::path& movie);
 
 #endif //__FFMPEG_HANDLER_H__


### PR DESCRIPTION
Found with google-runtime-references

Signed-off-by: Rosen Penev <rosenp@gmail.com>