### PR TITLE
Split CI validation jobs

### DIFF
--- a/.github/workflows/ci-js.yml
+++ b/.github/workflows/ci-js.yml
@@ -1,0 +1,25 @@
+name: CI validation for web UI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  js:
+    runs-on: ubuntu-20.04
+    env:
+      DETECT_CHROMEDRIVER_VERSION: true
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: run tests
+        run: |
+          npm ci
+          npm run lint
+          npm run test
+          npm run test:e2e
+        working-directory: ./gerbera-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,19 +57,3 @@ jobs:
         # Remove build directories before creating a cache.
         run: |
           conan remove '*' --force --builds --system-reqs
-  js:
-    runs-on: ubuntu-20.04
-    env:
-      DETECT_CHROMEDRIVER_VERSION: true
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: run tests
-        run: |
-          npm ci
-          npm run lint
-          npm run test
-          npm run test:e2e
-        working-directory: ./gerbera-web


### PR DESCRIPTION
makes it easier to rerun js if stuck