### PR TITLE
libfmt formatters for quoted SQL identifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ add_library(libgerbera STATIC
         src/database/sqlite3/sqlite_database.h
         src/database/sql_database.cc
         src/database/sql_database.h
+        src/database/sql_format.h
         src/database/database.cc
         src/database/database.h
         src/database/search_handler.cc

--- a/src/database/database.cc
+++ b/src/database/database.cc
@@ -56,7 +56,7 @@ std::shared_ptr<Database> Database::createInstance(const std::shared_ptr<Config>
         }
 #endif
         // other database types...
-        throw_std_runtime_error("Unknown database type: {}", type.c_str());
+        throw_std_runtime_error("Unknown database type: {}", type);
     }();
 
     database->init();

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -30,6 +30,7 @@
 /// \file sql_database.cc
 
 #include "sql_database.h" // API
+#include "sql_format.h"
 
 #include <algorithm>
 #include <climits>
@@ -1418,7 +1419,8 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
 
 std::map<std::string, std::string> SQLDatabase::retrieveMetadataForObject(int objectId)
 {
-    auto res = select(fmt::format("{2} FROM {0}{3}{1} WHERE {0}item_id{1} = {4}", table_quote_begin, table_quote_end, sql_meta_query, METADATA_TABLE, objectId));
+    const SQLIdentifier::Traits t(table_quote_begin, table_quote_end);
+    auto res = select(fmt::format("{} FROM {} WHERE {} = {}", sql_meta_query, SQLIdentifier(METADATA_TABLE, t), SQLIdentifier("item_id", t), objectId));
     if (!res)
         return {};
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -30,7 +30,6 @@
 /// \file sql_database.cc
 
 #include "sql_database.h" // API
-#include "sql_format.h"
 
 #include <algorithm>
 #include <climits>
@@ -1420,7 +1419,7 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
 std::map<std::string, std::string> SQLDatabase::retrieveMetadataForObject(int objectId)
 {
     auto query = fmt::format("{} FROM {} WHERE {} = {}",
-                             sql_meta_query, identifier(METADATA_TABLE), identifier("item_id"), objectId);
+        sql_meta_query, identifier(METADATA_TABLE), identifier("item_id"), objectId);
     auto res = select(query);
     if (!res)
         return {};

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -38,9 +38,9 @@
 #include <unordered_set>
 #include <utility>
 
-#include "sql_format.h"
 #include "config/config.h"
 #include "database.h"
+#include "sql_format.h"
 
 // forward declarations
 class CdsContainer;
@@ -189,9 +189,9 @@ protected:
     /// \brief migrate resources from mt_cds_objects to grb_resource before removing the column (DBVERSION 13)
     bool doResourceMigration();
     void migrateResources(int objectId, const std::string& resourcesStr);
-    
-    /// \brief returns a fmt-prinable identifier name
-    SQLIdentifier identifier(const std::string_view& name) const { return SQLIdentifier(name, table_quote_begin); }
+
+    /// \brief returns a fmt-printable identifier name
+    SQLIdentifier identifier(const std::string_view& name) const { return SQLIdentifier(name, table_quote_begin, table_quote_end); }
 
     std::shared_ptr<Mime> mime;
 

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -177,7 +177,7 @@ public:
 protected:
     explicit SQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime);
     void init() override;
-    int insert(const char* tableName, const std::vector<std::string>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
+    int insert(const char* tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
 
     /// \brief migrate metadata from mt_cds_objects to mt_metadata before removing the column (DBVERSION 12)
     bool doMetadataMigration();

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -38,6 +38,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "sql_format.h"
 #include "config/config.h"
 #include "database.h"
 
@@ -188,6 +189,9 @@ protected:
     /// \brief migrate resources from mt_cds_objects to grb_resource before removing the column (DBVERSION 13)
     bool doResourceMigration();
     void migrateResources(int objectId, const std::string& resourcesStr);
+    
+    /// \brief returns a fmt-prinable identifier name
+    SQLIdentifier identifier(const std::string_view& name) const { return SQLIdentifier(name, table_quote_begin); }
 
     std::shared_ptr<Mime> mime;
 

--- a/src/database/sql_format.h
+++ b/src/database/sql_format.h
@@ -28,22 +28,24 @@
 #include <fmt/format.h>
 #include <string_view>
 
-struct SQLIdentifier
-{
-    SQLIdentifier(const std::string_view& name, char quote)
+struct SQLIdentifier {
+    SQLIdentifier(const std::string_view& name, char quote_begin, char quote_end)
         : name(name)
-        , quote(quote)
-    {}
+        , quote_begin(quote_begin)
+        , quote_end(quote_end)
+    {
+    }
     std::string_view name;
-    char quote;
+    char quote_begin;
+    char quote_end;
 };
 
-template<>
-struct fmt::formatter<SQLIdentifier> : formatter<std::string_view>
-{
+template <>
+struct fmt::formatter<SQLIdentifier> : formatter<std::string_view> {
     template <typename FormatContext>
-    auto format(const SQLIdentifier& tn, FormatContext& ctx) -> decltype(ctx.out()) {
-        return format_to(ctx.out(), "{1}{0}{1}", tn.name, tn.quote);
+    auto format(const SQLIdentifier& tn, FormatContext& ctx) -> decltype(ctx.out())
+    {
+        return format_to(ctx.out(), "{}{}{}", tn.quote_begin, tn.name, tn.quote_end);
     }
 };
 

--- a/src/database/sql_format.h
+++ b/src/database/sql_format.h
@@ -3,7 +3,7 @@
 
   sql_format.h - this file is part of Gerbera.
 
-  Copyright (C) 2018-2021 Gerbera Contributors
+  Copyright (C) 2021 Gerbera Contributors
 
   Gerbera is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License version 2
@@ -30,20 +30,12 @@
 
 struct SQLIdentifier
 {
-    struct Traits
-    {
-        Traits(char quote) : quote_begin(quote), quote_end(quote) {}
-        Traits(char quote_begin, char quote_end) : quote_begin(quote_begin), quote_end(quote_end) {}
-        char quote_begin;
-        char quote_end;
-    };
-
-    SQLIdentifier(std::string_view&& name, const Traits& traits)
+    SQLIdentifier(const std::string_view& name, char quote)
         : name(name)
-        , traits(traits)
+        , quote(quote)
     {}
     std::string_view name;
-    const Traits& traits;
+    char quote;
 };
 
 template<>
@@ -51,9 +43,7 @@ struct fmt::formatter<SQLIdentifier> : formatter<std::string_view>
 {
     template <typename FormatContext>
     auto format(const SQLIdentifier& tn, FormatContext& ctx) -> decltype(ctx.out()) {
-        return format_to(ctx.out(),
-            "{}{}{}",
-            tn.traits.quote_begin, tn.name, tn.traits.quote_end);
+        return format_to(ctx.out(), "{1}{0}{1}", tn.name, tn.quote);
     }
 };
 

--- a/src/database/sql_format.h
+++ b/src/database/sql_format.h
@@ -1,0 +1,60 @@
+/*GRB*
+  Gerbera - https://gerbera.io/
+
+  sql_format.h - this file is part of Gerbera.
+
+  Copyright (C) 2018-2021 Gerbera Contributors
+
+  Gerbera is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 2
+  as published by the Free Software Foundation.
+
+  Gerbera is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+
+  $Id$
+*/
+
+/// \file sql_format.h
+
+#ifndef __SQL_FORMAT_H__
+#define __SQL_FORMAT_H__
+
+#include <fmt/format.h>
+#include <string_view>
+
+struct SQLIdentifier
+{
+    struct Traits
+    {
+        Traits(char quote) : quote_begin(quote), quote_end(quote) {}
+        Traits(char quote_begin, char quote_end) : quote_begin(quote_begin), quote_end(quote_end) {}
+        char quote_begin;
+        char quote_end;
+    };
+
+    SQLIdentifier(std::string_view&& name, const Traits& traits)
+        : name(name)
+        , traits(traits)
+    {}
+    std::string_view name;
+    const Traits& traits;
+};
+
+template<>
+struct fmt::formatter<SQLIdentifier> : formatter<std::string_view>
+{
+    template <typename FormatContext>
+    auto format(const SQLIdentifier& tn, FormatContext& ctx) -> decltype(ctx.out()) {
+        return format_to(ctx.out(),
+            "{}{}{}",
+            tn.traits.quote_begin, tn.name, tn.traits.quote_end);
+    }
+};
+
+#endif

--- a/src/database/sql_format.h
+++ b/src/database/sql_format.h
@@ -29,7 +29,7 @@
 #include <string_view>
 
 struct SQLIdentifier {
-    SQLIdentifier(const std::string_view& name, char quote_begin, char quote_end)
+    constexpr SQLIdentifier(const std::string_view& name, char quote_begin, char quote_end)
         : name(name)
         , quote_begin(quote_begin)
         , quote_end(quote_end)

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -364,8 +364,8 @@ void Sqlite3Database::shutdownDriver()
 
 void Sqlite3Database::storeInternalSetting(const std::string& key, const std::string& value)
 {
-    auto command = fmt::format("INSERT OR REPLACE INTO {0}{2}{1} ({0}key{1}, {0}value{1}) VALUES ({3}, {4})",
-        table_quote_begin, table_quote_begin, INTERNAL_SETTINGS_TABLE, quote(key), quote(value));
+    auto command = fmt::format("INSERT OR REPLACE INTO {} ({}, {}) VALUES ({}, {})",
+        identifier(INTERNAL_SETTINGS_TABLE), identifier("key"), identifier("value"), quote(key), quote(value));
     exec(command);
 }
 


### PR DESCRIPTION
I very much like the new fmt-based SQL statement generation code - but the format strings for quoting literals make the statements hard to read.

So I came up with [custom formatters](https://fmt.dev/latest/api.html#formatting-user-defined-types) for a SQLIdentifier struct that encapsulates the identifier name and quotation-traits and allows for a very readable quoted name formatting. One drawdown is that all identifiers need to be outside the SQL template.

There is only one usage example in this PR which I'd like to discuss before changing additional code (also ignore code formatting for now). Is this this a good idea?

On the other hand, why is the current code so pedantic on quoting all identifiers while both MySQL and SQLite should be able to handle all used identifiers without quotes.