### PR TITLE
return string instead of const char

### DIFF
--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -225,7 +225,7 @@ int MetadataHandler::remapContentHandler(const std::string& contHandler)
     return -1;
 }
 
-const char* MetadataHandler::mapContentHandler2String(int ch)
+std::string MetadataHandler::mapContentHandler2String(int ch)
 {
     auto ch_entry = std::find_if(ch_keys.begin(), ch_keys.end(), [ch](auto&& entry) { return ch == entry.first; });
     if (ch_entry != ch_keys.end()) {

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -217,7 +217,7 @@ public:
     virtual std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) = 0;
     virtual std::string getMimeType();
 
-    static const char* mapContentHandler2String(int ch);
+    static std::string mapContentHandler2String(int ch);
     static int remapContentHandler(const std::string& contHandler);
 };
 

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -137,7 +137,7 @@ void web::edit_load::process()
 
         resEntry = resources.append_child("resources");
         resEntry.append_attribute("resname") = "handlerType";
-        resEntry.append_attribute("resvalue") = fmt::to_string(MetadataHandler::mapContentHandler2String(resItem->getHandlerType())).c_str();
+        resEntry.append_attribute("resvalue") = MetadataHandler::mapContentHandler2String(resItem->getHandlerType()).c_str();
         resEntry.append_attribute("editable") = false;
 
         // write resource content


### PR DESCRIPTION
Allows removing to_string.

Signed-off-by: Rosen Penev <rosenp@gmail.com>