### PR TITLE
add missing header

### DIFF
--- a/src/content/scripting/script_names.h
+++ b/src/content/scripting/script_names.h
@@ -28,6 +28,7 @@
 
 #include <array>
 
+#include "cds_objects.h"
 #include "metadata/metadata_handler.h"
 
 static constexpr auto res_names = std::array<std::pair<resource_attributes_t, const char*>, R_MAX> { {


### PR DESCRIPTION
Needed for OBJECT_TYPE_CONTAINER, OBJECT_TYPE_ITEM,
OBJECT_TYPE_ITEM_EXTERNAL_URL

Signed-off-by: Rosen Penev <rosenp@gmail.com>