### PR TITLE
remove pointless find

### DIFF
--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1145,10 +1145,7 @@ std::pair<int, bool> ContentManager::addContainerChain(const std::string& chain,
 
     constexpr auto unwanted = std::array { M_DESCRIPTION, M_TITLE, M_TRACKNUMBER, M_ARTIST }; // not wanted for container!
     for (auto&& unw : unwanted) {
-        const auto itm = lastMetadata.find(MetadataHandler::getMetaFieldName(unw));
-        if (itm != lastMetadata.end()) {
-            lastMetadata.erase(itm);
-        }
+        lastMetadata.erase(MetadataHandler::getMetaFieldName(unw));
     }
     int containerID = INVALID_OBJECT_ID;
     std::vector<std::shared_ptr<CdsContainer>> containerList;


### PR DESCRIPTION
std::map::erase has an overload that takes a key and erases it if it
exists. No need to do extra work.

Signed-off-by: Rosen Penev <rosenp@gmail.com>