### PR TITLE
clang-tidy: use auto

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -233,7 +233,7 @@ void MatroskaHandler::parseAttachments(const std::shared_ptr<CdsItem>& item, Ebm
         log_debug("KaxFileName = {}", fileName);
 
         if (startswith(fileName, "cover")) {
-            auto&& fileData = GetChild<LIBMATROSKA_NAMESPACE::KaxFileData>(*attachedFile);
+            auto fileData = GetChild<LIBMATROSKA_NAMESPACE::KaxFileData>(*attachedFile);
             log_debug("KaxFileData (size={})", fileData.GetSize());
 
             if (p_io_handler != nullptr) {

--- a/test/scripting/test_import_script.cc
+++ b/test/scripting/test_import_script.cc
@@ -251,7 +251,7 @@ TEST_F(ImportScriptTest, AddsVideoItemToCdsContainerChainWithDirs)
     string mimetype = "video/mpeg";
     string id = "2";
     string location = "/home/gerbera/video.mp4";
-    int online_service = static_cast<int>(OS_None);
+    auto online_service = int(OS_None);
     int theora = 0;
     map<string, string> aux;
     map<string, string> meta;
@@ -288,7 +288,7 @@ TEST_F(ImportScriptTest, AddsAppleTrailerVideoItemToCdsContainerChains)
     string genre = "Genre";
     string id = "2";
     string location = "/home/gerbera/video.mp4";
-    int online_service = static_cast<int>(OS_ATrailers);
+    auto online_service = int(OS_ATrailers);
     int theora = 0;
     map<string, string> res;
 
@@ -337,7 +337,7 @@ TEST_F(ImportScriptTest, AddsImageItemToCdsContainerChains)
     string date = "2018-01-01";
     string id = "2";
     string location = "/home/gerbera/image.jpg";
-    int online_service = static_cast<int>(OS_ATrailers);
+    auto online_service = int(OS_ATrailers);
     int theora = 0;
 
     map<string, string> meta = {
@@ -383,7 +383,7 @@ TEST_F(ImportScriptTest, AddsOggTheoraVideoItemToCdsContainerChainWithDirs)
     string mimetype = "application/ogg";
     string id = "2";
     string location = "/home/gerbera/video.ogg";
-    int online_service = static_cast<int>(OS_None);
+    auto online_service = int(OS_None);
     int theora = 1;
     map<string, string> aux;
     map<string, string> meta;


### PR DESCRIPTION
Found with modernize-use-auto

Signed-off-by: Rosen Penev <rosenp@gmail.com>