### PR TITLE
getTimespecAfterMillis: return ret instead of void

### DIFF
--- a/src/content/update_manager.cc
+++ b/src/content/update_manager.cc
@@ -177,9 +177,6 @@ void UpdateManager::threadProc()
             }
             bool sendUpdates = true;
             if (sleepMillis >= MIN_SLEEP && objectIDHash->size() < MAX_OBJECT_IDS) {
-                std::chrono::milliseconds timeout;
-                getTimespecAfterMillis(sleepMillis, timeout);
-
                 log_debug("threadProc: sleeping for {} millis", sleepMillis.count());
                 auto ret = threadRunner->waitFor(lock, sleepMillis);
 

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -119,7 +119,8 @@ protected:
         }
         void updateNextNotify()
         {
-            getTimespecAfterMillis(notifyInterval, nextNotify);
+            auto start = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
+            nextNotify = start + notifyInterval;
         }
         std::chrono::milliseconds getNextNotify() const { return nextNotify; }
 

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -780,12 +780,6 @@ std::chrono::milliseconds getDeltaMillis(std::chrono::milliseconds first, std::c
     return second - first;
 }
 
-void getTimespecAfterMillis(std::chrono::milliseconds delta, std::chrono::milliseconds& ret)
-{
-    auto start = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch());
-    ret = start + delta;
-}
-
 std::string ipToInterface(std::string_view ip)
 {
     if (ip.empty()) {

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -302,8 +302,6 @@ std::chrono::milliseconds currentTimeMS();
 std::chrono::milliseconds getDeltaMillis(std::chrono::milliseconds ms);
 std::chrono::milliseconds getDeltaMillis(std::chrono::milliseconds first, std::chrono::milliseconds second);
 
-void getTimespecAfterMillis(std::chrono::milliseconds delta, std::chrono::milliseconds& ret);
-
 /// \brief Finds the Interface with the specified IP address.
 /// \param ip i.e. 192.168.4.56.
 /// \return Interface name or nullptr if IP was not found.


### PR DESCRIPTION
This function needed to be like this when using timespec. No longer.

Signed-off-by: Rosen Penev <rosenp@gmail.com>