### PR TITLE
Re-add CI check with clang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
           - name: gcc 9
             cc: gcc-9
             cxx: g++-9
-#          - name: clang 11
-#            cc: clang-11
-#            cxx: clang++-11
+          - name: clang 11
+            cc: clang-11
+            cxx: clang++-11
     env:
       CC: ${{ matrix.compiler.cc }}
       CXX: ${{ matrix.compiler.cxx }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -39,11 +39,11 @@ class GerberaConan(ConanFile):
     scm = {"type": "git", "url": "auto", "revision": "auto"}
 
     requires = [
-        "fmt/[>=7.1.3]",
-        "spdlog/[>=1.8.5]",
+        "fmt/7.1.3",
+        "spdlog/1.8.5",
         "pugixml/1.10",
         "libiconv/1.16",
-        "sqlite3/[>3.31.1]",
+        "sqlite3/[>=3.35.5]",
         "zlib/1.2.11",
         "pupnp/[>=1.14.0]",
     ]


### PR DESCRIPTION
conan seems to be fixed now

fixes #1507

Use exact version number for fmt and spdlog because newer versions are not yet stable