### PR TITLE
declare AVFormatContext as struct

### DIFF
--- a/src/metadata/ffmpeg_handler.h
+++ b/src/metadata/ffmpeg_handler.h
@@ -46,7 +46,7 @@ namespace fs = std::filesystem;
 #include "metadata_handler.h"
 
 // forward declaration
-class AVFormatContext;
+struct AVFormatContext;
 
 /// \brief This class is responsible for reading id3 tags metadata
 class FfmpegHandler : public MetadataHandler {


### PR DESCRIPTION
AVFormatContext is defined as a struct in the ffmpeg header.

Fixes -Wmismatched-tags

Signed-off-by: Rosen Penev <rosenp@gmail.com>