### PR TITLE
get rid of auto&& with structured bindings

### DIFF
--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -483,7 +483,7 @@ std::string DefaultSQLEmitter::emit(const ASTCompareOperator* node, const std::s
     const std::string& value) const
 {
     auto operatr = node->getValue();
-    auto&& [prpUpper, prpLower] = getPropertyStatement(property);
+    auto [prpUpper, prpLower] = getPropertyStatement(property);
 
     if ((operatr == ">" || operatr == ">=") && value.substr(0, 5) == "@last") {
         auto dateVal = to_seconds(std::chrono::system_clock::now()).count() - (24 * 60 * 60 * stoiString(value.substr(5)));
@@ -493,7 +493,7 @@ std::string DefaultSQLEmitter::emit(const ASTCompareOperator* node, const std::s
     if (operatr != "=")
         throw_std_runtime_error("Operator '{}' not yet supported", operatr);
 
-    auto&& [clsUpper, clcLower] = getPropertyStatement(UPNP_SEARCH_CLASS);
+    auto [clsUpper, clcLower] = getPropertyStatement(UPNP_SEARCH_CLASS);
     return fmt::format(logicOperator.at((property[0] == '@') ? "@compare" : "compare"), clsUpper,
         fmt::format("{}{}", prpUpper, operatr), fmt::format("{}{}", prpLower, operatr), value);
 }
@@ -504,8 +504,8 @@ std::string DefaultSQLEmitter::emit(const ASTStringOperator* node, const std::st
     if (logicOperator.find(stringOperator) == logicOperator.end()) {
         throw_std_runtime_error("Operation '{}' not yet supported", stringOperator);
     }
-    auto&& [prpUpper, prpLower] = getPropertyStatement(property);
-    auto&& [clsUpper, clsLower] = getPropertyStatement(UPNP_SEARCH_CLASS);
+    auto [prpUpper, prpLower] = getPropertyStatement(property);
+    auto [clsUpper, clsLower] = getPropertyStatement(UPNP_SEARCH_CLASS);
     return fmt::format(logicOperator.at(stringOperator), clsUpper, prpUpper, prpLower, value);
 }
 
@@ -519,8 +519,8 @@ std::string DefaultSQLEmitter::emit(const ASTExistsOperator* node, const std::st
     } else {
         throw_std_runtime_error("Invalid value '{}' on rhs of 'exists' operator", value);
     }
-    auto&& [prpUpper, prpLower] = getPropertyStatement(property);
-    auto&& [clsUpper, clsLower] = getPropertyStatement(UPNP_SEARCH_CLASS);
+    auto [prpUpper, prpLower] = getPropertyStatement(property);
+    auto [clsUpper, clsLower] = getPropertyStatement(UPNP_SEARCH_CLASS);
     return fmt::format(logicOperator.at((property[0] == '@') ? "@exists" : "exists"), clsUpper, prpUpper, prpLower, exists);
 }
 

--- a/src/web/directories.cc
+++ b/src/web/directories.cc
@@ -87,7 +87,7 @@ void web::directories::process()
                 || (exclude_config_dirs && startswith(filepath.filename().string(), ".")))
                 continue; // skip dir with leading .
         }
-        auto&& dir = fs::directory_iterator(filepath, ec);
+        auto dir = fs::directory_iterator(filepath, ec);
         bool hasContent = std::any_of(begin(dir), end(dir), [&](auto&& sub) { return sub.is_directory(ec) || isRegularFile(sub, ec); });
 
         /// \todo replace hexEncode with base64_encode?
@@ -97,7 +97,7 @@ void web::directories::process()
 
     auto f2i = StringConverter::f2i(config);
     for (auto&& [key, val] : filesMap) {
-        auto&& [file, has] = val;
+        auto [file, has] = val;
         auto ce = containers.append_child("container");
         ce.append_attribute("id") = key.c_str();
         ce.append_attribute("child_count") = has;


### PR DESCRIPTION
Confusingly, auto&& does not work here. The members are always created
as values.

Signed-off-by: Rosen Penev <rosenp@gmail.com>