### PR TITLE
clang-tidy: add missing functions

### DIFF
--- a/src/server.h
+++ b/src/server.h
@@ -49,14 +49,16 @@ class ContentManager;
 class Server : public std::enable_shared_from_this<Server> {
 public:
     explicit Server(std::shared_ptr<Config> config);
+    virtual ~Server();
+
+    Server(const Server&) = delete;
+    Server& operator=(const Server&) = delete;
 
     /// \brief Initializes the server.
     ///
     /// This function reads information from the config and initializes
     /// various variables (like server UDN and so forth).
     virtual void init();
-
-    virtual ~Server();
 
     /// \brief Cleanup routine to shutdown the server.
     ///


### PR DESCRIPTION
Found with cppcoreguidelines-special-member-functions

Signed-off-by: Rosen Penev <rosenp@gmail.com>