### PR TITLE
replace several usages of format with to_string

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -657,7 +657,7 @@ void ConfigManager::setOrigValue(const std::string& item, bool value)
 
 void ConfigManager::setOrigValue(const std::string& item, int value)
 {
-    origValues.try_emplace(item, fmt::format("{}", value));
+    origValues.try_emplace(item, fmt::to_string(value));
 }
 
 // The validate function ensures that the array is completely filled!

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -928,7 +928,7 @@ bool ConfigAutoscanSetup::updateItem(size_t i, const std::string& optItem, const
     index = getItemPath(i, ATTR_AUTOSCAN_DIRECTORY_INTERVAL);
     if (optItem == index) {
         if (entry->getOrig())
-            config->setOrigValue(index, fmt::format("{}", entry->getInterval().count()));
+            config->setOrigValue(index, fmt::to_string(entry->getInterval().count()));
         entry->setInterval(std::chrono::seconds(ConfigDefinition::findConfigSetup<ConfigIntSetup>(ATTR_AUTOSCAN_DIRECTORY_INTERVAL)->checkIntValue(optValue)));
         log_debug("New Autoscan Detail {} {}", index, config->getAutoscanListOption(option)->get(i)->getInterval().count());
         return true;
@@ -1175,7 +1175,7 @@ void ConfigTranscodingSetup::makeOption(const pugi::xml_node& root, const std::s
 std::string ConfigTranscodingSetup::getItemPath(int index, config_option_t propOption, config_option_t propOption2, config_option_t propOption3, config_option_t propOption4) const
 {
     if (index < 0) {
-        return fmt::format("{}", xpath);
+        return fmt::to_string(xpath);
     }
 
     auto opt2 = ConfigDefinition::ensureAttribute(propOption2, propOption3 == CFG_MAX);
@@ -1553,7 +1553,7 @@ std::shared_ptr<ConfigOption> ConfigClientSetup::newOption(const pugi::xml_node&
 std::string ConfigClientSetup::getItemPath(int index, config_option_t propOption, config_option_t propOption2, config_option_t propOption3, config_option_t propOption4) const
 {
     if (index < 0) {
-        return fmt::format("{}", ConfigDefinition::mapConfigOption(ATTR_CLIENTS_CLIENT));
+        return fmt::to_string(ConfigDefinition::mapConfigOption(ATTR_CLIENTS_CLIENT));
     }
     if (propOption != CFG_MAX) {
         return fmt::format("{}[{}]/{}", ConfigDefinition::mapConfigOption(ATTR_CLIENTS_CLIENT), index, ConfigDefinition::ensureAttribute(propOption));
@@ -1781,7 +1781,7 @@ std::shared_ptr<ConfigOption> ConfigDirectorySetup::newOption(const pugi::xml_no
 std::string ConfigDirectorySetup::getItemPath(int index, config_option_t propOption, config_option_t propOption2, config_option_t propOption3, config_option_t propOption4) const
 {
     if (index < 0) {
-        return fmt::format("{}", ConfigDefinition::mapConfigOption(ATTR_DIRECTORIES_TWEAK));
+        return fmt::to_string(ConfigDefinition::mapConfigOption(ATTR_DIRECTORIES_TWEAK));
     }
     if (propOption != CFG_MAX) {
         return fmt::format("{}[{}]/{}", ConfigDefinition::mapConfigOption(ATTR_DIRECTORIES_TWEAK), index, ConfigDefinition::ensureAttribute(propOption));

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -372,7 +372,7 @@ public:
 
     int checkIntValue(std::string& sVal, const std::string& pathName = "") const;
 
-    std::string getCurrentValue() const override { return optionValue == nullptr ? "" : fmt::format("{}", optionValue->getIntOption()); }
+    std::string getCurrentValue() const override { return optionValue == nullptr ? "" : fmt::to_string(optionValue->getIntOption()); }
 
     static bool CheckSqlLiteSyncValue(std::string& value);
 

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -276,7 +276,7 @@ Script::Script(std::shared_ptr<ContentManager> content,
             setIntProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_TASKCOUNT), adir->getTaskCount());
             setProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_LMT), fmt::format("{:%Y-%m-%d %H:%M:%S}", fmt::localtime(adir->getPreviousLMT().count())));
 
-            duk_put_prop_string(ctx, -2, fmt::format("{}", adir->getScanID()).c_str());
+            duk_put_prop_string(ctx, -2, fmt::to_string(adir->getScanID()).c_str());
         }
         autoscanItemPath = ascs->getItemPath(-2);
     }
@@ -741,7 +741,7 @@ void Script::cdsObject2dukObject(const std::shared_ptr<CdsObject>& obj)
         if (obj->getResourceCount() > 0) {
             int resCount = 0;
             for (auto&& res : obj->getResources()) {
-                setProperty(fmt::format("{}:handlerType", resCount), fmt::format("{}", res->getHandlerType()));
+                setProperty(fmt::format("{}:handlerType", resCount), fmt::to_string(res->getHandlerType()));
                 auto attributes = res->getAttributes();
                 for (auto&& [key, val] : attributes) {
                     setProperty(resCount == 0 ? key : fmt::format("{}-{}", resCount, key), val);

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -58,7 +58,7 @@ void web::configLoad::addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<Co
 {
     auto info = meta.append_child("item");
     info.append_attribute("item") = cs->getUniquePath().c_str();
-    info.append_attribute("id") = fmt::format("{}", cs->option).c_str();
+    info.append_attribute("id") = fmt::to_string(cs->option).c_str();
     info.append_attribute("type") = cs->getTypeString().c_str();
     info.append_attribute("value") = cs->getDefaultValue().c_str();
     info.append_attribute("help") = cs->getHelp();
@@ -85,7 +85,7 @@ template <typename T>
 void web::configLoad::setValue(pugi::xml_node& item, const T& value)
 {
     static_assert(fmt::has_formatter<T, fmt::format_context>::value, "T must be formattable");
-    item.append_attribute("value") = fmt::format("{}", value).c_str();
+    item.append_attribute("value") = fmt::to_string(value).c_str();
 }
 
 template <>

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -123,12 +123,12 @@ void web::edit_load::process()
     for (auto&& resItem : obj->getResources()) {
         auto resEntry = resources.append_child("resources");
         resEntry.append_attribute("resname") = "----RESOURCE----";
-        resEntry.append_attribute("resvalue") = fmt::format("{}", resIndex).c_str();
+        resEntry.append_attribute("resvalue") = fmt::to_string(resIndex).c_str();
         resEntry.append_attribute("editable") = false;
 
         resEntry = resources.append_child("resources");
         resEntry.append_attribute("resname") = "handlerType";
-        resEntry.append_attribute("resvalue") = fmt::format("{}", MetadataHandler::mapContentHandler2String(resItem->getHandlerType())).c_str();
+        resEntry.append_attribute("resvalue") = fmt::to_string(MetadataHandler::mapContentHandler2String(resItem->getHandlerType())).c_str();
         resEntry.append_attribute("editable") = false;
 
         // write resource content


### PR DESCRIPTION
to_string is shorter and faster.

Signed-off-by: Rosen Penev <rosenp@gmail.com>