### PR TITLE
fmt: reduce minimum version to 6.1.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ else()
     target_link_libraries(libgerbera PUBLIC UPNP::UPNP)
 endif()
 
-find_package(fmt 7.1.3 REQUIRED)
+find_package(fmt 6.1.2 REQUIRED)
 target_link_libraries(libgerbera PUBLIC fmt::fmt)
 
 find_package(spdlog 1.8.2 REQUIRED)


### PR DESCRIPTION
This is what is used on Debian 10.

Signed-off-by: Rosen Penev <rosenp@gmail.com>