### PR TITLE
add PathBase constructor

### DIFF
--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -344,16 +344,16 @@ std::unique_ptr<UpnpXMLBuilder::PathBase> UpnpXMLBuilder::getPathBase(const std:
     /// for each resource once the io handlers are ready    int objectType = ;
     if (item->isExternalItem()) {
         if (!item->getFlag(OBJECT_FLAG_PROXY_URL) && (!forceLocal)) {
-            return std::make_unique<PathBase>(PathBase { item->getLocation(), false });
+            return std::make_unique<PathBase>(item->getLocation(), false);
         }
 
         if ((item->getFlag(OBJECT_FLAG_ONLINE_SERVICE) && item->getFlag(OBJECT_FLAG_PROXY_URL)) || forceLocal) {
             auto path = RequestHandler::joinUrl({ CONTENT_ONLINE_HANDLER, dictEncodeSimple(dict), URL_RESOURCE_ID }, true);
-            return std::make_unique<PathBase>(PathBase { path, true });
+            return std::make_unique<PathBase>(path, true);
         }
     }
     auto path = RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, dictEncodeSimple(dict), URL_RESOURCE_ID }, true);
-    return std::make_unique<PathBase>(PathBase { path, true });
+    return std::make_unique<PathBase>(path, true);
 }
 
 /// \brief build path for first resource from item

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -106,8 +106,12 @@ protected:
     const std::string presentationURL;
 
     /// \brief Holds a part of path and bool which says if we need to append the resource
-    class PathBase {
-    public:
+    struct PathBase {
+        PathBase(std::string pathBase, bool addResID)
+            : pathBase(std::move(pathBase))
+            , addResID(addResID)
+        {
+        }
         std::string pathBase;
         bool addResID;
     };


### PR DESCRIPTION
Allows forwarding arguments directly.

Also change to struct. It's more accurate anyway.

Signed-off-by: Rosen Penev <rosenp@gmail.com>