### PR TITLE
Use metadata title in search results if present

### DIFF
--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1388,8 +1388,13 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
     obj->setClass(getCol(row, SearchCol::upnp_class));
 
     auto meta = retrieveMetadataForObject(obj->getID());
-    if (!meta.empty())
+    if (!meta.empty()) {
         obj->setMetadata(meta);
+
+        // Update tile from metadata if present
+        if (meta.count(MetadataHandler::getMetaFieldName(M_TITLE)))
+            obj->setTitle(meta.at(MetadataHandler::getMetaFieldName(M_TITLE)));
+    }
 
     auto resources = retrieveResourcesForObject(obj->getID());
     if (!resources.empty()) {

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1392,7 +1392,7 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
         obj->setMetadata(meta);
 
         // Update tile from metadata if present
-        if (meta.count(MetadataHandler::getMetaFieldName(M_TITLE)))
+        if (meta.find(MetadataHandler::getMetaFieldName(M_TITLE)) != meta.end())
             obj->setTitle(meta.at(MetadataHandler::getMetaFieldName(M_TITLE)));
     }
 


### PR DESCRIPTION
Use metadata title in search results (if present) instead of the raw `dc_title` field. Closes #1867  