### PR TITLE
Make UpnpXMLBuilder::orderedHandler nonstatic

### DIFF
--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -48,9 +48,9 @@
 #include "util/upnp_quirks.h"
 #include "web/session_manager.h"
 
-FileRequestHandler::FileRequestHandler(std::shared_ptr<ContentManager> content, UpnpXMLBuilder* xmlBuilder)
+FileRequestHandler::FileRequestHandler(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
     : RequestHandler(std::move(content))
-    , xmlBuilder(xmlBuilder)
+    , xmlBuilder(std::move(xmlBuilder))
 {
 }
 

--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -39,10 +39,10 @@
 
 class FileRequestHandler : public RequestHandler {
 protected:
-    UpnpXMLBuilder* xmlBuilder;
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
 
 public:
-    explicit FileRequestHandler(std::shared_ptr<ContentManager> content, UpnpXMLBuilder* xmlBuilder);
+    explicit FileRequestHandler(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
 
     void getInfo(const char* filename, UpnpFileInfo* info) override;
     std::unique_ptr<IOHandler> open(const char* filename, enum UpnpOpenFileMode mode) override;

--- a/src/server.cc
+++ b/src/server.cc
@@ -149,7 +149,7 @@ void Server::run()
     std::string presentationURL = getPresentationUrl();
 
     log_debug("Creating UpnpXMLBuilder");
-    xmlbuilder = std::make_unique<UpnpXMLBuilder>(context, virtualUrl, presentationURL);
+    xmlbuilder = std::make_shared<UpnpXMLBuilder>(context, virtualUrl, presentationURL);
 
     // register root device with the library
     auto desc = xmlbuilder->renderDeviceDescription();
@@ -493,7 +493,7 @@ std::unique_ptr<RequestHandler> Server::createRequestHandler(const char* filenam
     log_debug("Filename: {}", filename);
 
     if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, CONTENT_MEDIA_HANDLER))) {
-        return std::make_unique<FileRequestHandler>(content, xmlbuilder.get());
+        return std::make_unique<FileRequestHandler>(content, xmlbuilder);
     }
 
     if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, CONTENT_UI_HANDLER))) {
@@ -507,7 +507,7 @@ std::unique_ptr<RequestHandler> Server::createRequestHandler(const char* filenam
         auto it = params.find(URL_REQUEST_TYPE);
         std::string r_type = it != params.end() && !it->second.empty() ? it->second : "index";
 
-        return web::createWebRequestHandler(content, r_type);
+        return web::createWebRequestHandler(content, xmlbuilder, r_type);
     }
 
     if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, DEVICE_DESCRIPTION_PATH))) {

--- a/src/server.h
+++ b/src/server.h
@@ -147,7 +147,7 @@ protected:
     /// The value is read from the configuration.
     int aliveAdvertisementInterval {};
 
-    std::unique_ptr<UpnpXMLBuilder> xmlbuilder;
+    std::shared_ptr<UpnpXMLBuilder> xmlbuilder;
 
     /// \brief ContentDirectoryService instance.
     ///

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -81,8 +81,8 @@ public:
     /// \param attributes Dictionary containing the <res> tag attributes (like resolution, etc.)
     static void renderResource(const std::string& URL, const std::map<std::string, std::string>& attributes, pugi::xml_node* parent);
 
-    static std::pair<std::string, bool> renderContainerImage(const std::string& virtualURL, const std::shared_ptr<CdsContainer>& cont);
-    static std::pair<std::string, bool> renderItemImage(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item);
+    std::pair<std::string, bool> renderContainerImage(const std::string& virtualURL, const std::shared_ptr<CdsContainer>& cont);
+    std::pair<std::string, bool> renderItemImage(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item);
     static std::pair<std::string, bool> renderSubtitle(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item);
     static std::string renderOneResource(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item, const std::shared_ptr<CdsResource>& res);
 
@@ -99,7 +99,7 @@ protected:
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;
 
-    static std::vector<int> orderedHandler;
+    std::vector<int> orderedHandler;
 
     const std::string virtualURL;
     const std::string presentationURL;
@@ -110,7 +110,7 @@ protected:
         std::string pathBase;
         bool addResID;
     };
-    static std::vector<std::shared_ptr<CdsResource>> getOrderedResources(const std::shared_ptr<CdsItem>& item);
+    std::vector<std::shared_ptr<CdsResource>> getOrderedResources(const std::shared_ptr<CdsObject>& object);
 
     static std::unique_ptr<PathBase> getPathBase(const std::shared_ptr<CdsItem>& item, bool forceLocal = false);
     static std::string renderExtension(const std::string& contentType, const fs::path& location);

--- a/src/web/containers.cc
+++ b/src/web/containers.cc
@@ -37,8 +37,9 @@
 #include "server.h"
 #include "upnp_xml.h"
 
-web::containers::containers(std::shared_ptr<ContentManager> content)
+web::containers::containers(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
     : WebRequestHandler(std::move(content))
+    , xmlBuilder(std::move(xmlBuilder))
 {
 }
 
@@ -74,7 +75,7 @@ void web::containers::process()
         int autoscanType = cont->getAutoscanType();
         ce.append_attribute("autoscan_type") = mapAutoscanType(autoscanType).data();
 
-        auto [url, artAdded] = UpnpXMLBuilder::renderContainerImage(server->getVirtualUrl(), cont);
+        auto [url, artAdded] = xmlBuilder->renderContainerImage(server->getVirtualUrl(), cont);
         if (artAdded) {
             ce.append_attribute("image") = url.c_str();
         }

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -41,8 +41,9 @@
 #include "upnp_xml.h"
 #include "util/tools.h"
 
-web::edit_load::edit_load(std::shared_ptr<ContentManager> content)
+web::edit_load::edit_load(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
     : WebRequestHandler(std::move(content))
+    , xmlBuilder(std::move(xmlBuilder))
 {
 }
 
@@ -195,7 +196,7 @@ void web::edit_load::process()
         mimeType.append_attribute("value") = objItem->getMimeType().c_str();
         mimeType.append_attribute("editable") = true;
 
-        auto [url, artAdded] = UpnpXMLBuilder::renderItemImage(server->getVirtualUrl(), objItem);
+        auto [url, artAdded] = xmlBuilder->renderItemImage(server->getVirtualUrl(), objItem);
         if (artAdded) {
             auto image = item.append_child("image");
             image.append_attribute("value") = url.c_str();
@@ -212,7 +213,7 @@ void web::edit_load::process()
     // write container meta info
     if (obj->isContainer()) {
         auto cont = std::static_pointer_cast<CdsContainer>(obj);
-        auto [url, artAdded] = UpnpXMLBuilder::renderContainerImage(server->getVirtualUrl(), cont);
+        auto [url, artAdded] = xmlBuilder->renderContainerImage(server->getVirtualUrl(), cont);
         if (artAdded) {
             auto image = item.append_child("image");
             image.append_attribute("value") = url.c_str();

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -37,8 +37,9 @@
 #include "server.h"
 #include "upnp_xml.h"
 
-web::items::items(std::shared_ptr<ContentManager> content)
+web::items::items(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
     : WebRequestHandler(std::move(content))
+    , xmlBuilder(std::move(xmlBuilder))
 {
 }
 
@@ -131,7 +132,7 @@ void web::items::process()
         std::string res = UpnpXMLBuilder::getFirstResourcePath(objItem);
         item.append_child("res").append_child(pugi::node_pcdata).set_value(res.c_str());
 
-        auto [url, artAdded] = UpnpXMLBuilder::renderItemImage(server->getVirtualUrl(), objItem);
+        auto [url, artAdded] = xmlBuilder->renderItemImage(server->getVirtualUrl(), objItem);
         if (artAdded) {
             item.append_child("image").append_child(pugi::node_pcdata).set_value(url.c_str());
         }

--- a/src/web/pages.cc
+++ b/src/web/pages.cc
@@ -35,6 +35,7 @@ namespace web {
 
 std::unique_ptr<WebRequestHandler> createWebRequestHandler(
     std::shared_ptr<ContentManager> content,
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder,
     std::string_view page)
 {
     if (page == "add")
@@ -46,15 +47,15 @@ std::unique_ptr<WebRequestHandler> createWebRequestHandler(
     if (page == "auth")
         return std::make_unique<web::auth>(std::move(content));
     if (page == "containers")
-        return std::make_unique<web::containers>(std::move(content));
+        return std::make_unique<web::containers>(std::move(content), std::move(xmlBuilder));
     if (page == "directories")
         return std::make_unique<web::directories>(std::move(content));
     if (page == "files")
         return std::make_unique<web::files>(std::move(content));
     if (page == "items")
-        return std::make_unique<web::items>(std::move(content));
+        return std::make_unique<web::items>(std::move(content), std::move(xmlBuilder));
     if (page == "edit_load")
-        return std::make_unique<web::edit_load>(std::move(content));
+        return std::make_unique<web::edit_load>(std::move(content), std::move(xmlBuilder));
     if (page == "edit_save")
         return std::make_unique<web::edit_save>(std::move(content));
     if (page == "autoscan")

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -41,6 +41,7 @@
 // forward declaration
 class Config;
 class Database;
+class UpnpXMLBuilder;
 
 namespace web {
 
@@ -59,8 +60,11 @@ public:
 
 /// \brief Browser container tree
 class containers : public WebRequestHandler {
+protected:
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
+
 public:
-    explicit containers(std::shared_ptr<ContentManager> content);
+    explicit containers(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
     void process() override;
 };
 
@@ -80,8 +84,11 @@ public:
 
 /// \brief Browser item list
 class items : public WebRequestHandler {
+protected:
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
+
 public:
-    explicit items(std::shared_ptr<ContentManager> content);
+    explicit items(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
     void process() override;
 };
 
@@ -101,8 +108,11 @@ public:
 
 /// \brief Browser remove item
 class edit_load : public WebRequestHandler {
+protected:
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
+
 public:
-    explicit edit_load(std::shared_ptr<ContentManager> content);
+    explicit edit_load(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
     void process() override;
 };
 
@@ -164,6 +174,7 @@ public:
 /// \return the appropriate request handler.
 std::unique_ptr<WebRequestHandler> createWebRequestHandler(
     std::shared_ptr<ContentManager> content,
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder,
     std::string_view page);
 
 /// \brief Browse clients list

--- a/web/gerbera-config-expert.json
+++ b/web/gerbera-config-expert.json
@@ -1246,6 +1246,24 @@
 					]
 				},
 				{
+					"item": "/server/upnp/album-properties/upnp-namespace",
+					"caption": "Album-Namespaces",
+					"type": "List",
+					"editable": true,
+					"children": [
+						{
+							"item": "/server/upnp/album-properties/upnp-namespace/attribute::xmlns",
+							"caption": "xmlns",
+							"editable": true
+						},
+						{
+							"item": "/server/upnp/album-properties/upnp-namespace/attribute::uri",
+							"caption": "uri",
+							"editable": true
+						}
+					]
+				},
+				{
 					"item": "/server/upnp/artist-properties/upnp-property",
 					"caption": "Artist-Properties",
 					"type": "List",
@@ -1259,6 +1277,24 @@
 						{
 							"item": "/server/upnp/artist-properties/upnp-property/attribute::meta-data",
 							"caption": "Metadata",
+							"editable": true
+						}
+					]
+				},
+				{
+					"item": "/server/upnp/artist-properties/upnp-namespace",
+					"caption": "Artist-Namespaces",
+					"type": "List",
+					"editable": true,
+					"children": [
+						{
+							"item": "/server/upnp/artist-properties/upnp-namespace/attribute::xmlns",
+							"caption": "xmlns",
+							"editable": true
+						},
+						{
+							"item": "/server/upnp/artist-properties/upnp-namespace/attribute::uri",
+							"caption": "uri",
 							"editable": true
 						}
 					]
@@ -1282,6 +1318,24 @@
 					]
 				},
 				{
+					"item": "/server/upnp/genre-properties/upnp-namespace",
+					"caption": "Genre-Namespaces",
+					"type": "List",
+					"editable": true,
+					"children": [
+						{
+							"item": "/server/upnp/genre-properties/upnp-namespace/attribute::xmlns",
+							"caption": "xmlns",
+							"editable": true
+						},
+						{
+							"item": "/server/upnp/genre-properties/upnp-namespace/attribute::uri",
+							"caption": "uri",
+							"editable": true
+						}
+					]
+				},
+				{
 					"item": "/server/upnp/playlist-properties/upnp-property",
 					"caption": "Playlist-Properties",
 					"type": "List",
@@ -1300,6 +1354,24 @@
 					]
 				},
 				{
+					"item": "/server/upnp/playlist-properties/upnp-namespace",
+					"caption": "Playlist-Namespaces",
+					"type": "List",
+					"editable": true,
+					"children": [
+						{
+							"item": "/server/upnp/playlist-properties/upnp-namespace/attribute::xmlns",
+							"caption": "xmlns",
+							"editable": true
+						},
+						{
+							"item": "/server/upnp/playlist-properties/upnp-namespace/attribute::uri",
+							"caption": "uri",
+							"editable": true
+						}
+					]
+				},
+				{
 					"item": "/server/upnp/title-properties/upnp-property",
 					"caption": "Title-Properties",
 					"type": "List",
@@ -1313,6 +1385,24 @@
 						{
 							"item": "/server/upnp/title-properties/upnp-property/attribute::meta-data",
 							"caption": "Metadata",
+							"editable": true
+						}
+					]
+				},
+				{
+					"item": "/server/upnp/title-properties/upnp-namespace",
+					"caption": "Title-Namespaces",
+					"type": "List",
+					"editable": true,
+					"children": [
+						{
+							"item": "/server/upnp/title-properties/upnp-namespace/attribute::xmlns",
+							"caption": "xmlns",
+							"editable": true
+						},
+						{
+							"item": "/server/upnp/title-properties/upnp-namespace/attribute::uri",
+							"caption": "uri",
 							"editable": true
 						}
 					]


### PR DESCRIPTION
make xmlbuilder object shared_ptr and make it available where needed (instead of static access)