### PR TITLE
add back several defaulted destructors

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -121,6 +121,8 @@ protected:
     std::shared_ptr<CdsObject> parent;
 
 public:
+    virtual ~CdsObject() = default;
+
     /// \brief Set the object ID.
     ///
     /// ID is the object ID that is used by the UPnP Content Directory service.

--- a/src/config/config_options.h
+++ b/src/config/config_options.h
@@ -46,6 +46,8 @@ class DirectoryConfigList;
 
 class ConfigOption {
 public:
+    virtual ~ConfigOption() = default;
+
     virtual std::string getOption() const
     {
         throw std::runtime_error("Wrong option type string");

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -92,6 +92,8 @@ protected:
     }
 
 public:
+    virtual ~ConfigSetup() = default;
+
     static constexpr auto ROOT_NAME = std::string_view("config");
 
     pugi::xpath_node_set getXmlTree(const pugi::xml_node& element) const;

--- a/src/content/layout/layout.h
+++ b/src/content/layout/layout.h
@@ -45,6 +45,7 @@ class ContentManager;
 class Layout {
 public:
     explicit Layout(std::shared_ptr<ContentManager> content);
+    virtual ~Layout() = default;
 
     virtual void processCdsObject(std::shared_ptr<CdsObject> obj, fs::path rootpath) = 0;
 

--- a/src/content/onlineservice/curl_online_service.h
+++ b/src/content/onlineservice/curl_online_service.h
@@ -46,6 +46,7 @@ class CdsObject;
 class CurlContentHandler {
 public:
     explicit CurlContentHandler(const std::shared_ptr<Context>& context);
+    virtual ~CurlContentHandler() = default;
 
     /// \brief Sets the service XML from which we will extract the objects.
     /// \return false if service XML contained an error status.

--- a/src/database/search_handler.h
+++ b/src/database/search_handler.h
@@ -111,6 +111,8 @@ class SQLEmitter;
 
 class ASTNode {
 public:
+    virtual ~ASTNode() = default;
+
     std::string emitSQL() const;
     virtual std::string emit() const = 0;
 
@@ -356,6 +358,7 @@ protected:
 
 class SQLEmitter {
 public:
+    virtual ~SQLEmitter() = default;
     virtual std::string emitSQL(const ASTNode* node) const = 0;
     virtual std::string emit(const ASTAsterisk* node) const = 0;
     virtual std::string emit(const ASTParenthesis* node, const std::string& bracketedNode) const = 0;
@@ -374,6 +377,7 @@ public:
 
 class ColumnMapper {
 public:
+    virtual ~ColumnMapper() = default;
     virtual bool hasEntry(const std::string& tag) const = 0;
     virtual std::string tableQuoted() const = 0;
     virtual std::string mapQuoted(const std::string& tag) const = 0;

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -54,8 +54,7 @@ class SQLEmitter;
 
 class SQLRow {
 public:
-    //SQLRow() { }
-    //virtual ~SQLRow();
+    virtual ~SQLRow() = default;
     std::string col(int index) const
     {
         char* c = col_c_str(index);
@@ -64,8 +63,6 @@ public:
         return std::string(c);
     }
     virtual char* col_c_str(int index) const = 0;
-
-    virtual ~SQLRow() = default;
 };
 
 class SQLResult {

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -48,8 +48,7 @@ class Sqlite3Result;
 /// \brief A virtual class that represents a task to be done by the sqlite3 thread.
 class SLTask {
 public:
-    /// \brief Instantiate a task
-    SLTask() = default;
+    virtual ~SLTask() = default;
 
     /// \brief run the sqlite3 task
     /// \param sl The instance of Sqlite3Database to do the queries with.

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -190,6 +190,7 @@ public:
     /// \brief Definition of the supported metadata fields.
 
     explicit MetadataHandler(const std::shared_ptr<Context>& context);
+    virtual ~MetadataHandler() = default;
 
     static void setMetadata(const std::shared_ptr<Context>& context, const std::shared_ptr<CdsItem>& item, const fs::directory_entry& dirEnt);
     static std::string getMetaFieldName(metadata_fields_t field);

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -52,7 +52,8 @@ class Server;
 
 class RequestHandler {
 public:
-    RequestHandler(std::shared_ptr<ContentManager> content);
+    explicit RequestHandler(std::shared_ptr<ContentManager> content);
+    virtual ~RequestHandler() = default;
 
     /// \brief Returns information about the requested content.
     /// \param filename Requested URL

--- a/src/transcoding/transcode_handler.h
+++ b/src/transcoding/transcode_handler.h
@@ -49,6 +49,7 @@ class TranscodingProfile;
 class TranscodeHandler {
 public:
     explicit TranscodeHandler(std::shared_ptr<ContentManager> content);
+    virtual ~TranscodeHandler() = default;
 
     virtual std::unique_ptr<IOHandler> serveContent(std::shared_ptr<TranscodingProfile> profile,
         std::string location,

--- a/src/util/generic_task.h
+++ b/src/util/generic_task.h
@@ -32,6 +32,7 @@ protected:
 
 public:
     explicit GenericTask(task_owner_t taskOwner);
+    virtual ~GenericTask() = default;
     virtual void run() = 0;
     void setDescription(const std::string& description) { this->description = description; }
     std::string getDescription() const { return description; }


### PR DESCRIPTION
Found with Wnon-virtual-dtor and delete-non-abstract-non-virtual-dtor

These seem to be needed by smart pointers.

Signed-off-by: Rosen Penev <rosenp@gmail.com>