### PR TITLE
replace several emplace_back with push_back

### DIFF
--- a/src/config/config_definition.h
+++ b/src/config/config_definition.h
@@ -54,7 +54,7 @@ public:
         for (auto&& co : complexOptions) {
             auto tco = std::dynamic_pointer_cast<CS>(co);
             if (tco && tco->getValue()) {
-                result.emplace_back(tco);
+                result.push_back(std::move(tco));
             }
         }
         return result;

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -687,7 +687,9 @@ bool ConfigArraySetup::InitItemsPerPage(const pugi::xml_node& value, std::vector
                 log_error("Error in config file: incorrect <{}> value for <{}>", node_name, value.name());
                 return false;
             }
-            result.emplace_back(child.text().as_string());
+
+            auto str = std::string(child.text().as_string());
+            result.push_back(std::move(str));
         }
     }
     return true;

--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -405,7 +405,7 @@ void AutoscanInotify::checkMoveWatches(int wd, const std::shared_ptr<Wd>& wdObj)
                 if (watchToRemove) {
                     auto adir = watchToRemove->getAutoscanDirectory();
                     if (adir->persistent()) {
-                        monitorNonexisting(path, std::move(adir));
+                        monitorNonexisting(path, adir);
                         content->handlePeristentAutoscanRemove(adir);
                     }
 

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1159,12 +1159,12 @@ std::pair<int, bool> ContentManager::addContainerChain(const std::string& chain,
         for (auto&& contId : updateID) {
             auto container = std::dynamic_pointer_cast<CdsContainer>(database->loadObject(contId));
             containerMap[container->getLocation()] = container;
-            containerList.emplace_back(container);
+            containerList.push_back(std::move(container));
         }
         isNew = true;
     } else {
         containerID = containerMap[newChain]->getID();
-        containerList.emplace_back(containerMap[newChain]);
+        containerList.push_back(containerMap[newChain]);
     }
 
     if (!updateID.empty()) {
@@ -1603,7 +1603,7 @@ void ContentManager::removeObject(const std::shared_ptr<AutoscanDirectory>& adir
                 rm_list = autoscan_inotify->removeIfSubdir(path);
                 for (size_t i = 0; i < rm_list->size(); i++) {
                     auto dir = rm_list->get(i);
-                    inotify->unmonitor(std::move(dir));
+                    inotify->unmonitor(dir);
                 }
             }
 #endif

--- a/src/content/scripting/js_functions.cc
+++ b/src/content/scripting/js_functions.cc
@@ -84,7 +84,7 @@ duk_ret_t js_addContainerTree(duk_context* ctx)
             duk_to_object(ctx, -1);
             auto cds_obj = self->dukObject2cdsObject(nullptr);
             if (cds_obj) {
-                result.emplace_back(cds_obj);
+                result.push_back(std::move(cds_obj));
             } else {
                 log_js("js_addContainerTree: no CdsObject at {}", i);
             }

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -114,8 +114,8 @@ std::vector<std::string> Script::getPropertyNames() const
     duk_enum(ctx, -1, 0);
     while (duk_next(ctx, -1 /*enum_idx*/, 0 /*get_value*/)) {
         /* [ ... enum key ] */
-        auto sym = duk_get_string(ctx, -1);
-        keys.emplace_back(sym);
+        auto sym = std::string(duk_get_string(ctx, -1));
+        keys.push_back(std::move(sym));
         duk_pop(ctx); /* pop_key */
     }
     duk_pop(ctx); // duk_enum

--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -552,7 +552,7 @@ std::string SortParser::parse()
         }
         auto sortSql = colMapper ? colMapper->mapQuoted(seg) : "";
         if (!sortSql.empty()) {
-            sort.emplace_back(fmt::format("{} {}", sortSql, (desc ? "DESC" : "ASC")));
+            sort.push_back(fmt::format("{} {}", sortSql, (desc ? "DESC" : "ASC")));
         } else {
             log_warning("Unknown sort key '{}' in '{}'", seg, sortCrit);
         }

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -126,7 +126,7 @@ std::vector<fs::path> ContentPathSetup::getContentPath(const std::shared_ptr<Cds
         }
     }
     if (result.empty())
-        result.emplace_back("");
+        result.emplace_back();
     return result;
 }
 

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -91,7 +91,7 @@ std::vector<std::string> splitString(std::string_view str, char sep, bool empty)
         } else if (pos == data) {
             data++;
             if ((data < end) && empty)
-                ret.emplace_back("");
+                ret.emplace_back();
         } else {
             std::string part(data, pos - data);
             ret.push_back(part);


### PR DESCRIPTION
The clang-tidy check it seems looks for cases where the types do not
match to suggest emplace_back. Use push_back where they do. Saves some
size.

Signed-off-by: Rosen Penev <rosenp@gmail.com>