### PR TITLE
change db variable to pointer

### DIFF
--- a/src/database/mysql/mysql_database.h
+++ b/src/database/mysql/mysql_database.h
@@ -56,7 +56,7 @@ protected:
 
     static std::string getError(MYSQL* db);
 
-    MYSQL db {};
+    MYSQL* db {};
 
 private:
     void init() override;


### PR DESCRIPTION
Allows removing a const_cast and a bunch of address-of operators.

Signed-off-by: Rosen Penev <rosenp@gmail.com>