### PR TITLE
Fix mapConfigOption return

### DIFF
--- a/src/config/config_definition.cc
+++ b/src/config/config_definition.cc
@@ -1252,7 +1252,7 @@ const char* ConfigDefinition::mapConfigOption(config_option_t option)
     if (co != complexOptions.end()) {
         return (*co)->xpath;
     }
-    return {};
+    return "";
 }
 
 bool ConfigDefinition::isDependent(config_option_t option)


### PR DESCRIPTION
{} for `const char*` becomes nullptr, which breaks string construction on result of  `mapConfigOption`