### PR TITLE
Close memory leak by duplicate call to ixmlCloneDOMString

### DIFF
--- a/src/content/onlineservice/atrailers_content_handler.cc
+++ b/src/content/onlineservice/atrailers_content_handler.cc
@@ -33,9 +33,8 @@
 #include "atrailers_content_handler.h" // API
 
 #include "cds_objects.h"
-#include "config/config_manager.h"
+#include "config/config.h"
 #include "metadata/metadata_handler.h"
-#include "online_service.h"
 #include "util/tools.h"
 
 ATrailersContentHandler::ATrailersContentHandler(const std::shared_ptr<Context>& context)

--- a/src/content/onlineservice/atrailers_content_handler.h
+++ b/src/content/onlineservice/atrailers_content_handler.h
@@ -35,10 +35,6 @@
 #ifndef __ATRAILERS_CONTENT_HANDLER_H__
 #define __ATRAILERS_CONTENT_HANDLER_H__
 
-#include <memory>
-#include <pugixml.hpp>
-
-#include "context.h"
 #include "curl_online_service.h"
 
 // forward declaration

--- a/src/content/onlineservice/atrailers_service.cc
+++ b/src/content/onlineservice/atrailers_service.cc
@@ -32,14 +32,7 @@
 #ifdef ATRAILERS
 #include "atrailers_service.h" // API
 
-#include <string>
-
-#include "config/config_manager.h"
-#include "config/config_options.h"
 #include "content/content_manager.h"
-#include "database/database.h"
-#include "util/string_converter.h"
-#include "util/url.h"
 
 #define ATRAILERS_SERVICE_URL_640 "https://trailers.apple.com/trailers/home/xml/current.xml"
 #define ATRAILERS_SERVICE_URL_720P "https://trailers.apple.com/trailers/home/xml/current_720p.xml"

--- a/src/content/onlineservice/atrailers_service.h
+++ b/src/content/onlineservice/atrailers_service.h
@@ -35,12 +35,7 @@
 #ifndef __ATRAILERS_SERVICE_H__
 #define __ATRAILERS_SERVICE_H__
 
-#include <curl/curl.h>
-#include <memory>
-#include <pugixml.hpp>
-
 #include "atrailers_content_handler.h"
-#include "curl_online_service.h"
 
 // forward declaration
 class ContentManager;

--- a/src/content/onlineservice/curl_online_service.cc
+++ b/src/content/onlineservice/curl_online_service.cc
@@ -26,10 +26,7 @@
 #ifdef HAVE_CURL
 #include "curl_online_service.h" // API
 
-#include <string>
-
-#include "config/config_manager.h"
-#include "config/config_options.h"
+#include "config/config.h"
 #include "content/content_manager.h"
 #include "database/database.h"
 #include "util/string_converter.h"

--- a/src/content/onlineservice/curl_online_service.h
+++ b/src/content/onlineservice/curl_online_service.h
@@ -31,7 +31,6 @@
 #define __CURL_ONLINE_SERVICE_H__
 
 #include <curl/curl.h>
-#include <memory>
 #include <pugixml.hpp>
 
 #include "context.h"

--- a/src/content/onlineservice/sopcast_content_handler.cc
+++ b/src/content/onlineservice/sopcast_content_handler.cc
@@ -33,8 +33,7 @@
 #include "sopcast_content_handler.h" // API
 
 #include "cds_objects.h"
-#include "config/config_manager.h"
-#include "curl_online_service.h"
+#include "config/config.h"
 #include "metadata/metadata_handler.h"
 #include "util/tools.h"
 

--- a/src/content/onlineservice/sopcast_content_handler.h
+++ b/src/content/onlineservice/sopcast_content_handler.h
@@ -35,10 +35,6 @@
 #ifndef __SOPCAST_CONTENT_HANDLER_H__
 #define __SOPCAST_CONTENT_HANDLER_H__
 
-#include <memory>
-#include <pugixml.hpp>
-
-#include "context.h"
 #include "curl_online_service.h"
 
 #define SOPCAST_SERVICE "SopCast"

--- a/src/content/onlineservice/sopcast_service.cc
+++ b/src/content/onlineservice/sopcast_service.cc
@@ -32,12 +32,8 @@
 #ifdef SOPCAST
 #include "sopcast_service.h" // API
 
-#include "config/config_manager.h"
 #include "content/content_manager.h"
-#include "database/database.h"
 #include "sopcast_content_handler.h"
-#include "util/string_converter.h"
-#include "util/url.h"
 
 #define SOPCAST_CHANNEL_URL "http://www.sopcast.com/gchlxml"
 

--- a/src/content/onlineservice/sopcast_service.h
+++ b/src/content/onlineservice/sopcast_service.h
@@ -35,10 +35,6 @@
 #ifndef __SOPCAST_SERVICE_H__
 #define __SOPCAST_SERVICE_H__
 
-#include <curl/curl.h>
-#include <memory>
-#include <pugixml.hpp>
-
 #include "curl_online_service.h"
 
 // forward declaration

--- a/src/device_description_handler.cc
+++ b/src/device_description_handler.cc
@@ -41,11 +41,7 @@ void DeviceDescriptionHandler::getInfo(const char* filename, UpnpFileInfo* info)
 {
     // We should be able to do the generation here, but libupnp doesnt support the request cookies yet
     UpnpFileInfo_set_FileLength(info, -1);
-#if defined(USING_NPUPNP)
     UpnpFileInfo_set_ContentType(info, "application/xml");
-#else
-    UpnpFileInfo_set_ContentType(info, ixmlCloneDOMString("application/xml"));
-#endif
     UpnpFileInfo_set_IsReadable(info, 1);
     UpnpFileInfo_set_IsDirectory(info, 0);
 }

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -202,7 +202,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 #if defined(USING_NPUPNP)
     UpnpFileInfo_set_ContentType(info, mimeType);
 #else
-    UpnpFileInfo_set_ContentType(info, ixmlCloneDOMString(mimeType.c_str()));
+    UpnpFileInfo_set_ContentType(info, mimeType.c_str());
 #endif
 
     headers->writeHeaders(info);

--- a/src/serve_request_handler.cc
+++ b/src/serve_request_handler.cc
@@ -91,7 +91,7 @@ void ServeRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 #if defined(USING_NPUPNP)
         UpnpFileInfo_set_ContentType(info, mimetype);
 #else
-        UpnpFileInfo_set_ContentType(info, ixmlCloneDOMString(mimetype.c_str()));
+        UpnpFileInfo_set_ContentType(info, mimetype.c_str());
 #endif
     } else {
         throw_std_runtime_error("Not a regular file: {}", path.c_str());

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -117,7 +117,7 @@ void URLRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 #if defined(USING_NPUPNP)
     UpnpFileInfo_set_ContentType(info, mimeType);
 #else
-    UpnpFileInfo_set_ContentType(info, ixmlCloneDOMString(mimeType.c_str()));
+    UpnpFileInfo_set_ContentType(info, mimeType.c_str());
 #endif
     log_debug("web_get_info(): end");
 

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -109,7 +109,7 @@ void WebRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 #if defined(USING_NPUPNP)
     UpnpFileInfo_set_ContentType(info, contentType);
 #else
-    UpnpFileInfo_set_ContentType(info, ixmlCloneDOMString(contentType.c_str()));
+    UpnpFileInfo_set_ContentType(info, contentType.c_str());
 #endif
     Headers headers;
     headers.addHeader(std::string { "Cache-Control" }, std::string { "no-cache, must-revalidate" });


### PR DESCRIPTION
The call is in `UpnpFileInfo_set_ContentType` (at least 1.14.0 which is minimum)

Remove several includes that seem to be copy-pasted (search for pugixml resulted these files)

fixes #1583