### PR TITLE
move orderedHandler out of the class

### DIFF
--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -38,7 +38,7 @@
 #include "request_handler.h"
 #include "transcoding/transcoding.h"
 
-std::vector<int> UpnpXMLBuilder::orderedHandler = {};
+static std::vector<int> orderedHandler;
 
 UpnpXMLBuilder::UpnpXMLBuilder(const std::shared_ptr<Context>& context,
     std::string virtualUrl, std::string presentationURL)

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -99,8 +99,6 @@ protected:
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;
 
-    static std::vector<int> orderedHandler;
-
     const std::string virtualURL;
     const std::string presentationURL;
 


### PR DESCRIPTION
It's not really needed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>