### PR TITLE
clang-tidy: remove redundant specifiers

### DIFF
--- a/src/content/onlineservice/sopcast_content_handler.h
+++ b/src/content/onlineservice/sopcast_content_handler.h
@@ -75,7 +75,6 @@ public:
 protected:
     static std::shared_ptr<CdsObject> getObject(const std::string& groupName, const pugi::xml_node& channel);
 
-protected:
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;
 

--- a/src/content/scripting/script.h
+++ b/src/content/scripting/script.h
@@ -108,7 +108,6 @@ protected:
 
     duk_context* ctx;
 
-protected:
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;
     std::shared_ptr<ContentManager> content;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -312,7 +312,6 @@ protected:
 
     virtual std::shared_ptr<Database> getSelf() = 0;
 
-protected:
     std::shared_ptr<Config> config;
 };
 

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -98,7 +98,6 @@ private:
 
     static bool downloadDescription(const std::string& location, std::unique_ptr<pugi::xml_document> xml);
 
-private:
     std::mutex mutex;
     using AutoLock = std::lock_guard<std::mutex>;
     std::shared_ptr<std::vector<ClientCacheEntry>> cache;


### PR DESCRIPTION
Found with readability-redundant-access-specifiers

Signed-off-by: Rosen Penev <rosenp@gmail.com>