### PR TITLE
clang-tidy: use pointers instead of references

### DIFF
--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -238,7 +238,7 @@ void AutoscanInotify::threadProc()
                             asSetting.rescanResource = true;
                             asSetting.mergeOptions(config, path);
                             // path, recursive, async, hidden, rescanResource, low priority, cancellable
-                            content->addFile(dirEnt, adir->getLocation(), asSetting, true, true, false);
+                            content->addFile(dirEnt, adir->getLocation(), &asSetting, true, true, false);
                             if (mask & IN_ISDIR) {
                                 monitorUnmonitorRecursive(dirEnt, false, adir, false, asSetting.followSymlinks);
                             }

--- a/src/content/content_manager.h
+++ b/src/content/content_manager.h
@@ -174,7 +174,7 @@ public:
     /// \param rescanResource true allows to reload a directory containing a resource
     /// \param queue for immediate processing or in normal order
     /// \return object ID of the added file - only in blockign mode, when used in async mode this function will return INVALID_OBJECT_ID
-    int addFile(const fs::directory_entry& dirEnt, AutoScanSetting& asSetting,
+    int addFile(const fs::directory_entry& dirEnt, AutoScanSetting* asSetting,
         bool async = true, bool lowPriority = false, bool cancellable = true);
 
     /// \brief Adds a file or directory to the database.
@@ -186,7 +186,7 @@ public:
     /// \param rescanResource true allows to reload a directory containing a resource
     /// \param queue for immediate processing or in normal order
     /// \return object ID of the added file - only in blockign mode, when used in async mode this function will return INVALID_OBJECT_ID
-    int addFile(const fs::directory_entry& dirEnt, const fs::path& rootpath, AutoScanSetting& asSetting,
+    int addFile(const fs::directory_entry& dirEnt, const fs::path& rootpath, AutoScanSetting* asSetting,
         bool async = true, bool lowPriority = false, bool cancellable = true);
 
     int ensurePathExistence(fs::path path);
@@ -340,12 +340,12 @@ protected:
     std::vector<std::shared_ptr<Executor>> process_list;
 
     int addFileInternal(const fs::directory_entry& dirEnt, const fs::path& rootpath,
-        AutoScanSetting& asSetting,
+        AutoScanSetting* asSetting,
         bool async = true,
         bool lowPriority = false,
         unsigned int parentTaskID = 0,
         bool cancellable = true);
-    int _addFile(const fs::directory_entry& dirEnt, fs::path rootPath, AutoScanSetting& asSetting,
+    int _addFile(const fs::directory_entry& dirEnt, fs::path rootPath, AutoScanSetting* asSetting,
         const std::shared_ptr<CMAddFileTask>& task = nullptr);
 
     void _removeObject(const std::shared_ptr<AutoscanDirectory>& adir, int objectID, bool rescanResource, bool all);

--- a/src/content/scripting/js_functions.cc
+++ b/src/content/scripting/js_functions.cc
@@ -180,7 +180,7 @@ duk_ret_t js_addCdsObject(duk_context* ctx)
                     asSetting.rescanResource = false;
                     asSetting.mergeOptions(config, loc);
 
-                    pcd_id = cm->addFile(dirEnt, asSetting, false);
+                    pcd_id = cm->addFile(dirEnt, &asSetting, false);
                     if (pcd_id == INVALID_OBJECT_ID) {
                         return 0;
                     }

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -65,15 +65,15 @@ std::shared_ptr<Database> Database::createInstance(const std::shared_ptr<Config>
     return database;
 }
 
-void Database::stripAndUnescapeVirtualContainerFromPath(std::string virtualPath, std::string& first, std::string& last)
+void Database::stripAndUnescapeVirtualContainerFromPath(std::string virtualPath, std::string* first, std::string* last)
 {
     if (virtualPath.at(0) != VIRTUAL_CONTAINER_SEPARATOR) {
         throw_std_runtime_error("Got non-absolute virtual path {}; needs to start with: {}", virtualPath, VIRTUAL_CONTAINER_SEPARATOR);
     }
     size_t sep = virtualPath.rfind(VIRTUAL_CONTAINER_SEPARATOR);
     if (sep == 0) {
-        first = "/";
-        last = virtualPath.substr(1);
+        *first = "/";
+        *last = virtualPath.substr(1);
     } else {
         while (sep != std::string::npos) {
             char beforeSep = virtualPath.at(sep - 1);
@@ -83,10 +83,10 @@ void Database::stripAndUnescapeVirtualContainerFromPath(std::string virtualPath,
             sep = virtualPath.rfind(VIRTUAL_CONTAINER_SEPARATOR, sep - 1);
         }
         if (sep == 0) {
-            first = "/";
+            *first = "/";
         } else {
-            first = virtualPath.substr(0, sep);
+            *first = virtualPath.substr(0, sep);
         }
-        last = unescape(virtualPath.substr(sep + 1), VIRTUAL_CONTAINER_ESCAPE);
+        *last = unescape(virtualPath.substr(sep + 1), VIRTUAL_CONTAINER_ESCAPE);
     }
 }

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -173,7 +173,7 @@ public:
     /// updateID will hold the objectID of the container that was changed,
     /// in case new containers were created during the operation.
     virtual void addContainerChain(std::string path, const std::string& lastClass, int lastRefID, int* containerID,
-        std::vector<int>& updateID, const std::map<std::string, std::string>& lastMetadata)
+        std::vector<int>* updateID, const std::map<std::string, std::string>& lastMetadata)
         = 0;
 
     /// \brief Builds the container path. Fetches the path of the
@@ -305,7 +305,7 @@ public:
 
 protected:
     /* helper for addContainerChain */
-    static void stripAndUnescapeVirtualContainerFromPath(std::string path, std::string& first, std::string& last);
+    static void stripAndUnescapeVirtualContainerFromPath(std::string path, std::string* first, std::string* last);
 
     static std::shared_ptr<Database> createInstance(const std::shared_ptr<Config>& config, const std::shared_ptr<Timer>& timer);
     friend class Server;

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -140,7 +140,7 @@ public:
     std::string incrementUpdateIDs(const std::unique_ptr<std::unordered_set<int>>& ids) override;
 
     fs::path buildContainerPath(int parentID, const std::string& title) override;
-    void addContainerChain(std::string path, const std::string& lastClass, int lastRefID, int* containerID, std::vector<int>& updateID, const std::map<std::string, std::string>& lastMetadata) override;
+    void addContainerChain(std::string path, const std::string& lastClass, int lastRefID, int* containerID, std::vector<int>* updateID, const std::map<std::string, std::string>& lastMetadata) override;
     std::string getInternalSetting(const std::string& key) override;
     void storeInternalSetting(const std::string& key, const std::string& value) override = 0;
 
@@ -223,7 +223,7 @@ private:
     std::vector<std::shared_ptr<AddUpdateTable>> _addUpdateObject(const std::shared_ptr<CdsObject>& obj, Operation op, int* changedContainer);
 
     void generateMetadataDBOperations(const std::shared_ptr<CdsObject>& obj, Operation op,
-        std::vector<std::shared_ptr<AddUpdateTable>>& operations);
+        std::vector<std::shared_ptr<AddUpdateTable>>* operations);
 
     std::unique_ptr<std::ostringstream> sqlForInsert(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<AddUpdateTable>& addUpdateTable) const;
     std::unique_ptr<std::ostringstream> sqlForUpdate(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<AddUpdateTable>& addUpdateTable) const;

--- a/src/main.cc
+++ b/src/main.cc
@@ -529,7 +529,7 @@ int main(int argc, char** argv, char** envp)
                         asSetting.hidden = configManager->getBoolOption(CFG_IMPORT_HIDDEN_FILES);
                         asSetting.rescanResource = false;
                         asSetting.mergeOptions(configManager, f);
-                        server->getContent()->addFile(dirEnt, asSetting, true);
+                        server->getContent()->addFile(dirEnt, &asSetting, true);
                     } else {
                         log_error("Failed to read {}: {}", f.c_str(), ec.message());
                     }

--- a/src/web/add.cc
+++ b/src/web/add.cc
@@ -60,7 +60,7 @@ void web::add::process()
     std::error_code ec;
     auto dirEnt = fs::directory_entry(path, ec);
     if (!ec) {
-        content->addFile(dirEnt, asSetting);
+        content->addFile(dirEnt, &asSetting);
     } else {
         log_error("Failed to read {}: {}", path.c_str(), ec.message());
     }

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -21,7 +21,7 @@ public:
 
     void addObject(std::shared_ptr<CdsObject> object, int* changedContainer) override { }
     void addContainerChain(std::string path, const std::string& lastClass, int lastRefID, int* containerID,
-        std::vector<int>& updateID, const std::map<std::string, std::string>& lastMetadata) override { }
+        std::vector<int>* updateID, const std::map<std::string, std::string>& lastMetadata) override { }
     fs::path buildContainerPath(int parentID, const std::string& title) override { return ""; }
 
     void updateObject(std::shared_ptr<CdsObject> object, int* changedContainer) override { }


### PR DESCRIPTION
Found with google-runtime-references

Signed-off-by: Rosen Penev <rosenp@gmail.com>