### PR TITLE
clang: add missing move

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -138,7 +138,7 @@ std::unique_ptr<IOHandler> MatroskaHandler::serveContent(std::shared_ptr<CdsObje
     std::unique_ptr<MemIOHandler> io_handler;
     parseMKV(item, &io_handler);
 
-    return io_handler;
+    return std::move(io_handler);
 }
 
 void MatroskaHandler::parseMKV(const std::shared_ptr<CdsItem>& item, std::unique_ptr<MemIOHandler>* p_io_handler) const


### PR DESCRIPTION
Found with Wreturn-std-move-in-c++11

Signed-off-by: Rosen Penev <rosenp@gmail.com>