### PR TITLE
clang-tidy: make member function const

### DIFF
--- a/src/cds_resource.h
+++ b/src/cds_resource.h
@@ -69,7 +69,7 @@ public:
         std::map<std::string, std::string> parameters,
         std::map<std::string, std::string> options);
 
-    int getResId() { return resId; }
+    int getResId() const { return resId; }
     void setResId(int rId) { resId = rId; }
     /// \brief Adds a resource attribute.
     ///


### PR DESCRIPTION
Found with readability-make-member-function-const

Signed-off-by: Rosen Penev <rosenp@gmail.com>