### PR TITLE
fixup lambda for C++20 compatibility

### DIFF
--- a/src/database/database.h
+++ b/src/database/database.h
@@ -188,7 +188,7 @@ public:
     /// It will be escaped.
     virtual fs::path buildContainerPath(int parentID, const std::string& title) = 0;
 
-    virtual void updateObject(std::shared_ptr<CdsObject> object, int* changedContainer) = 0;
+    virtual void updateObject(const std::shared_ptr<CdsObject>& object, int* changedContainer) = 0;
 
     virtual std::vector<std::shared_ptr<CdsObject>> browse(const std::unique_ptr<BrowseParam>& param) = 0;
     virtual std::vector<std::shared_ptr<CdsObject>> search(const std::unique_ptr<SearchParam>& param, int* numMatches) = 0;

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -661,7 +661,7 @@ void SQLDatabase::addObject(std::shared_ptr<CdsObject> obj, int* changedContaine
     commit("addObject");
 }
 
-void SQLDatabase::updateObject(std::shared_ptr<CdsObject> obj, int* changedContainer)
+void SQLDatabase::updateObject(const std::shared_ptr<CdsObject>& obj, int* changedContainer)
 {
     std::vector<std::shared_ptr<AddUpdateTable>> data;
     if (obj->getID() == CDS_ID_FS_ROOT) {
@@ -680,8 +680,8 @@ void SQLDatabase::updateObject(std::shared_ptr<CdsObject> obj, int* changedConta
 
     beginTransaction("updateObject");
     for (auto&& addUpdateTable : data) {
-        Operation op = addUpdateTable->getOperation();
-        auto qb = [=]() -> std::unique_ptr<std::ostringstream> {
+        auto qb = [this, &obj, &addUpdateTable]() -> std::unique_ptr<std::ostringstream> {
+            Operation op = addUpdateTable->getOperation();
             switch (op) {
             case Operation::Insert:
                 return sqlForInsert(obj, addUpdateTable);

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -118,7 +118,7 @@ public:
     }
 
     void addObject(std::shared_ptr<CdsObject> object, int* changedContainer) override;
-    void updateObject(std::shared_ptr<CdsObject> object, int* changedContainer) override;
+    void updateObject(const std::shared_ptr<CdsObject>& object, int* changedContainer) override;
 
     std::shared_ptr<CdsObject> loadObject(int objectID) override;
     int getChildCount(int contId, bool containers, bool items, bool hideFsRoot) override;

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -24,7 +24,7 @@ public:
         std::vector<int>& updateID, const std::map<std::string, std::string>& lastMetadata) override { }
     fs::path buildContainerPath(int parentID, const std::string& title) override { return ""; }
 
-    void updateObject(std::shared_ptr<CdsObject> object, int* changedContainer) override { }
+    void updateObject(const std::shared_ptr<CdsObject>& object, int* changedContainer) override { }
 
     std::vector<std::shared_ptr<CdsObject>> browse(const std::unique_ptr<BrowseParam>& param) override { return std::vector<std::shared_ptr<CdsObject>>(); }
     std::vector<std::shared_ptr<CdsObject>> search(const std::unique_ptr<SearchParam>& param, int* numMatches) override { return std::vector<std::shared_ptr<CdsObject>>(); }


### PR DESCRIPTION
Implicit this capture is deprecated.

Also changed to use const reference. Saves size.

Signed-off-by: Rosen Penev <rosenp@gmail.com>