### PR TITLE
Add M3U8 support

### DIFF
--- a/scripts/js/common.js
+++ b/scripts/js/common.js
@@ -876,6 +876,11 @@ function readM3uPlaylist(playlist_title, playlistChain, playlistDirChain) {
     var line = readln();
     var playlistOrder = 1;
 
+    // Remove a BOM if there is one
+    if (line.charCodeAt(0) === 0xFEFF) {
+        line = line.substr(1);
+    }
+
     // Here is the do - while loop which will read the playlist line by line.
     do {
         var matches = line.match(/^#EXTINF:(-?\d+),\s?(\S.+)$/i);

--- a/src/config/config_definition.cc
+++ b/src/config/config_definition.cc
@@ -237,6 +237,7 @@ static std::map<std::string, std::string> ext_mt_defaults {
     { "flv", "video/x-flv" },
     { "m2ts", "video/mp2t" }, // LibMagic fails to identify MPEG2 Transport Streams
     { "m3u", "audio/x-mpegurl" },
+    { "m3u8", "audio/x-mpegurl" },
     { "m4a", "audio/mp4" }, // LibMagic identifies this as audio/x-m4a, preventing TagLib from parsing it
     { "mka", "audio/x-matroska" },
     { "mkv", "video/x-matroska" },

--- a/test/config/fixtures/mock-config-all.xml
+++ b/test/config/fixtures/mock-config-all.xml
@@ -76,6 +76,7 @@
         <map from="flv" to="video/x-flv" />
         <map from="m2ts" to="video/mp2t" />
         <map from="m3u" to="audio/x-mpegurl" />
+        <map from="m3u8" to="audio/x-mpegurl" />
         <map from="m4a" to="audio/mp4" />
         <map from="mka" to="audio/x-matroska" />
         <map from="mkv" to="video/x-matroska" />

--- a/test/config/fixtures/mock-config-minimal.xml
+++ b/test/config/fixtures/mock-config-minimal.xml
@@ -64,6 +64,7 @@
         <map from="flv" to="video/x-flv" />
         <map from="m2ts" to="video/mp2t" />
         <map from="m3u" to="audio/x-mpegurl" />
+        <map from="m3u8" to="audio/x-mpegurl" />
         <map from="m4a" to="audio/mp4" />
         <map from="mka" to="audio/x-matroska" />
         <map from="mkv" to="video/x-matroska" />

--- a/test/config/fixtures/mock-import-magic-js-online.xml
+++ b/test/config/fixtures/mock-import-magic-js-online.xml
@@ -16,6 +16,7 @@
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />
+      <map from="m3u8" to="audio/x-mpegurl" />
       <map from="m4a" to="audio/mp4" />
       <map from="mka" to="audio/x-matroska" />
       <map from="mkv" to="video/x-matroska" />

--- a/test/config/fixtures/mock-import-magic-js.xml
+++ b/test/config/fixtures/mock-import-magic-js.xml
@@ -16,6 +16,7 @@
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />
+      <map from="m3u8" to="audio/x-mpegurl" />
       <map from="m4a" to="audio/mp4" />
       <map from="mka" to="audio/x-matroska" />
       <map from="mkv" to="video/x-matroska" />

--- a/test/config/fixtures/mock-import-magic.xml
+++ b/test/config/fixtures/mock-import-magic.xml
@@ -12,6 +12,7 @@
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />
+      <map from="m3u8" to="audio/x-mpegurl" />
       <map from="m4a" to="audio/mp4" />
       <map from="mka" to="audio/x-matroska" />
       <map from="mkv" to="video/x-matroska" />

--- a/test/config/fixtures/mock-import-mappings.xml
+++ b/test/config/fixtures/mock-import-mappings.xml
@@ -7,6 +7,7 @@
     <map from="flv" to="video/x-flv" />
     <map from="m2ts" to="video/mp2t" />
     <map from="m3u" to="audio/x-mpegurl" />
+    <map from="m3u8" to="audio/x-mpegurl" />
     <map from="m4a" to="audio/mp4" />
     <map from="mka" to="audio/x-matroska" />
     <map from="mkv" to="video/x-matroska" />

--- a/test/config/fixtures/mock-import-none.xml
+++ b/test/config/fixtures/mock-import-none.xml
@@ -11,6 +11,7 @@
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />
+      <map from="m3u8" to="audio/x-mpegurl" />
       <map from="m4a" to="audio/mp4" />
       <map from="mka" to="audio/x-matroska" />
       <map from="mkv" to="video/x-matroska" />

--- a/test/scripting/CMakeLists.txt
+++ b/test/scripting/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(testscripting
     test_import_script.cc
     test_import_struct_script.cc
     test_internal_m3u_playlist.cc
+    test_internal_m3u8_playlist.cc
     test_internal_pls_playlist.cc
     test_runtime.cc
 )

--- a/test/scripting/test_internal_m3u8_playlist.cc
+++ b/test/scripting/test_internal_m3u8_playlist.cc
@@ -1,0 +1,212 @@
+#ifdef HAVE_JS
+
+#include <duktape.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "cds_objects.h"
+#include "config/config_manager.h"
+#include "util/string_converter.h"
+
+#include "mock/common_script_mock.h"
+#include "mock/duk_helper.h"
+#include "mock/script_test_fixture.h"
+
+using namespace ::testing;
+
+// Extends ScriptTestFixture to allow
+// for unique testing of the Internal URL M3U8 Playlist
+// processing
+class InternalUrlM3U8PlaylistTest : public ScriptTestFixture {
+public:
+    // As Duktape requires static methods, so must the mock expectations be
+    static std::unique_ptr<CommonScriptMock> commonScriptMock;
+
+    // Used to iterate through `readln` content
+    static int readLineCnt;
+
+    InternalUrlM3U8PlaylistTest()
+    {
+        commonScriptMock = std::make_unique<::testing::NiceMock<CommonScriptMock>>();
+        scriptName = "playlists.js";
+    }
+
+    ~InternalUrlM3U8PlaylistTest() override
+    {
+        commonScriptMock.reset();
+    }
+};
+
+std::unique_ptr<CommonScriptMock> InternalUrlM3U8PlaylistTest::commonScriptMock;
+int InternalUrlM3U8PlaylistTest::readLineCnt = 0;
+
+static duk_ret_t getPlaylistType(duk_context* ctx)
+{
+    std::string playlistMimeType = ScriptTestFixture::getPlaylistType(ctx);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->getPlaylistType(playlistMimeType);
+}
+
+static duk_ret_t print(duk_context* ctx)
+{
+    std::string msg = ScriptTestFixture::print(ctx);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->print(msg);
+}
+
+static duk_ret_t addContainerTree(duk_context* ctx)
+{
+    std::map<std::string, std::string> map {
+        { "", "0" },
+        { "/Playlists/All Playlists/Playlist Title", "42" },
+        { "/Playlists/Directories/of/Playlist Title", "43" },
+    };
+    std::vector<std::string> tree = ScriptTestFixture::addContainerTree(ctx, map);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->addContainerTree(tree);
+}
+
+static duk_ret_t createContainerChain(duk_context* ctx)
+{
+    std::vector<std::string> array = ScriptTestFixture::createContainerChain(ctx);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->createContainerChain(array);
+}
+
+static duk_ret_t getLastPath(duk_context* ctx)
+{
+    std::string inputPath = ScriptTestFixture::getLastPath(ctx);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->getLastPath(inputPath);
+}
+
+// Proxy the Duktape script with `readln`
+// Mimics reading the playlist file line by line
+// Uses the `CommonScriptMock` to track expectations
+static duk_ret_t readln(duk_context* ctx)
+{
+    std::vector<std::string> lines {
+        "\xEF\xBB\xBF#EXTM3U",
+        "#EXTINF:123, Example Artist, Thumbs Up Inc. \xF0\x9F\x91\x8D",
+        "/home/gerbera/example\xE2\x9C\x85.mp3",
+        "-EOF-" // used to stop processing :/
+    };
+
+    std::string line = lines.at(InternalUrlM3U8PlaylistTest::readLineCnt);
+
+    duk_push_string(ctx, line.c_str());
+    InternalUrlM3U8PlaylistTest::readLineCnt++;
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->readln(line);
+}
+
+static duk_ret_t addCdsObject(duk_context* ctx)
+{
+    std::vector<std::string> keys { "objectType", "location", "title", "playlistOrder" };
+    addCdsObjectParams params = ScriptTestFixture::addCdsObject(ctx, keys);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->addCdsObject(params.objectValues, params.containerChain, params.objectType);
+}
+
+static duk_ret_t copyObject(duk_context* ctx)
+{
+    std::map<std::string, std::string> obj {
+        { "title", "example\xE2\x9C\x85.mp3" },
+        { "objectType", "2" },
+        { "location", "/home/gerbera/example\xE2\x9C\x85.mp3" },
+        { "playlistOrder", "1" },
+    };
+    std::map<std::string, std::string> meta {
+        { "dc:title", "example\xE2\x9C\x85.mp3" },
+        { "upnp:artist", "Artist" },
+        { "upnp:album", "Album" },
+        { "dc:date", "2018" },
+    };
+    copyObjectParams params = ScriptTestFixture::copyObject(ctx, obj, meta);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->copyObject(params.isObject);
+}
+
+static duk_ret_t getCdsObject(duk_context* ctx)
+{
+    std::map<std::string, std::string> obj {
+        { "title", "example\xE2\x9C\x85.mp3" },
+        { "objectType", "2" },
+        { "location", "/home/gerbera/example\xE2\x9C\x85.mp3" },
+        { "playlistOrder", "1" },
+    };
+    std::map<std::string, std::string> meta {
+        { "dc:title", "example\xE2\x9C\x85.mp3" },
+        { "upnp:artist", "Artist" },
+        { "upnp:album", "Album" },
+        { "dc:date", "2018" },
+    };
+    getCdsObjectParams params = ScriptTestFixture::getCdsObject(ctx, obj, meta);
+    return InternalUrlM3U8PlaylistTest::commonScriptMock->getCdsObject(params.location);
+}
+
+// Mock the Duktape C methods
+// that are called from the playlists.js script
+// * These are static methods, which makes mocking difficult.
+static duk_function_list_entry js_global_functions[] = {
+    { "print", print, DUK_VARARGS },
+    { "getPlaylistType", getPlaylistType, 1 },
+    { "createContainerChain", createContainerChain, 1 },
+    { "getLastPath", getLastPath, 1 },
+    { "readln", readln, 1 },
+    { "addCdsObject", addCdsObject, 3 },
+    { "copyObject", copyObject, 1 },
+    { "getCdsObject", getCdsObject, 1 },
+    { "addContainerTree", addContainerTree, 1 },
+    { nullptr, nullptr, 0 },
+};
+
+template <typename Map>
+bool map_compare(Map const& lhs, Map const& rhs)
+{
+    return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
+}
+MATCHER_P(IsIdenticalMap, control, "Map to be identical")
+{
+    {
+        return (map_compare(arg, control));
+    }
+}
+
+TEST_F(InternalUrlM3U8PlaylistTest, CreatesDukContextWithPlaylistScript)
+{
+    EXPECT_NE(ctx, nullptr);
+}
+
+TEST_F(InternalUrlM3U8PlaylistTest, AddsCdsObjectFromM3U8PlaylistWithInternalUrlPlaylistAndDirChains)
+{
+    std::map<std::string, std::string> asPlaylistChain {
+        { "objectType", "2" },
+        { "location", "/home/gerbera/example\xE2\x9C\x85.mp3" },
+        { "playlistOrder", "1" },
+        { "title", "example\xE2\x9C\x85.mp3" },
+    };
+
+    std::map<std::string, std::string> asPlaylistDirChain {
+        { "objectType", "2" },
+        { "location", "/home/gerbera/example\xE2\x9C\x85.mp3" },
+        { "playlistOrder", "2" },
+        { "title", "example\xE2\x9C\x85.mp3" },
+    };
+
+    // Expecting the common script calls
+    // and will proxy through the mock objects
+    // for verification.
+    EXPECT_CALL(*commonScriptMock, getPlaylistType(Eq("audio/x-mpegurl"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, print(Eq("Processing playlist: /location/of/playlist.m3u8"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, addContainerTree(ElementsAre("Playlists", "All Playlists", "Playlist Title"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, getLastPath(Eq("/location/of/playlist.m3u8"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, addContainerTree(ElementsAre("Playlists", "Directories", "of", "Playlist Title"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, readln(Eq("\xEF\xBB\xBF#EXTM3U"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, readln(Eq("#EXTINF:123, Example Artist, Thumbs Up Inc. \xF0\x9F\x91\x8D"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, readln(Eq("/home/gerbera/example\xE2\x9C\x85.mp3"))).WillOnce(Return(1));
+    EXPECT_CALL(*commonScriptMock, readln(Eq("-EOF-"))).WillOnce(Return(0));
+    EXPECT_CALL(*commonScriptMock, addCdsObject(IsIdenticalMap(asPlaylistChain), "42", UNDEFINED)).WillOnce(Return(0));
+    EXPECT_CALL(*commonScriptMock, addCdsObject(IsIdenticalMap(asPlaylistDirChain), "43", UNDEFINED)).WillOnce(Return(0));
+    EXPECT_CALL(*commonScriptMock, getCdsObject(Eq("/home/gerbera/example\xE2\x9C\x85.mp3"))).WillRepeatedly(Return(1));
+    EXPECT_CALL(*commonScriptMock, copyObject(Eq(true))).WillRepeatedly(Return(1));
+
+    addGlobalFunctions(ctx, js_global_functions);
+    dukMockPlaylist(ctx, "Playlist Title", "/location/of/playlist.m3u8", "audio/x-mpegurl");
+
+    executeScript(ctx);
+}
+#endif


### PR DESCRIPTION
The M3U8 format allows special characters within the file names and descriptions. It uses an UTF8 BOM to indicate the byte order. This commit strips the BOM in common.js to make sure the rest of the file is interpreted correctly. Without this change the BOM will be part of the first line of the playlist and lead to an error message or a missing playlist entry.

The core of this commit is stripping a BOM from the first line of the playlist if it exists and mapping the m3u8 extension to `audio/x-mpegurl`. I use foobar2000 to generate the playlists and some of my filenames contain characters that can not be encoded correctly within a m3u playlist.

I opted to create a new test for m3u8 playlists that is almost a copy of the m3u case. I opted for a dedicated test because the it's a different file format and to make this commit cleaner. Maybe this test could also be rolled into the m3u test. But my ctest knowledge is too limited to say anything about that.