### PR TITLE
convert shared_ptr to const ref

### DIFF
--- a/src/database/database.h
+++ b/src/database/database.h
@@ -71,9 +71,9 @@ protected:
     int totalMatches {};
 
 public:
-    BrowseParam(std::shared_ptr<CdsObject> object, unsigned int flags)
+    BrowseParam(const std::shared_ptr<CdsObject>& object, unsigned int flags)
         : flags(flags)
-        , object(std::move(object))
+        , object(object)
     {
     }
 


### PR DESCRIPTION
Fixes some weird -fanalyzer warning.

Signed-off-by: Rosen Penev <rosenp@gmail.com>