### PR TITLE
switch several for loops to use size_t

### DIFF
--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -211,7 +211,7 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
     // video resolution, audio sampling rate, nr of audio channels
     audioset = false;
     videoset = false;
-    for (unsigned int i = 0; i < pFormatCtx->nb_streams; i++) {
+    for (size_t i = 0; i < pFormatCtx->nb_streams; i++) {
         AVStream* st = pFormatCtx->streams[i];
         if ((st != nullptr) && (!videoset) && (as_codecpar(st)->codec_type == AVMEDIA_TYPE_VIDEO)) {
             if (as_codecpar(st)->codec_tag > 0) {

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -183,7 +183,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
     std::array<char, BUFLEN> exif_entry_buffer;
 #define exif_egv(arg) exif_entry_get_value(arg, exif_entry_buffer.data(), BUFLEN)
 
-    for (unsigned int i = 0; i < content->count; i++) {
+    for (size_t i = 0; i < content->count; i++) {
         ExifEntry* e = content->entries[i];
 
         // log_debug("Processing entry: {}", i);

--- a/src/server.cc
+++ b/src/server.cc
@@ -215,7 +215,7 @@ int Server::startupInterface(const std::string& iface, in_port_t inPort)
     const char* ifName = iface.empty() ? nullptr : iface.c_str();
 
     int ret = UPNP_E_INIT_FAILED;
-    for (int attempt = 0; ret != UPNP_E_SUCCESS; attempt++) {
+    for (size_t attempt = 0; ret != UPNP_E_SUCCESS; attempt++) {
         ret = UpnpInit2(ifName, inPort);
         if (ret != UPNP_E_SUCCESS) {
             if (attempt > 3) {


### PR DESCRIPTION
Array indeces are typically pointers, which are either 32 or 64 bit. Use
size_t to avoid bad code generation.

Signed-off-by: Rosen Penev <rosenp@gmail.com>