### PR TITLE
const ref conversions

### DIFF
--- a/src/content/layout/builtin_layout.cc
+++ b/src/content/layout/builtin_layout.cc
@@ -405,7 +405,7 @@ std::string BuiltinLayout::mapGenre(const std::string& genre)
     return genre;
 }
 
-void BuiltinLayout::processCdsObject(const std::shared_ptr<CdsObject>& obj, fs::path rootpath)
+void BuiltinLayout::processCdsObject(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath)
 {
     log_debug("Process CDS Object: {}", obj->getTitle().c_str());
 #ifdef ENABLE_PROFILING

--- a/src/content/layout/builtin_layout.h
+++ b/src/content/layout/builtin_layout.h
@@ -51,7 +51,7 @@ public:
     virtual ~BuiltinLayout();
 #endif
 
-    void processCdsObject(const std::shared_ptr<CdsObject>& obj, fs::path rootpath) override;
+    void processCdsObject(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath) override;
 
 protected:
     void add(const std::shared_ptr<CdsObject>& obj, const std::pair<int, bool>& parentID, bool use_ref = true);

--- a/src/content/layout/js_layout.cc
+++ b/src/content/layout/js_layout.cc
@@ -41,7 +41,7 @@ JSLayout::JSLayout(const std::shared_ptr<ContentManager>& content,
 {
 }
 
-void JSLayout::processCdsObject(const std::shared_ptr<CdsObject>& obj, fs::path rootpath)
+void JSLayout::processCdsObject(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath)
 {
     if (!import_script)
         return;

--- a/src/content/layout/js_layout.h
+++ b/src/content/layout/js_layout.h
@@ -46,7 +46,7 @@ public:
     JSLayout(const std::shared_ptr<ContentManager>& content,
         const std::shared_ptr<ScriptingRuntime>& runtime);
 
-    void processCdsObject(const std::shared_ptr<CdsObject>& obj, fs::path rootpath) override;
+    void processCdsObject(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath) override;
 };
 
 #endif // __JS_LAYOUT_H__

--- a/src/content/layout/layout.h
+++ b/src/content/layout/layout.h
@@ -47,7 +47,7 @@ public:
     explicit Layout(std::shared_ptr<ContentManager> content);
     virtual ~Layout() = default;
 
-    virtual void processCdsObject(const std::shared_ptr<CdsObject>& obj, fs::path rootpath) = 0;
+    virtual void processCdsObject(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath) = 0;
 
 protected:
     std::shared_ptr<Config> config;

--- a/src/content/onlineservice/curl_online_service.cc
+++ b/src/content/onlineservice/curl_online_service.cc
@@ -91,7 +91,7 @@ std::unique_ptr<pugi::xml_document> CurlOnlineService::getData()
     return doc;
 }
 
-bool CurlOnlineService::refreshServiceData(std::shared_ptr<Layout> layout)
+bool CurlOnlineService::refreshServiceData(const std::shared_ptr<Layout>& layout)
 {
     log_debug("Refreshing {}", serviceName);
     // the layout is in full control of the service items

--- a/src/content/onlineservice/curl_online_service.h
+++ b/src/content/onlineservice/curl_online_service.h
@@ -79,7 +79,7 @@ public:
 
     /// \brief Retrieves user specified content from the service and adds
     /// the items to the database.
-    bool refreshServiceData(std::shared_ptr<Layout> layout) override;
+    bool refreshServiceData(const std::shared_ptr<Layout>& layout) override;
 
     /// \brief Get the human readable name for the service
     std::string getServiceName() const override;

--- a/src/content/onlineservice/online_service.h
+++ b/src/content/onlineservice/online_service.h
@@ -77,7 +77,7 @@ public:
     /// to get. Another call to this function after it returned true will
     /// reset the internal counters and thus make it fetch the content from
     /// the beginning.
-    virtual bool refreshServiceData(std::shared_ptr<Layout> layout) = 0;
+    virtual bool refreshServiceData(const std::shared_ptr<Layout>& layout) = 0;
 
     /// \brief Returns the service type
     virtual service_type_t getServiceType() const = 0;

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -286,7 +286,7 @@ public:
     virtual void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) = 0;
     virtual void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) = 0;
     virtual void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) = 0;
-    virtual void checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir) = 0;
+    virtual void checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir) = 0;
 
     virtual std::vector<int> getPathIDs(int objectID) = 0;
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -2256,7 +2256,7 @@ void SQLDatabase::_autoscanChangePersistentFlag(int objectID, bool persistent)
     exec(q.str());
 }
 
-void SQLDatabase::checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir)
+void SQLDatabase::checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir)
 {
     (void)_checkOverlappingAutoscans(adir);
 }

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -156,7 +156,7 @@ public:
     void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
     void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
     void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
-    void checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir) override;
+    void checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir) override;
 
     /* config methods */
     std::vector<ConfigValue> getConfigValues() override;

--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -171,7 +171,7 @@ void Exiv2Handler::fillMetadata(const std::shared_ptr<CdsObject>& item)
     }
 }
 
-std::unique_ptr<IOHandler> Exiv2Handler::serveContent(std::shared_ptr<CdsObject> item, int resNum)
+std::unique_ptr<IOHandler> Exiv2Handler::serveContent(const std::shared_ptr<CdsObject>& item, int resNum)
 {
     return nullptr;
 }

--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -40,7 +40,7 @@
 #include "util/string_converter.h"
 #include "util/tools.h"
 
-void Exiv2Handler::fillMetadata(std::shared_ptr<CdsObject> item)
+void Exiv2Handler::fillMetadata(const std::shared_ptr<CdsObject>& item)
 {
     try {
         std::string value;

--- a/src/metadata/exiv2_handler.h
+++ b/src/metadata/exiv2_handler.h
@@ -41,7 +41,7 @@ public:
         : MetadataHandler(context)
     {
     }
-    void fillMetadata(std::shared_ptr<CdsObject> item) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& item) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> item, int resNum) override;
 };
 

--- a/src/metadata/exiv2_handler.h
+++ b/src/metadata/exiv2_handler.h
@@ -42,7 +42,7 @@ public:
     {
     }
     void fillMetadata(const std::shared_ptr<CdsObject>& item) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> item, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& item, int resNum) override;
 };
 
 #endif // __METADATA_EXIV2_H__

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -288,7 +288,7 @@ static void FfmpegNoOutputStub(void* ptr, int level, const char* fmt, va_list vl
     // do nothing
 }
 
-void FfmpegHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void FfmpegHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     if (!item)

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -366,7 +366,7 @@ void FfmpegHandler::writeThumbnailCacheFile(const fs::path& movie_filename, cons
 }
 #endif
 
-std::unique_ptr<IOHandler> FfmpegHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> FfmpegHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
 #ifdef HAVE_FFMPEGTHUMBNAILER
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);

--- a/src/metadata/ffmpeg_handler.h
+++ b/src/metadata/ffmpeg_handler.h
@@ -55,7 +55,7 @@ public:
         : MetadataHandler(context)
     {
     }
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
     std::string getMimeType() override;
 

--- a/src/metadata/ffmpeg_handler.h
+++ b/src/metadata/ffmpeg_handler.h
@@ -56,7 +56,7 @@ public:
     {
     }
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
     std::string getMimeType() override;
 
 private:

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -283,7 +283,7 @@ void LibExifHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
     exif_data_unref(ed);
 }
 
-std::unique_ptr<IOHandler> LibExifHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> LibExifHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     if (!item)

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -236,7 +236,7 @@ void LibExifHandler::process_ifd(ExifContent* content, const std::shared_ptr<Cds
     }
 }
 
-void LibExifHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void LibExifHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     if (!item)

--- a/src/metadata/libexif_handler.h
+++ b/src/metadata/libexif_handler.h
@@ -64,7 +64,7 @@ public:
     {
     }
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 };
 
 #endif

--- a/src/metadata/libexif_handler.h
+++ b/src/metadata/libexif_handler.h
@@ -63,7 +63,7 @@ public:
         : MetadataHandler(context)
     {
     }
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
 };
 

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -115,7 +115,7 @@ public:
     }
 };
 
-void MatroskaHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void MatroskaHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     if (!item)

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -124,7 +124,7 @@ void MatroskaHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
     parseMKV(item, nullptr);
 }
 
-std::unique_ptr<IOHandler> MatroskaHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> MatroskaHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     if (!item)

--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -46,7 +46,7 @@ public:
     {
     }
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 
 private:
     void parseMKV(const std::shared_ptr<CdsItem>& item, std::unique_ptr<MemIOHandler>* p_io_handler) const;

--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -45,7 +45,7 @@ public:
         : MetadataHandler(context)
     {
     }
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
 
 private:

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -169,7 +169,7 @@ FanArtHandler::FanArtHandler(const std::shared_ptr<Context>& context)
     }
 }
 
-void FanArtHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void FanArtHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     log_debug("Running fanart handler on {}", obj->getLocation().c_str());
     auto pathList = setup->getContentPath(obj, SETTING_FANART);
@@ -217,7 +217,7 @@ ContainerArtHandler::ContainerArtHandler(const std::shared_ptr<Context>& context
     }
 }
 
-void ContainerArtHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void ContainerArtHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     auto pathList = setup->getContentPath(obj, SETTING_CONTAINERART, config->getOption(CFG_IMPORT_RESOURCES_CONTAINERART_LOCATION));
     if (pathList.empty() || pathList[0].empty()) {
@@ -271,7 +271,7 @@ SubtitleHandler::SubtitleHandler(const std::shared_ptr<Context>& context)
     }
 }
 
-void SubtitleHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void SubtitleHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     auto pathList = setup->getContentPath(obj, SETTING_SUBTITLE);
 
@@ -326,7 +326,7 @@ ResourceHandler::ResourceHandler(const std::shared_ptr<Context>& context)
     }
 }
 
-void ResourceHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void ResourceHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     auto pathList = setup->getContentPath(obj, SETTING_RESOURCE);
 

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -191,7 +191,7 @@ void FanArtHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
     }
 }
 
-std::unique_ptr<IOHandler> FanArtHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> FanArtHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
     fs::path path = obj->getResource(resNum)->getAttribute(R_RESOURCE_FILE);
     if (path.empty()) {
@@ -242,7 +242,7 @@ void ContainerArtHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
     }
 }
 
-std::unique_ptr<IOHandler> ContainerArtHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> ContainerArtHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
     fs::path path = obj->getResource(resNum)->getAttribute(R_RESOURCE_FILE);
     if (path.empty()) {
@@ -300,7 +300,7 @@ void SubtitleHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
     }
 }
 
-std::unique_ptr<IOHandler> SubtitleHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> SubtitleHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
     fs::path path = obj->getResource(resNum)->getAttribute(R_RESOURCE_FILE);
     if (path.empty()) {
@@ -345,7 +345,7 @@ void ResourceHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
     }
 }
 
-std::unique_ptr<IOHandler> ResourceHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> ResourceHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
     fs::path path = obj->getResource(resNum)->getAttribute(R_RESOURCE_FILE);
     if (path.empty()) {

--- a/src/metadata/metacontent_handler.h
+++ b/src/metadata/metacontent_handler.h
@@ -61,7 +61,7 @@ public:
 class FanArtHandler : public MetacontentHandler {
 public:
     explicit FanArtHandler(const std::shared_ptr<Context>& context);
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
 
 private:
@@ -72,7 +72,7 @@ private:
 class ContainerArtHandler : public MetacontentHandler {
 public:
     explicit ContainerArtHandler(const std::shared_ptr<Context>& context);
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
 
 private:
@@ -83,7 +83,7 @@ private:
 class SubtitleHandler : public MetacontentHandler {
 public:
     explicit SubtitleHandler(const std::shared_ptr<Context>& context);
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
 
 private:
@@ -94,7 +94,7 @@ private:
 class ResourceHandler : public MetacontentHandler {
 public:
     explicit ResourceHandler(const std::shared_ptr<Context>& context);
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
 
 private:

--- a/src/metadata/metacontent_handler.h
+++ b/src/metadata/metacontent_handler.h
@@ -62,7 +62,7 @@ class FanArtHandler : public MetacontentHandler {
 public:
     explicit FanArtHandler(const std::shared_ptr<Context>& context);
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 
 private:
     static std::unique_ptr<ContentPathSetup> setup;
@@ -73,7 +73,7 @@ class ContainerArtHandler : public MetacontentHandler {
 public:
     explicit ContainerArtHandler(const std::shared_ptr<Context>& context);
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 
 private:
     static std::unique_ptr<ContentPathSetup> setup;
@@ -84,7 +84,7 @@ class SubtitleHandler : public MetacontentHandler {
 public:
     explicit SubtitleHandler(const std::shared_ptr<Context>& context);
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 
 private:
     static std::unique_ptr<ContentPathSetup> setup;
@@ -95,7 +95,7 @@ class ResourceHandler : public MetacontentHandler {
 public:
     explicit ResourceHandler(const std::shared_ptr<Context>& context);
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 
 private:
     static std::unique_ptr<ContentPathSetup> setup;

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -214,7 +214,7 @@ public:
     /// \param obj Object to stream
     /// \param resNum number of resource
     /// \return iohandler to stream to client
-    virtual std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) = 0;
+    virtual std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) = 0;
     virtual std::string getMimeType();
 
     static std::string mapContentHandler2String(int ch);

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -208,7 +208,7 @@ public:
 
     /// \brief read metadata from file and add to object
     /// \param obj Object to handle
-    virtual void fillMetadata(std::shared_ptr<CdsObject> obj) = 0;
+    virtual void fillMetadata(const std::shared_ptr<CdsObject>& obj) = 0;
 
     /// \brief stream content of object or resource to client
     /// \param obj Object to stream

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -231,7 +231,7 @@ void TagLibHandler::populateAuxTags(const std::shared_ptr<CdsItem>& item, const 
 
 /// \brief read metadata from file and add to object
 /// \param obj Object to handle
-void TagLibHandler::fillMetadata(std::shared_ptr<CdsObject> obj)
+void TagLibHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 {
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     if (!item)

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -299,7 +299,7 @@ void TagLibHandler::addArtworkResource(const std::shared_ptr<CdsItem>& item, con
 /// \param obj Object to stream
 /// \param resNum number of resource
 /// \return iohandler to stream to client
-std::unique_ptr<IOHandler> TagLibHandler::serveContent(std::shared_ptr<CdsObject> obj, int resNum)
+std::unique_ptr<IOHandler> TagLibHandler::serveContent(const std::shared_ptr<CdsObject>& obj, int resNum)
 {
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     if (!item) // not streamable

--- a/src/metadata/taglib_handler.h
+++ b/src/metadata/taglib_handler.h
@@ -57,7 +57,7 @@ public:
     /// \param obj Object to stream
     /// \param resNum number of resource
     /// \return iohandler to stream to client
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<CdsObject> obj, int resNum) override;
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 
 private:
     std::string entrySeparator;

--- a/src/metadata/taglib_handler.h
+++ b/src/metadata/taglib_handler.h
@@ -51,7 +51,7 @@ public:
 
     /// \brief read metadata from file and add to object
     /// \param obj Object to handle
-    void fillMetadata(std::shared_ptr<CdsObject> obj) override;
+    void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
 
     /// \brief stream content of object or resource to client
     /// \param obj Object to stream

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -64,7 +64,7 @@ public:
     void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override { }
     void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override { }
     void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override { }
-    void checkOverlappingAutoscans(std::shared_ptr<AutoscanDirectory> adir) override { }
+    void checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir) override { }
 
     std::vector<int> getPathIDs(int objectID) override { return {}; }
     int ensurePathExistence(const fs::path& path, int* changedContainer) override { return 0; }


### PR DESCRIPTION
I think clang-tidy can't diagnose these as they're virtual functions.