### PR TITLE
remove several defines

### DIFF
--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -45,56 +45,56 @@
 //#define MYSQL_EXEC_DEBUG
 
 // updates 1->2
-#define MYSQL_UPDATE_1_2_1 "ALTER TABLE `mt_cds_object` CHANGE `location` `location` BLOB NULL DEFAULT NULL"
-#define MYSQL_UPDATE_1_2_2 "ALTER TABLE `mt_cds_object` CHANGE `metadata` `metadata` BLOB NULL DEFAULT NULL"
-#define MYSQL_UPDATE_1_2_3 "ALTER TABLE `mt_cds_object` CHANGE `auxdata` `auxdata` BLOB NULL DEFAULT NULL"
-#define MYSQL_UPDATE_1_2_4 "ALTER TABLE `mt_cds_object` CHANGE `resources` `resources` BLOB NULL DEFAULT NULL"
-#define MYSQL_UPDATE_1_2_5 "ALTER TABLE `mt_autoscan` CHANGE `location` `location` BLOB NULL DEFAULT NULL"
+static constexpr auto MYSQL_UPDATE_1_2_1 = "ALTER TABLE `mt_cds_object` CHANGE `location` `location` BLOB NULL DEFAULT NULL";
+static constexpr auto MYSQL_UPDATE_1_2_2 = "ALTER TABLE `mt_cds_object` CHANGE `metadata` `metadata` BLOB NULL DEFAULT NULL";
+static constexpr auto MYSQL_UPDATE_1_2_3 = "ALTER TABLE `mt_cds_object` CHANGE `auxdata` `auxdata` BLOB NULL DEFAULT NULL";
+static constexpr auto MYSQL_UPDATE_1_2_4 = "ALTER TABLE `mt_cds_object` CHANGE `resources` `resources` BLOB NULL DEFAULT NULL";
+static constexpr auto MYSQL_UPDATE_1_2_5 = "ALTER TABLE `mt_autoscan` CHANGE `location` `location` BLOB NULL DEFAULT NULL";
 
 // updates 2->3
-#define MYSQL_UPDATE_2_3_1 "ALTER TABLE `mt_autoscan` CHANGE `scan_mode` `scan_mode` ENUM( 'timed', 'inotify' ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL"
-#define MYSQL_UPDATE_2_3_2 "ALTER TABLE `mt_autoscan` DROP INDEX `mt_autoscan_obj_id`, ADD UNIQUE `mt_autoscan_obj_id` ( `obj_id` )"
-#define MYSQL_UPDATE_2_3_3 "ALTER TABLE `mt_autoscan` ADD `path_ids` BLOB AFTER `location`"
+static constexpr auto MYSQL_UPDATE_2_3_1 = "ALTER TABLE `mt_autoscan` CHANGE `scan_mode` `scan_mode` ENUM( 'timed', 'inotify' ) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL";
+static constexpr auto MYSQL_UPDATE_2_3_2 = "ALTER TABLE `mt_autoscan` DROP INDEX `mt_autoscan_obj_id`, ADD UNIQUE `mt_autoscan_obj_id` ( `obj_id` )";
+static constexpr auto MYSQL_UPDATE_2_3_3 = "ALTER TABLE `mt_autoscan` ADD `path_ids` BLOB AFTER `location`";
 
 // updates 3->4
-#define MYSQL_UPDATE_3_4_1 "ALTER TABLE `mt_cds_object` ADD `service_id` varchar(255) default NULL"
-#define MYSQL_UPDATE_3_4_2 "ALTER TABLE `mt_cds_object` ADD KEY `cds_object_service_id` (`service_id`)"
+static constexpr auto MYSQL_UPDATE_3_4_1 = "ALTER TABLE `mt_cds_object` ADD `service_id` varchar(255) default NULL";
+static constexpr auto MYSQL_UPDATE_3_4_2 = "ALTER TABLE `mt_cds_object` ADD KEY `cds_object_service_id` (`service_id`)";
 
 // updates 4->5
-#define MYSQL_UPDATE_4_5_1 "CREATE TABLE `mt_metadata` ( \
-  `id` int(11) NOT NULL auto_increment, \
-  `item_id` int(11) NOT NULL, \
-  `property_name` varchar(255) NOT NULL, \
-  `property_value` text NOT NULL, \
-  PRIMARY KEY `id` (`id`), \
-  KEY `metadata_item_id` (`item_id`), \
-  CONSTRAINT `mt_metadata_idfk1` FOREIGN KEY (`item_id`) REFERENCES `mt_cds_object` (`id`) ON DELETE CASCADE ON UPDATE CASCADE \
-) ENGINE=MyISAM CHARSET=utf8"
+static constexpr auto MYSQL_UPDATE_4_5_1 = "CREATE TABLE `mt_metadata` ( "
+                                           "`id` int(11) NOT NULL auto_increment, "
+                                           "`item_id` int(11) NOT NULL, "
+                                           "`property_name` varchar(255) NOT NULL, "
+                                           "`property_value` text NOT NULL, "
+                                           "PRIMARY KEY `id` (`id`), "
+                                           "KEY `metadata_item_id` (`item_id`), "
+                                           "CONSTRAINT `mt_metadata_idfk1` FOREIGN KEY (`item_id`) REFERENCES `mt_cds_object` (`id`) ON DELETE CASCADE ON UPDATE CASCADE "
+                                           ") ENGINE=MyISAM CHARSET=utf8";
 
 // updates 5->6: add config value table
-#define MYSQL_UPDATE_5_6_1 "CREATE TABLE `grb_config_value` ( \
-  `item` varchar(255) primary key, \
-  `key` varchar(255) NOT NULL, \
-  `item_value` varchar(255) NOT NULL, \
-  `status` varchar(20) NOT NULL) \
-  ENGINE=MyISAM CHARSET=utf8"
-#define MYSQL_UPDATE_5_6_2 "CREATE INDEX grb_config_value_item ON grb_config_value(item)"
+static constexpr auto MYSQL_UPDATE_5_6_1 = "CREATE TABLE `grb_config_value` ( "
+                                           "`item` varchar(255) primary key, "
+                                           "`key` varchar(255) NOT NULL, "
+                                           "`item_value` varchar(255) NOT NULL, "
+                                           "`status` varchar(20) NOT NULL) "
+                                           "ENGINE=MyISAM CHARSET=utf8";
+static constexpr auto MYSQL_UPDATE_5_6_2 = "CREATE INDEX grb_config_value_item ON grb_config_value(item)";
 
 // updates 6->7
-#define MYSQL_UPDATE_6_7_1 "DROP TABLE mt_cds_active_item;"
+static constexpr auto MYSQL_UPDATE_6_7_1 = "DROP TABLE mt_cds_active_item;";
 
 // updates 7->8: part_number
-#define MYSQL_UPDATE_7_8_1 "ALTER TABLE `mt_cds_object` ADD `part_number` int(11) default NULL AFTER `flags`"
-#define MYSQL_UPDATE_7_8_2 "ALTER TABLE `mt_cds_object` DROP KEY `cds_object_track_number`"
-#define MYSQL_UPDATE_7_8_3 "ALTER TABLE `mt_cds_object` ADD KEY `cds_object_track_number` (`part_number`,`track_number`)"
+static constexpr auto MYSQL_UPDATE_7_8_1 = "ALTER TABLE `mt_cds_object` ADD `part_number` int(11) default NULL AFTER `flags`";
+static constexpr auto MYSQL_UPDATE_7_8_2 = "ALTER TABLE `mt_cds_object` DROP KEY `cds_object_track_number`";
+static constexpr auto MYSQL_UPDATE_7_8_3 = "ALTER TABLE `mt_cds_object` ADD KEY `cds_object_track_number` (`part_number`,`track_number`)";
 
 // updates 8->9: bookmark_pos
-#define MYSQL_UPDATE_8_9_1 "ALTER TABLE `mt_cds_object` ADD `bookmark_pos` int(11) unsigned NOT NULL default '0' AFTER `service_id`"
+static constexpr auto MYSQL_UPDATE_8_9_1 = "ALTER TABLE `mt_cds_object` ADD `bookmark_pos` int(11) unsigned NOT NULL default '0' AFTER `service_id`";
 
 // updates 9->10: last_modified
-#define MYSQL_UPDATE_9_10_1 "ALTER TABLE `mt_cds_object` ADD `last_modified` bigint(20) unsigned default NULL AFTER `bookmark_pos`"
+static constexpr auto MYSQL_UPDATE_9_10_1 = "ALTER TABLE `mt_cds_object` ADD `last_modified` bigint(20) unsigned default NULL AFTER `bookmark_pos`";
 
-#define MYSQL_UPDATE_VERSION "UPDATE `mt_internal_setting` SET `value`='{}' WHERE `key`='db_version' AND `value`='{}'"
+static constexpr auto MYSQL_UPDATE_VERSION = "UPDATE `mt_internal_setting` SET `value`='{}' WHERE `key`='db_version' AND `value`='{}'";
 
 static const auto dbUpdates = std::array<std::vector<const char*>, 9> { {
     { MYSQL_UPDATE_1_2_1, MYSQL_UPDATE_1_2_2, MYSQL_UPDATE_1_2_3, MYSQL_UPDATE_1_2_4, MYSQL_UPDATE_1_2_5 },
@@ -195,8 +195,7 @@ void MySQLDatabase::init()
         dbName.c_str(),
         dbPort, // port
         (dbSock.empty() ? nullptr : dbSock.c_str()), // socket
-        0 // flags
-    );
+        0); // flags
     if (!res_mysql) {
         throw_std_runtime_error("Connecting to database {}:{}/{} failed: {}", dbHost, dbPort, dbName, getError(&db));
     }

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -35,88 +35,88 @@
 
 #include "config/config_manager.h"
 
-#define DB_BACKUP_FORMAT "{}.backup"
+static constexpr auto DB_BACKUP_FORMAT = "{}.backup";
 
 // updates 1->2
-#define SQLITE3_UPDATE_1_2_1 "DROP INDEX mt_autoscan_obj_id"
-#define SQLITE3_UPDATE_1_2_2 "CREATE UNIQUE INDEX mt_autoscan_obj_id ON mt_autoscan(obj_id)"
-#define SQLITE3_UPDATE_1_2_3 "ALTER TABLE \"mt_autoscan\" ADD \"path_ids\" text"
+static constexpr auto SQLITE3_UPDATE_1_2_1 = "DROP INDEX mt_autoscan_obj_id";
+static constexpr auto SQLITE3_UPDATE_1_2_2 = "CREATE UNIQUE INDEX mt_autoscan_obj_id ON mt_autoscan(obj_id)";
+static constexpr auto SQLITE3_UPDATE_1_2_3 = R"(ALTER TABLE "mt_autoscan" ADD "path_ids" text)";
 
 // updates 2->3
-#define SQLITE3_UPDATE_2_3_1 "ALTER TABLE \"mt_cds_object\" ADD \"service_id\" varchar(255) default NULL"
-#define SQLITE3_UPDATE_2_3_2 "CREATE INDEX mt_cds_object_service_id ON mt_cds_object(service_id)"
+static constexpr auto SQLITE3_UPDATE_2_3_1 = R"(ALTER TABLE "mt_cds_object" ADD "service_id" varchar(255) default NULL)";
+static constexpr auto SQLITE3_UPDATE_2_3_2 = "CREATE INDEX mt_cds_object_service_id ON mt_cds_object(service_id)";
 
 // updates 3->4: Move to Metadata table
-#define SQLITE3_UPDATE_3_4_1 "CREATE TABLE \"mt_metadata\" ( \
-  \"id\" integer primary key, \
-  \"item_id\" integer NOT NULL, \
-  \"property_name\" varchar(255) NOT NULL, \
-  \"property_value\" text NOT NULL, \
-  CONSTRAINT \"mt_metadata_idfk1\" FOREIGN KEY (\"item_id\") REFERENCES \"mt_cds_object\" (\"id\") \
-  ON DELETE CASCADE ON UPDATE CASCADE )"
-#define SQLITE3_UPDATE_3_4_2 "CREATE INDEX mt_metadata_item_id ON mt_metadata(item_id)"
+static constexpr auto SQLITE3_UPDATE_3_4_1 = R"(CREATE TABLE "mt_metadata" ()"
+                                             R"("id" integer primary key, )"
+                                             R"("item_id" integer NOT NULL, )"
+                                             R"("property_name" varchar(255) NOT NULL, )"
+                                             R"("property_value" text NOT NULL, )"
+                                             R"(CONSTRAINT "mt_metadata_idfk1" FOREIGN KEY ("item_id") REFERENCES "mt_cds_object" ("id") )"
+                                             R"(ON DELETE CASCADE ON UPDATE CASCADE )";
+static constexpr auto SQLITE3_UPDATE_3_4_2 = "CREATE INDEX mt_metadata_item_id ON mt_metadata(item_id)";
 
 // updates 4->5: Fix incorrect SQLite foreign key
-#define SQLITE3_UPDATE_4_5_1 "PRAGMA foreign_keys = OFF;  \
-CREATE TABLE mt_cds_object_new \
-( \
-    id integer primary key, \
-    ref_id integer default NULL \
-    constraint cds_object_ibfk_1 \
-        references mt_cds_object (id) \
-            ON update cascade on delete cascade, \
-            parent_id integer default '0' not null \
-    constraint cds_object_ibfk_2 \
-        references mt_cds_object (id) \
-            ON update cascade on delete cascade, \
-            object_type tinyint unsigned not null, \
-    upnp_class varchar(80) default NULL, \
-    dc_title varchar(255) default NULL, \
-    location text default NULL, \
-    location_hash integer unsigned default NULL, \
-    metadata text default NULL, \
-    auxdata text default NULL, \
-    resources text default NULL, \
-    update_id integer default '0' not null, \
-    mime_type varchar(40) default NULL, \
-    flags integer unsigned default '1' not null, \
-    track_number integer default NULL, \
-    service_id varchar(255) default NULL \
-); \
-INSERT INTO mt_cds_object_new(id, ref_id, parent_id, object_type, upnp_class, dc_title, location, location_hash, metadata, auxdata, resources, update_id, mime_type, flags, track_number, service_id) SELECT id, ref_id, parent_id, object_type, upnp_class, dc_title, location, location_hash, metadata, auxdata, resources, update_id, mime_type, flags, track_number, service_id FROM mt_cds_object; \
-DROP TABLE mt_cds_object; \
-ALTER TABLE mt_cds_object_new RENAME TO mt_cds_object; \
-CREATE INDEX mt_cds_object_parent_id ON mt_cds_object (parent_id, object_type, dc_title); \
-CREATE INDEX mt_cds_object_ref_id ON mt_cds_object (ref_id); \
-CREATE INDEX mt_cds_object_service_id ON mt_cds_object (service_id); \
-CREATE INDEX mt_location_parent ON mt_cds_object (location_hash, parent_id); \
-CREATE INDEX mt_object_type ON mt_cds_object (object_type); \
-CREATE INDEX mt_track_number on mt_cds_object (track_number); \
-PRAGMA foreign_keys = ON;"
+static constexpr auto SQLITE3_UPDATE_4_5_1 = "PRAGMA foreign_keys = OFF;  "
+                                             "CREATE TABLE mt_cds_object_new "
+                                             "( "
+                                             "    id integer primary key, "
+                                             "    ref_id integer default NULL "
+                                             "    constraint cds_object_ibfk_1 "
+                                             "        references mt_cds_object (id) "
+                                             "            ON update cascade on delete cascade, "
+                                             "            parent_id integer default '0' not null "
+                                             "    constraint cds_object_ibfk_2 "
+                                             "        references mt_cds_object (id) "
+                                             "            ON update cascade on delete cascade, "
+                                             "            object_type tinyint unsigned not null, "
+                                             "    upnp_class varchar(80) default NULL, "
+                                             "    dc_title varchar(255) default NULL, "
+                                             "    location text default NULL, "
+                                             "    location_hash integer unsigned default NULL, "
+                                             "    metadata text default NULL, "
+                                             "    auxdata text default NULL, "
+                                             "    resources text default NULL, "
+                                             "    update_id integer default '0' not null, "
+                                             "    mime_type varchar(40) default NULL, "
+                                             "    flags integer unsigned default '1' not null, "
+                                             "    track_number integer default NULL, "
+                                             "    service_id varchar(255) default NULL "
+                                             "); "
+                                             "INSERT INTO mt_cds_object_new(id, ref_id, parent_id, object_type, upnp_class, dc_title, location, location_hash, metadata, auxdata, resources, update_id, mime_type, flags, track_number, service_id) SELECT id, ref_id, parent_id, object_type, upnp_class, dc_title, location, location_hash, metadata, auxdata, resources, update_id, mime_type, flags, track_number, service_id FROM mt_cds_object; "
+                                             "DROP TABLE mt_cds_object; "
+                                             "ALTER TABLE mt_cds_object_new RENAME TO mt_cds_object; "
+                                             "CREATE INDEX mt_cds_object_parent_id ON mt_cds_object (parent_id, object_type, dc_title); "
+                                             "CREATE INDEX mt_cds_object_ref_id ON mt_cds_object (ref_id); "
+                                             "CREATE INDEX mt_cds_object_service_id ON mt_cds_object (service_id); "
+                                             "CREATE INDEX mt_location_parent ON mt_cds_object (location_hash, parent_id); "
+                                             "CREATE INDEX mt_object_type ON mt_cds_object (object_type); "
+                                             "CREATE INDEX mt_track_number on mt_cds_object (track_number); "
+                                             "PRAGMA foreign_keys = ON;";
 
 // updates 5->6: add config value table
-#define SQLITE3_UPDATE_5_6_1 "CREATE TABLE \"grb_config_value\" ( \
-  \"item\" varchar(255) primary key, \
-  \"key\" varchar(255) NOT NULL, \
-  \"item_value\" varchar(255) NOT NULL, \
-  \"status\" varchar(20) NOT NULL)"
-#define SQLITE3_UPDATE_5_6_2 "CREATE INDEX grb_config_value_item ON grb_config_value(item)"
+static constexpr auto SQLITE3_UPDATE_5_6_1 = R"(CREATE TABLE "grb_config_value" ( )"
+                                             R"("item" varchar(255) primary key, )"
+                                             R"("key" varchar(255) NOT NULL, )"
+                                             R"("item_value" varchar(255) NOT NULL, )"
+                                             R"("status" varchar(20) NOT NULL)";
+static constexpr auto SQLITE3_UPDATE_5_6_2 = "CREATE INDEX grb_config_value_item ON grb_config_value(item)";
 
 // updates 6->7
-#define SQLITE3_UPDATE_6_7_1 "DROP TABLE mt_cds_active_item;"
+static constexpr auto SQLITE3_UPDATE_6_7_1 = "DROP TABLE mt_cds_active_item;";
 
 // updates 7->8: part_number
-#define SQLITE3_UPDATE_7_8_1 "ALTER TABLE \"mt_cds_object\" ADD \"part_number\" integer default NULL"
-#define SQLITE3_UPDATE_7_8_2 "DROP INDEX mt_track_number"
-#define SQLITE3_UPDATE_7_8_3 "CREATE INDEX \"grb_track_number\" ON mt_cds_object (part_number,track_number)"
+static constexpr auto SQLITE3_UPDATE_7_8_1 = R"(ALTER TABLE "mt_cds_object" ADD "part_number" integer default NULL)";
+static constexpr auto SQLITE3_UPDATE_7_8_2 = "DROP INDEX mt_track_number";
+static constexpr auto SQLITE3_UPDATE_7_8_3 = R"(CREATE INDEX "grb_track_number" ON mt_cds_object (part_number,track_number))";
 
 // updates 8->9: bookmark_pos
-#define SQLITE3_UPDATE_8_9_1 "ALTER TABLE \"mt_cds_object\" ADD \"bookmark_pos\" integer unsigned NOT NULL default 0"
+static constexpr auto SQLITE3_UPDATE_8_9_1 = R"(ALTER TABLE "mt_cds_object" ADD "bookmark_pos" integer unsigned NOT NULL default 0)";
 
 // updates 9->10: last_modified
-#define SQLITE3_UPDATE_9_10_1 "ALTER TABLE \"mt_cds_object\" ADD \"last_modified\" integer unsigned default NULL"
+static constexpr auto SQLITE3_UPDATE_9_10_1 = R"(ALTER TABLE "mt_cds_object" ADD "last_modified" integer unsigned default NULL)";
 
-#define SQLITE3_UPDATE_VERSION "UPDATE \"mt_internal_setting\" SET \"value\"='{}' WHERE \"key\"='db_version' AND \"value\"='{}'"
+static constexpr auto SQLITE3_UPDATE_VERSION = R"("UPDATE "mt_internal_setting" SET "value"='{}' WHERE "key"='db_version' AND "value"='{}')";
 
 static const auto dbUpdates = std::array<std::vector<const char*>, 9> { {
     { SQLITE3_UPDATE_1_2_1, SQLITE3_UPDATE_1_2_2, SQLITE3_UPDATE_1_2_3 },


### PR DESCRIPTION
These are hard to read. Convert to constexpr variables and use raw
format strings where needed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Not sure if these are correct transformations. All done manually.