### PR TITLE
lastfm: switch to C++ API

### DIFF
--- a/src/content/onlineservice/lastfm_scrobbler.cc
+++ b/src/content/onlineservice/lastfm_scrobbler.cc
@@ -36,7 +36,7 @@
 #include "metadata/metadata_handler.h"
 #include "util/tools.h"
 
-LastFm::LastFm(std::shared_ptr<Context> context)
+LastFm::LastFm(const std::shared_ptr<Context>& context)
     : config(context->getConfig())
 {
 }
@@ -69,7 +69,7 @@ void LastFm::shutdown()
     scrobbler = nullptr;
 }
 
-void LastFm::startedPlaying(std::shared_ptr<CdsItem> item)
+void LastFm::startedPlaying(const std::shared_ptr<CdsItem>& item)
 {
     if (currentTrackId == item->getID() || !scrobbler)
         return;

--- a/src/content/onlineservice/lastfm_scrobbler.h
+++ b/src/content/onlineservice/lastfm_scrobbler.h
@@ -36,7 +36,7 @@
 #define __LASTFM_H__
 
 #include <cstdlib>
-#include <lastfmlib/lastfmscrobblerc.h>
+#include <lastfmlib/lastfmscrobbler.h>
 #include <memory>
 
 #include "cds_objects.h"
@@ -71,7 +71,7 @@ public:
 private:
     std::shared_ptr<Config> config;
 
-    lastfm_scrobbler* scrobbler {};
+    std::unique_ptr<LastFmScrobbler> scrobbler;
     int currentTrackId { -1 };
 };
 

--- a/src/content/onlineservice/lastfm_scrobbler.h
+++ b/src/content/onlineservice/lastfm_scrobbler.h
@@ -45,7 +45,7 @@
 
 class LastFm {
 public:
-    explicit LastFm(std::shared_ptr<Context> context);
+    explicit LastFm(const std::shared_ptr<Context>& context);
     ~LastFm();
 
     /// \brief Initializes the LastFm client.
@@ -66,7 +66,7 @@ public:
     /// to a file
     ///
     /// \param item the audio item that is being played
-    void startedPlaying(std::shared_ptr<CdsItem> item);
+    void startedPlaying(const std::shared_ptr<CdsItem>& item);
 
 private:
     std::shared_ptr<Config> config;


### PR DESCRIPTION
Simpler. Also switched to use unique_ptr instead of C pointer.

Signed-off-by: Rosen Penev <rosenp@gmail.com>