### PR TITLE
use const auto&

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -226,7 +226,7 @@ void MatroskaHandler::parseAttachments(const std::shared_ptr<CdsItem>& item, Ebm
         log_debug("KaxFileName = {}", fileName);
 
         if (startswith(fileName, "cover")) {
-            auto&& fileData = GetChild<LIBMATROSKA_NAMESPACE::KaxFileData>(*attachedFile);
+            const auto& fileData = GetChild<LIBMATROSKA_NAMESPACE::KaxFileData>(*attachedFile);
             log_debug("KaxFileData (size={})", fileData.GetSize());
 
             if (p_io_handler) {


### PR DESCRIPTION
works around a clang-tidy bug.

Signed-off-by: Rosen Penev <rosenp@gmail.com>