### PR TITLE
use string_view for upnp_headers

### DIFF
--- a/src/util/upnp_headers.cc
+++ b/src/util/upnp_headers.cc
@@ -37,9 +37,9 @@
 #include "common.h"
 #include "util/tools.h"
 
-std::string Headers::stripInvalid(const std::string& value)
+std::string Headers::stripInvalid(std::string_view value)
 {
-    std::string result = value;
+    std::string result(value);
     std::size_t found = value.find_first_of('\r');
     if (found != std::string::npos) {
         result = value.substr(0, found);
@@ -51,7 +51,7 @@ std::string Headers::stripInvalid(const std::string& value)
     return result;
 }
 
-void Headers::addHeader(const std::string& key, const std::string& value)
+void Headers::addHeader(std::string_view key, std::string_view value)
 {
     if (key.empty() || value.empty()) {
         return;
@@ -76,12 +76,12 @@ std::string Headers::formatHeader(const std::pair<std::string, std::string>& hea
     return fmt::format("{}: {}{}", header.first, header.second, (crlf) ? "\r\n" : "");
 }
 
-std::pair<std::string, std::string> Headers::parseHeader(const std::string& header)
+std::pair<std::string, std::string> Headers::parseHeader(std::string_view header)
 {
-    std::string first = header;
+    std::string first(header);
     std::string second;
     std::size_t found = header.find_first_of(':');
-    if (found != std::string::npos) {
+    if (found != std::string_view::npos) {
         first = header.substr(0, found);
         second = header.substr(found + 1);
     }

--- a/src/util/upnp_headers.h
+++ b/src/util/upnp_headers.h
@@ -28,20 +28,22 @@
 
 #include <map>
 #include <memory>
-#include <upnp.h>
+#include <string_view>
 #include <vector>
+
+#include <upnp.h>
 
 class Headers {
 public:
-    void addHeader(const std::string& key, const std::string& value);
+    void addHeader(std::string_view key, std::string_view value);
     void writeHeaders(UpnpFileInfo* fileInfo) const;
 
     static std::unique_ptr<std::map<std::string, std::string>> readHeaders(UpnpFileInfo* fileInfo);
 
 private:
     static std::string formatHeader(const std::pair<std::string, std::string>& header, bool crlf);
-    static std::pair<std::string, std::string> parseHeader(const std::string& header);
-    static std::string stripInvalid(const std::string& value);
+    static std::pair<std::string, std::string> parseHeader(std::string_view header);
+    static std::string stripInvalid(std::string_view value);
 
     std::unique_ptr<std::map<std::string, std::string>> headers;
 };


### PR DESCRIPTION
They're copied to an std::string at the onset.

Signed-off-by: Rosen Penev <rosenp@gmail.com>