### PR TITLE
clang-tidy: use emplace_back

### DIFF
--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -878,7 +878,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::browse(const std::unique_pt
         };
 
         if (!getContainers && !getItems) {
-            where.push_back("0 = 1");
+            where.emplace_back("0 = 1");
         } else if (getContainers && !getItems) {
             where.push_back(fmt::format("{} = {}", browseColumnMapper->mapQuoted(BrowseCol::object_type), quote(OBJECT_TYPE_CONTAINER)));
             orderBy = fmt::format(" ORDER BY {}", orderByCode());

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -126,7 +126,7 @@ std::vector<fs::path> ContentPathSetup::getContentPath(const std::shared_ptr<Cds
         }
     }
     if (result.empty())
-        result.push_back("");
+        result.emplace_back("");
     return result;
 }
 


### PR DESCRIPTION
Found with modernize-use-emplace

Signed-off-by: Rosen Penev <rosenp@gmail.com>