### PR TITLE
clang-tidy: return a new vector

### DIFF
--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -125,9 +125,7 @@ std::vector<fs::path> ContentPathSetup::getContentPath(const std::shared_ptr<Cds
             }
         }
     }
-    if (result.empty())
-        result.push_back("");
-    return result;
+    return result.empty() ? std::vector<fs::path>(1, "") : std::move(result);
 }
 
 static constexpr std::array<std::pair<std::string_view, metadata_fields_t>, 5> metaTags { {


### PR DESCRIPTION
clang-tidy complains to use emplace_back instead of push_back. Just
return a vector with an empty element.

Signed-off-by: Rosen Penev <rosenp@gmail.com>