### PR TITLE
replace several inserts with std::copy

### DIFF
--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -625,7 +625,7 @@ std::vector<std::string> ConfigArraySetup::getXmlContent(const pugi::xml_node& o
     if (result.empty()) {
         log_debug("{} assigning {} default values", xpath, defaultEntries.size());
         useDefault = true;
-        result.assign(defaultEntries.begin(), defaultEntries.end());
+        result = defaultEntries;
     }
     if (notEmpty && result.empty()) {
         throw_std_runtime_error("Invalid array {} empty '{}'", xpath, optValue);
@@ -831,9 +831,7 @@ std::map<std::string, std::string> ConfigDictionarySetup::getXmlContent(const pu
     if (result.empty()) {
         log_debug("{} assigning {} default values", xpath, defaultEntries.size());
         useDefault = true;
-        for (auto&& entry : defaultEntries) {
-            result.insert(entry); // this should be an insert without a loop, but Debian 10 doesn't compile.
-        }
+        result = defaultEntries;
     }
     if (notEmpty && result.empty()) {
         throw_std_runtime_error("Invalid dictionary {} empty '{}'", xpath, optValue);

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1625,7 +1625,7 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::_recursiveRemove(
 
     // collect container for update signals
     if (!containers.empty()) {
-        parentIds.insert(parentIds.end(), containers.begin(), containers.end());
+        std::copy(containers.begin(), containers.end(), std::back_inserter(parentIds));
         auto sql = fmt::format("{} ({})", parentSql, fmt::join(parentIds, ","));
         res = select(sql);
         if (!res)
@@ -1641,7 +1641,7 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::_recursiveRemove(
         // collect child entries
         if (!parentIds.empty()) {
             // add ids to remove
-            removeIds.insert(removeIds.end(), parentIds.begin(), parentIds.end());
+            std::copy(parentIds.begin(), parentIds.end(), std::back_inserter(removeIds));
             auto sql = fmt::format("{} ({})", parentSql, fmt::join(parentIds, ","));
             res = select(sql);
             if (!res)
@@ -1733,15 +1733,10 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::_purgeEmptyContainers(
 
     std::unique_ptr<SQLRow> row;
 
-    std::vector<int32_t> selUi;
-    std::vector<int32_t> selUpnp;
-
     ChangedContainers changedContainers;
 
-    auto& uiV = maybeEmpty->ui;
-    selUi.insert(selUi.end(), uiV.begin(), uiV.end());
-    auto& upnpV = maybeEmpty->upnp;
-    selUpnp.insert(selUpnp.end(), upnpV.begin(), upnpV.end());
+    auto selUi = std::vector(maybeEmpty->ui);
+    auto selUpnp = std::vector(maybeEmpty->upnp);
 
     bool again;
     int count = 0;
@@ -1803,11 +1798,11 @@ std::unique_ptr<Database::ChangedContainers> SQLDatabase::_purgeEmptyContainers(
     auto& changedUi = changedContainers.ui;
     auto& changedUpnp = changedContainers.upnp;
     if (!selUi.empty()) {
-        changedUi.insert(changedUi.end(), selUi.begin(), selUi.end());
-        changedUpnp.insert(changedUpnp.end(), selUi.begin(), selUi.end());
+        std::copy(selUi.begin(), selUi.end(), std::back_inserter(changedUi));
+        std::copy(selUi.begin(), selUi.end(), std::back_inserter(changedUpnp));
     }
     if (!selUpnp.empty()) {
-        changedUpnp.insert(changedUpnp.end(), selUpnp.begin(), selUpnp.end());
+        std::copy(selUpnp.begin(), selUpnp.end(), std::back_inserter(changedUpnp));
     }
     // log_debug("end; changedContainers (upnp): {}", fmt::join(changedUpnp, ","));
     // log_debug("end; changedContainers (ui): {}", fmt::join(changedUi, ","));


### PR DESCRIPTION
For whatever reason, the latter is more efficient.

Maybe because std::copy internally is implemented as a push_back loop
and insert is done in some other way.

Signed-off-by: Rosen Penev <rosenp@gmail.com>