### PR TITLE
move unique_ptr removals

### DIFF
--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -694,8 +694,7 @@ void ContentManager::_rescanDirectory(const std::shared_ptr<AutoscanDirectory>& 
         if (!asSetting.followSymlinks && dirEnt.is_symlink()) {
             int objectID = database->findObjectIDByPath(newPath);
             if (objectID > 0) {
-                if (list)
-                    list->erase(objectID);
+                list.erase(objectID);
                 removeObject(adir, objectID, false);
             }
             log_debug("link {} skipped", newPath.c_str());
@@ -711,8 +710,7 @@ void ContentManager::_rescanDirectory(const std::shared_ptr<AutoscanDirectory>& 
         if (isRegularFile(dirEnt, ec)) {
             int objectID = database->findObjectIDByPath(newPath);
             if (objectID > 0) {
-                if (list)
-                    list->erase(objectID);
+                list.erase(objectID);
 
                 // check modification time and update file if chagned
                 if (last_modified_current_max < lwt) {
@@ -746,8 +744,7 @@ void ContentManager::_rescanDirectory(const std::shared_ptr<AutoscanDirectory>& 
                 last_modified_new_max = lwt;
             if (objectID > 0) {
                 log_debug("rescanSubDirectory {}", newPath.c_str());
-                if (list)
-                    list->erase(objectID);
+                list.erase(objectID);
                 // add a task to rescan the directory that was found
                 rescanDirectory(adir, objectID, newPath, task->isCancellable());
             } else {
@@ -786,7 +783,7 @@ void ContentManager::_rescanDirectory(const std::shared_ptr<AutoscanDirectory>& 
     if ((shutdownFlag) || ((task) && !task->isValid())) {
         return;
     }
-    if (list && !list->empty()) {
+    if (!list.empty()) {
         auto changedContainers = database->removeObjects(list);
         if (changedContainers) {
             session_manager->containerChangedUI(changedContainers->ui);

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1508,7 +1508,7 @@ void ContentManager::cleanupOnlineServiceObjects(const std::shared_ptr<OnlineSer
         std::chrono::seconds last = {};
         std::string temp;
 
-        for (int object_id : *ids) {
+        for (int object_id : ids) {
             auto obj = database->loadObject(object_id);
             if (!obj)
                 continue;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -288,7 +288,7 @@ public:
     virtual void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) = 0;
     virtual void checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir) = 0;
 
-    virtual std::unique_ptr<std::vector<int>> getPathIDs(int objectID) = 0;
+    virtual std::vector<int> getPathIDs(int objectID) = 0;
 
     /// \brief Ensures that a container given by it's location on disk is
     /// present in the database. If it does not exist it will be created, but

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -245,13 +245,13 @@ public:
     /// \param parentID parent container
     /// \param withoutContainer if false: all children are returned; if true: only items are returned
     /// \return DBHash containing the objectID's - nullptr if there are none!
-    virtual std::unique_ptr<std::unordered_set<int>> getObjects(int parentID, bool withoutContainer) = 0;
+    virtual std::unordered_set<int> getObjects(int parentID, bool withoutContainer) = 0;
 
     /// \brief Remove all objects found in list
     /// \param list a DBHash containing objectIDs that have to be removed
     /// \param all if true and the object to be removed is a reference
     /// \return changed container ids
-    virtual std::unique_ptr<ChangedContainers> removeObjects(const std::unique_ptr<std::unordered_set<int>>& list, bool all = false) = 0;
+    virtual std::unique_ptr<ChangedContainers> removeObjects(const std::unordered_set<int>& list, bool all = false) = 0;
 
     /// \brief Loads an object given by the online service ID.
     virtual std::shared_ptr<CdsObject> loadObjectByServiceID(const std::string& serviceID) = 0;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -259,7 +259,7 @@ public:
     /// \brief Return an array of object ID's for a particular service.
     ///
     /// In the database, the service is identified by a service id prefix.
-    virtual std::unique_ptr<std::vector<int>> getServiceObjectIDs(char servicePrefix) = 0;
+    virtual std::vector<int> getServiceObjectIDs(char servicePrefix) = 0;
 
     /* accounting methods */
     virtual int getTotalFiles(bool isVirtual = false, const std::string& mimeType = "", const std::string& upnpClass = "") = 0;

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -743,7 +743,7 @@ std::shared_ptr<CdsObject> SQLDatabase::loadObjectByServiceID(const std::string&
     return nullptr;
 }
 
-std::unique_ptr<std::vector<int>> SQLDatabase::getServiceObjectIDs(char servicePrefix)
+std::vector<int> SQLDatabase::getServiceObjectIDs(char servicePrefix)
 {
     std::ostringstream qb;
     qb << "SELECT " << TQ("id")
@@ -763,7 +763,7 @@ std::unique_ptr<std::vector<int>> SQLDatabase::getServiceObjectIDs(char serviceP
         objectIDs.push_back(std::stoi(row->col(0)));
     }
 
-    return std::make_unique<std::vector<int>>(objectIDs);
+    return objectIDs;
 }
 
 std::vector<std::shared_ptr<CdsObject>> SQLDatabase::browse(const std::unique_ptr<BrowseParam>& param)

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -163,7 +163,7 @@ public:
     void removeConfigValue(const std::string& item) override;
     void updateConfigValue(const std::string& key, const std::string& item, const std::string& value, const std::string& status = "unchanged") override;
 
-    std::unique_ptr<std::vector<int>> getPathIDs(int objectID) override;
+    std::vector<int> getPathIDs(int objectID) override;
 
     void shutdown() override;
     virtual void shutdownDriver() = 0;
@@ -270,7 +270,7 @@ private:
     int _getAutoscanObjectID(int autoscanID);
     void _autoscanChangePersistentFlag(int objectID, bool persistent);
     static std::shared_ptr<AutoscanDirectory> _fillAutoscanDirectory(const std::unique_ptr<SQLRow>& row);
-    std::unique_ptr<std::vector<int>> _checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir);
+    std::vector<int> _checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir);
 
     /* location helper: filesystem path or virtual path to db location*/
     static std::string addLocationPrefix(char prefix, const fs::path& path);

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -123,10 +123,10 @@ public:
     std::shared_ptr<CdsObject> loadObject(int objectID) override;
     int getChildCount(int contId, bool containers, bool items, bool hideFsRoot) override;
 
-    std::unique_ptr<std::unordered_set<int>> getObjects(int parentID, bool withoutContainer) override;
+    std::unordered_set<int> getObjects(int parentID, bool withoutContainer) override;
 
     std::unique_ptr<ChangedContainers> removeObject(int objectID, bool all) override;
-    std::unique_ptr<ChangedContainers> removeObjects(const std::unique_ptr<std::unordered_set<int>>& list, bool all = false) override;
+    std::unique_ptr<ChangedContainers> removeObjects(const std::unordered_set<int>& list, bool all = false) override;
 
     std::shared_ptr<CdsObject> loadObjectByServiceID(const std::string& serviceID) override;
     std::vector<int> getServiceObjectIDs(char servicePrefix) override;

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -129,7 +129,7 @@ public:
     std::unique_ptr<ChangedContainers> removeObjects(const std::unique_ptr<std::unordered_set<int>>& list, bool all = false) override;
 
     std::shared_ptr<CdsObject> loadObjectByServiceID(const std::string& serviceID) override;
-    std::unique_ptr<std::vector<int>> getServiceObjectIDs(char servicePrefix) override;
+    std::vector<int> getServiceObjectIDs(char servicePrefix) override;
 
     /* accounting methods */
     int getTotalFiles(bool isVirtual = false, const std::string& mimeType = "", const std::string& upnpClass = "") override;

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -93,13 +93,11 @@ void web::items::process()
         int startpoint_id = INVALID_OBJECT_ID;
         if (autoscanType == 0) {
             auto pathIDs = database->getPathIDs(parentID);
-            if (pathIDs) {
-                for (int pathId : *pathIDs) {
-                    auto pathDir = database->getAutoscanDirectory(pathId);
-                    if (pathDir && pathDir->getRecursive()) {
-                        startpoint_id = pathId;
-                        break;
-                    }
+            for (int pathId : pathIDs) {
+                auto pathDir = database->getAutoscanDirectory(pathId);
+                if (pathDir && pathDir->getRecursive()) {
+                    startpoint_id = pathId;
+                    break;
                 }
             }
         } else {

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -38,8 +38,8 @@ public:
     int getChildCount(int contId, bool containers = true, bool items = true, bool hideFsRoot = false) override { return 0; }
 
     std::unique_ptr<ChangedContainers> removeObject(int objectID, bool all) override { return nullptr; }
-    std::unique_ptr<std::unordered_set<int>> getObjects(int parentID, bool withoutContainer) override { return nullptr; }
-    std::unique_ptr<ChangedContainers> removeObjects(const std::unique_ptr<std::unordered_set<int>>& list, bool all = false) override { return nullptr; }
+    std::unordered_set<int> getObjects(int parentID, bool withoutContainer) override { return {}; }
+    std::unique_ptr<ChangedContainers> removeObjects(const std::unordered_set<int>& list, bool all = false) override { return {}; }
 
     std::shared_ptr<CdsObject> loadObjectByServiceID(const std::string& serviceID) override { return nullptr; }
     std::vector<int> getServiceObjectIDs(char servicePrefix) override { return {}; }

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -42,7 +42,7 @@ public:
     std::unique_ptr<ChangedContainers> removeObjects(const std::unique_ptr<std::unordered_set<int>>& list, bool all = false) override { return nullptr; }
 
     std::shared_ptr<CdsObject> loadObjectByServiceID(const std::string& serviceID) override { return nullptr; }
-    std::unique_ptr<std::vector<int>> getServiceObjectIDs(char servicePrefix) override { return nullptr; }
+    std::vector<int> getServiceObjectIDs(char servicePrefix) override { return {}; }
 
     int getTotalFiles(bool isVirtual = false, const std::string& mimeType = "", const std::string& upnpClass = "") override { return 0; }
 

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -66,7 +66,7 @@ public:
     void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override { }
     void checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir) override { }
 
-    std::unique_ptr<std::vector<int>> getPathIDs(int objectID) override { return nullptr; }
+    std::vector<int> getPathIDs(int objectID) override { return {}; }
     int ensurePathExistence(const fs::path& path, int* changedContainer) override { return 0; }
 
     void clearFlagInDB(int flag) override { }


### PR DESCRIPTION
Some background:

Because of -fanalyzer warnings, I changed these make_unique calls such that the function creates the vector or whatever and then moves it into make_unique. But doing that is quite silly as it's more efficient return the object. NRVO is prevented when make_unique is used. Compiled binary sees a small size reduction locally.

Runtime test seems to be fine as well.