### PR TITLE
switch xmlDoc to unique_ptr

### DIFF
--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -114,7 +114,7 @@ void WebRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 
 std::unique_ptr<IOHandler> WebRequestHandler::open(enum UpnpOpenFileMode mode)
 {
-    xmlDoc = std::make_shared<pugi::xml_document>();
+    xmlDoc = std::make_unique<pugi::xml_document>();
     auto decl = xmlDoc->prepend_child(pugi::node_declaration);
     decl.append_attribute("version") = "1.0";
     decl.append_attribute("encoding") = "UTF-8";

--- a/src/web/web_request_handler.h
+++ b/src/web/web_request_handler.h
@@ -79,7 +79,7 @@ protected:
     enum UpnpOpenFileMode mode;
 
     /// \brief This is the xml document, the root node to be populated by process() method.
-    std::shared_ptr<pugi::xml_document> xmlDoc;
+    std::unique_ptr<pugi::xml_document> xmlDoc;
 
     /// \brief Hints for Xml2Json, such that we know when to create an array
     std::unique_ptr<Xml2Json::Hints> xml2JsonHints;


### PR DESCRIPTION
It doesn't need to be copied.

Signed-off-by: Rosen Penev <rosenp@gmail.com>