### PR TITLE
Conan: Require CMake >=3.18

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -39,6 +39,7 @@ class GerberaConan(ConanFile):
     scm = {"type": "git", "url": "auto", "revision": "auto"}
 
     requires = [
+        "cmake/[>=3.18.0]",
         "fmt/7.1.3",
         "spdlog/1.8.5",
         "pugixml/1.10",


### PR DESCRIPTION
We rely on the abiity to create ALIAS for non global imported targets

Fixes: #1420
