### PR TITLE
clang-tidy: don't use else after return

### DIFF
--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -502,7 +502,9 @@ std::string DefaultSQLEmitter::emit(const ASTCompareOperator* node, const std::s
     if ((operatr == ">" || operatr == ">=") && value.substr(0, 5) == "@last") {
         auto dateVal = to_seconds(std::chrono::system_clock::now()).count() - (24 * 60 * 60 * stoiString(value.substr(5)));
         return fmt::format(logicOperator.at("newer"), "", fmt::format("{} {}", prpUpper, operatr), fmt::format("{} {}", prpLower, operatr), dateVal);
-    } else if (operatr != "=")
+    }
+
+    if (operatr != "=")
         throw_std_runtime_error("Operator '{}' not yet supported", operatr);
 
     auto&& [clsUpper, clcLower] = getPropertyStatement(UPNP_SEARCH_CLASS);

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -700,9 +700,8 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::browse(const std::unique_pt
             auto result = this->search(srcParam, &numMatches);
             param->setTotalMatches(numMatches);
             return result;
-        } else {
-            log_warning("Dynamic content {} error '{}'", parent->getID(), parent->getLocation().string());
         }
+        log_warning("Dynamic content {} error '{}'", parent->getID(), parent->getLocation().string());
     }
 
     bool getContainers = param->getFlag(BROWSE_CONTAINERS);


### PR DESCRIPTION
Found with readability-else-after-return

Signed-off-by: Rosen Penev <rosenp@gmail.com>