### PR TITLE
add missing std::vector

### DIFF
--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1171,12 +1171,12 @@ int SQLDatabase::createContainer(int parentID, std::string name, const std::stri
     log_debug("Created object row, id: {}", newId);
 
     if (!itemMetadata.empty()) {
+        auto mfields = std::vector {
+            identifier("item_id"),
+            identifier("property_name"),
+            identifier("property_value"),
+        };
         for (auto&& [key, val] : itemMetadata) {
-            auto mfields = std::vector {
-                identifier("item_id"),
-                identifier("property_name"),
-                identifier("property_value"),
-            };
             auto mvalues = std::vector {
                 fmt::format("{}", newId),
                 quote(key),

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -665,7 +665,7 @@ std::vector<std::shared_ptr<SQLDatabase::AddUpdateTable>> SQLDatabase::_addUpdat
 
     // check for a duplicate (virtual) object
     if (hasReference && op != Operation::Update) {
-        const auto where = {
+        auto where = std::vector {
             fmt::format("{}={}", identifier("parent_id"), quote(obj->getParentID())),
             fmt::format("{}={}", identifier("ref_id"), quote(refObj->getID())),
             fmt::format("{}={}", identifier("dc_title"), quote(obj->getTitle())),
@@ -1843,7 +1843,7 @@ std::string SQLDatabase::getInternalSetting(const std::string& key)
 /* config methods */
 std::vector<ConfigValue> SQLDatabase::getConfigValues()
 {
-    auto fields = {
+    auto fields = std::vector {
         identifier("item"),
         identifier("key"),
         identifier("item_value"),


### PR DESCRIPTION
small size reduction. fmt seems to like vector.

This also avoids using std::initializer_list, which should not ve used.

Signed-off-by: Rosen Penev <rosenp@gmail.com>