### PR TITLE
get rid of ClientCacheEntry pointer

### DIFF
--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -87,7 +87,7 @@ public:
     void getInfo(const struct sockaddr_storage* addr, const std::string& userAgent, const ClientInfo** ppInfo);
 
     void addClientByDiscovery(const struct sockaddr_storage* addr, const std::string& userAgent, const std::string& descLocation);
-    std::shared_ptr<std::vector<ClientCacheEntry>> getClientList() const { return cache; }
+    const std::vector<ClientCacheEntry>& getClientList() const { return cache; }
 
 private:
     bool getInfoByAddr(const struct sockaddr_storage* addr, const ClientInfo** ppInfo);
@@ -100,7 +100,7 @@ private:
 
     std::mutex mutex;
     using AutoLock = std::lock_guard<std::mutex>;
-    std::shared_ptr<std::vector<ClientCacheEntry>> cache;
+    std::vector<ClientCacheEntry> cache;
 
     std::vector<ClientInfo> clientInfo;
 };

--- a/src/web/clients.cc
+++ b/src/web/clients.cc
@@ -52,8 +52,8 @@ void web::clients::process()
     auto clients = root.append_child("clients");
     xml2JsonHints->setArrayName(clients, "client");
 
-    auto arr = content->getContext()->getClients()->getClientList();
-    for (auto&& obj : *arr) {
+    auto&& arr = content->getContext()->getClients()->getClientList();
+    for (auto&& obj : arr) {
         auto item = clients.append_child("client");
         auto ip = sockAddrGetNameInfo(reinterpret_cast<const struct sockaddr*>(&obj.addr));
         item.append_attribute("ip") = ip.c_str();


### PR DESCRIPTION
It's only copied in a single place. No need for shared_ptr complexity.

Signed-off-by: Rosen Penev <rosenp@gmail.com>