### PR TITLE
remove pointless constructor

### DIFF
--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -33,7 +33,7 @@
 
 #include <upnp.h>
 
-Clients::Clients()
+Clients::Clients(const std::shared_ptr<Config>& config)
 {
     // table of supported clients (reverse search, sequence of entries matters!)
     clientInfo = {
@@ -117,11 +117,7 @@ Clients::Clients()
             "[BD]J5500",
         },
     };
-}
 
-Clients::Clients(const std::shared_ptr<Config>& config)
-    : Clients()
-{
     auto clientConfigList = config->getClientConfigListOption(CFG_CLIENTS_LIST);
     for (size_t i = 0; i < clientConfigList->size(); i++) {
         auto clientConfig = clientConfigList->get(i);

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -81,7 +81,6 @@ struct ClientCacheEntry {
 
 class Clients {
 public:
-    Clients();
     explicit Clients(const std::shared_ptr<Config>& config);
 
     // always return something, 'Unknown' if we do not know better


### PR DESCRIPTION
Initialization can just be moved down.

Signed-off-by: Rosen Penev <rosenp@gmail.com>