### PR TITLE
convert expandName to string_view

### DIFF
--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -138,7 +138,7 @@ static constexpr auto metaTags = std::array<std::pair<std::string_view, metadata
     std::pair("%title%", M_TITLE),
 };
 
-std::string ContentPathSetup::expandName(const std::string& name, const std::shared_ptr<CdsObject>& obj)
+std::string ContentPathSetup::expandName(std::string_view name, const std::shared_ptr<CdsObject>& obj)
 {
     std::string copy(name);
 

--- a/src/metadata/metacontent_handler.h
+++ b/src/metadata/metacontent_handler.h
@@ -44,7 +44,7 @@ private:
     std::vector<std::string> names;
     std::map<std::string, std::string> patterns;
     std::shared_ptr<DirectoryConfigList> allTweaks;
-    static std::string expandName(const std::string& name, const std::shared_ptr<CdsObject>& obj);
+    static std::string expandName(std::string_view name, const std::shared_ptr<CdsObject>& obj);
     bool caseSensitive;
 };
 


### PR DESCRIPTION
The parameter is only used to be copied to an std::string.

Signed-off-by: Rosen Penev <rosenp@gmail.com>