### PR TITLE
nppnp changes

### DIFF
--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -199,11 +199,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 
     UpnpFileInfo_set_LastModified(info, statbuf.st_mtime);
     UpnpFileInfo_set_IsDirectory(info, S_ISDIR(statbuf.st_mode));
-#if defined(USING_NPUPNP)
-    UpnpFileInfo_set_ContentType(info, mimeType);
-#else
     UpnpFileInfo_set_ContentType(info, mimeType.c_str());
-#endif
 
     headers->writeHeaders(info);
 

--- a/src/serve_request_handler.cc
+++ b/src/serve_request_handler.cc
@@ -88,11 +88,7 @@ void ServeRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
             UpnpFileInfo_set_IsReadable(info, 0);
         }
 
-#if defined(USING_NPUPNP)
-        UpnpFileInfo_set_ContentType(info, mimetype);
-#else
         UpnpFileInfo_set_ContentType(info, mimetype.c_str());
-#endif
     } else {
         throw_std_runtime_error("Not a regular file: {}", path.c_str());
     }

--- a/src/server.cc
+++ b/src/server.cc
@@ -411,17 +411,9 @@ int Server::handleUpnpClientEvent(Upnp_EventType eventType, const void* event)
     case UPNP_DISCOVERY_ADVERTISEMENT_ALIVE:
     case UPNP_DISCOVERY_SEARCH_RESULT: {
         auto d_event = reinterpret_cast<const UpnpDiscovery*>(event);
-#if defined(USING_NPUPNP)
         const char* userAgent = UpnpDiscovery_get_Os_cstr(d_event);
-#else
-        const char* userAgent = UpnpString_get_String(UpnpDiscovery_get_Os(d_event));
-#endif
         const struct sockaddr_storage* destAddr = UpnpDiscovery_get_DestAddr(d_event);
-#if defined(USING_NPUPNP)
         const char* location = UpnpDiscovery_get_Location_cstr(d_event);
-#else
-        const char* location = UpnpString_get_String(UpnpDiscovery_get_Location(d_event));
-#endif
 
         clients->addClientByDiscovery(destAddr, userAgent, location);
         break;

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -114,11 +114,7 @@ void URLRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     //            ixmlCloneDOMString(header.c_str()));
     //    }
 
-#if defined(USING_NPUPNP)
-    UpnpFileInfo_set_ContentType(info, mimeType);
-#else
     UpnpFileInfo_set_ContentType(info, mimeType.c_str());
-#endif
     log_debug("web_get_info(): end");
 
     /// \todo transcoding for get_info

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -106,11 +106,7 @@ void WebRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     std::string mimetype = (returnType == "xml") ? MIMETYPE_XML : MIMETYPE_JSON;
     std::string contentType = mimetype + "; charset=" + DEFAULT_INTERNAL_CHARSET;
 
-#if defined(USING_NPUPNP)
-    UpnpFileInfo_set_ContentType(info, contentType);
-#else
     UpnpFileInfo_set_ContentType(info, contentType.c_str());
-#endif
     Headers headers;
     headers.addHeader(std::string { "Cache-Control" }, std::string { "no-cache, must-revalidate" });
     headers.writeHeaders(info);


### PR DESCRIPTION
Get rid of the pointless ifdefs and just pass a C string to npupnp. It's
copy constructed anyway.

The overall goal is to reduce the NPUPNP diff to libupnp.

Signed-off-by: Rosen Penev <rosenp@gmail.com>