### PR TITLE
Revert "use targets for libmatroska and libebml"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,9 +524,14 @@ endif()
 
 if(WITH_MATROSKA)
     find_package(EBML REQUIRED)
-    target_link_libraries(libgerbera PUBLIC EBML::ebml)
+
+    target_include_directories(libgerbera PUBLIC ${EBML_INCLUDE_DIRS})
+    target_link_libraries(libgerbera PUBLIC ${EBML_LIBRARIES})
+
     find_package(Matroska REQUIRED)
-    target_link_libraries(libgerbera PUBLIC Matroska::matroska)
+    target_include_directories(libgerbera PUBLIC ${Matroska_INCLUDE_DIRS})
+    target_link_libraries(libgerbera PUBLIC ${Matroska_LIBRARIES})
+
     target_compile_definitions(libgerbera PUBLIC HAVE_MATROSKA)
 endif()
 

--- a/cmake/FindEBML.cmake
+++ b/cmake/FindEBML.cmake
@@ -1,0 +1,30 @@
+# - Try to find libebml
+# Once done this will define
+#
+#  EBML_FOUND - system has libebml
+#  EBML_INCLUDE_DIRS - the libebml include directory
+#  EBML_LIBRARIES - Link these to use EBML
+#
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig QUIET)
+
+# EBML
+pkg_search_module(PC_EBML QUIET libebml)
+find_path(EBML_INCLUDE_DIR EbmlVersion.h
+        HINTS ${PC_EBML_INCLUDEDIR}
+        PATH_SUFFIXES ebml)
+FIND_LIBRARY(EBML_LIBRARY ebml
+        HINTS ${PC_EBML_LIBDIR})
+
+find_package_handle_standard_args(EBML DEFAULT_MSG
+        EBML_LIBRARY EBML_INCLUDE_DIR)
+if (EBML_FOUND)
+    set(EBML_LIBRARIES ${EBML_LIBRARY})
+    set(EBML_INCLUDE_DIRS ${EBML_INCLUDE_DIR})
+endif ()
+MARK_AS_ADVANCED(
+        EBML_INCLUDE_DIR
+        EBML_LIBRARY
+)

--- a/cmake/FindMatroska.cmake
+++ b/cmake/FindMatroska.cmake
@@ -1,0 +1,31 @@
+# - Try to find libMatroska
+# Once done this will define
+#
+#  Matroska_FOUND - system has libMatroska
+#  Matroska_INCLUDE_DIRS - the libMatroska include directory
+#  Matroska_LIBRARIES - Link these to use Matroska
+#
+
+INCLUDE(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig QUIET)
+
+# Matroska
+pkg_search_module(PC_MAT QUIET libmatroska)
+find_path(Matroska_INCLUDE_DIR KaxVersion.h
+        HINTS ${PC_MAT_INCLUDEDIR}
+        PATH_SUFFIXES matroska)
+find_library(Matroska_LIBRARY matroska
+        HINTS ${PC_MAT_LIBDIR})
+
+find_package_handle_standard_args(Matroska DEFAULT_MSG
+        Matroska_LIBRARY Matroska_INCLUDE_DIR)
+if (Matroska_FOUND)
+    set(Matroska_LIBRARIES ${Matroska_LIBRARY})
+    set(Matroska_INCLUDE_DIRS ${Matroska_INCLUDE_DIR})
+endif ()
+MARK_AS_ADVANCED(
+        Matroska_INCLUDE_DIR
+        Matroska_LIBRARY
+)
+


### PR DESCRIPTION
Reverts gerbera/gerbera#1861

Breaks build with older distos (e.g. Ubuntu 16.04 & 18.04) as no CMake config is provided in their versions of the package.