### PR TITLE
use thread constructor

### DIFF
--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -81,7 +81,7 @@ void AutoscanInotify::run()
     if (shutdownFlag) {
         shutdownFlag = false;
         inotify = std::make_unique<Inotify>();
-        thread_ = std::thread { &AutoscanInotify::threadProc, this };
+        thread_ = std::thread([this] { threadProc(); });
     }
 }
 


### PR DESCRIPTION
Looks cleaner.

Also switch to lambda. Shorter.

Signed-off-by: Rosen Penev <rosenp@gmail.com>