### PR TITLE
pass 0 to std::unordered_

### DIFF
--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -54,7 +54,7 @@ AutoscanInotify::AutoscanInotify(std::shared_ptr<ContentManager> content)
         }
     }
 
-    watches = std::make_unique<std::unordered_map<int, std::shared_ptr<Wd>>>();
+    watches = std::make_unique<std::unordered_map<int, std::shared_ptr<Wd>>>(0);
     shutdownFlag = true;
     events = IN_CLOSE_WRITE | IN_CREATE | IN_MOVED_FROM | IN_MOVED_TO | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT;
 }

--- a/src/content/update_manager.cc
+++ b/src/content/update_manager.cc
@@ -50,7 +50,7 @@ UpdateManager::UpdateManager(std::shared_ptr<Config> config, std::shared_ptr<Dat
     : config(std::move(config))
     , database(std::move(database))
     , server(std::move(server))
-    , objectIDHash(std::make_unique<std::unordered_set<int>>())
+    , objectIDHash(std::make_unique<std::unordered_set<int>>(0))
 {
 }
 


### PR DESCRIPTION
Without this, fanalyzer complains that make_unique creates a null
pointer. libstdc++ defaults to a size of 0 if unspecified anyway.

Signed-off-by: Rosen Penev <rosenp@gmail.com>