### PR TITLE
don't allocate empty pugixml pointers

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -69,19 +69,19 @@ const std::unique_ptr<Quirks>& ActionRequest::getQuirks() const
 
 std::unique_ptr<pugi::xml_document> ActionRequest::getRequest() const
 {
-    auto request = std::make_unique<pugi::xml_document>();
+    pugi::xml_document request;
 #if defined(USING_NPUPNP)
-    auto ret = request->load_string(upnp_request->xmlAction.c_str());
+    auto ret = request.load_string(upnp_request->xmlAction.c_str());
 #else
     DOMString cxml = ixmlPrintDocument(UpnpActionRequest_get_ActionRequest(upnp_request));
-    auto ret = request->load_string(cxml);
+    auto ret = request.load_string(cxml);
     ixmlFreeDOMString(cxml);
 #endif
 
     if (ret.status != pugi::xml_parse_status::status_ok)
         throw_std_runtime_error("Unable to parse ixml");
 
-    return request;
+    return std::make_unique<pugi::xml_document>(std::move(request));
 }
 
 void ActionRequest::setResponse(std::unique_ptr<pugi::xml_document> response)

--- a/src/content/onlineservice/curl_online_service.cc
+++ b/src/content/onlineservice/curl_online_service.cc
@@ -81,14 +81,14 @@ std::unique_ptr<pugi::xml_document> CurlOnlineService::getData()
         return nullptr;
 
     log_debug("GOT BUFFER{}", buffer.c_str());
-    auto doc = std::make_unique<pugi::xml_document>();
-    pugi::xml_parse_result result = doc->load_string(sc->convert(buffer).c_str());
+    pugi::xml_document doc;
+    auto result = doc.load_string(sc->convert(buffer).c_str());
     if (result.status != pugi::xml_parse_status::status_ok) {
         log_error("Error parsing {} XML: {}", serviceName, result.description());
         return nullptr;
     }
 
-    return doc;
+    return std::make_unique<pugi::xml_document>(std::move(doc));
 }
 
 bool CurlOnlineService::refreshServiceData(const std::shared_ptr<Layout>& layout)


### PR DESCRIPTION
Fixes multiple fanalyzer warnings, even unrelated ones.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

Setting as draft, Last time I tried this it failed with Ubuntu.