### PR TITLE
fix bad unique_ptr usage

### DIFF
--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -96,7 +96,7 @@ private:
     bool getInfoByCache(const struct sockaddr_storage* addr, const ClientInfo** ppInfo);
     void updateCache(const struct sockaddr_storage* addr, const std::string& userAgent, const ClientInfo* pInfo);
 
-    static bool downloadDescription(const std::string& location, std::unique_ptr<pugi::xml_document> xml);
+    static std::unique_ptr<pugi::xml_document> downloadDescription(const std::string& location);
 
     std::mutex mutex;
     using AutoLock = std::lock_guard<std::mutex>;


### PR DESCRIPTION
Return it instead. This function's usage is commented
out. If uncommented, it fails as you cannot copy a unique_ptr. Fixed
that as well.

Signed-off-by: Rosen Penev <rosenp@gmail.com>