### PR TITLE
Remove unique_ptr objects where stack memory is sufficient

### DIFF
--- a/src/database/database.h
+++ b/src/database/database.h
@@ -191,8 +191,8 @@ public:
 
     virtual void updateObject(const std::shared_ptr<CdsObject>& object, int* changedContainer) = 0;
 
-    virtual std::vector<std::shared_ptr<CdsObject>> browse(const std::unique_ptr<BrowseParam>& param) = 0;
-    virtual std::vector<std::shared_ptr<CdsObject>> search(std::unique_ptr<SearchParam> param, int* numMatches) = 0;
+    virtual std::vector<std::shared_ptr<CdsObject>> browse(BrowseParam& param) = 0;
+    virtual std::vector<std::shared_ptr<CdsObject>> search(const SearchParam& param, int* numMatches) = 0;
 
     virtual std::vector<std::string> getMimeTypes() = 0;
 

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -131,8 +131,8 @@ public:
     /* accounting methods */
     int getTotalFiles(bool isVirtual = false, const std::string& mimeType = "", const std::string& upnpClass = "") override;
 
-    std::vector<std::shared_ptr<CdsObject>> browse(const std::unique_ptr<BrowseParam>& param) override;
-    std::vector<std::shared_ptr<CdsObject>> search(std::unique_ptr<SearchParam> param, int* numMatches) override;
+    std::vector<std::shared_ptr<CdsObject>> browse(BrowseParam& param) override;
+    std::vector<std::shared_ptr<CdsObject>> search(const SearchParam& param, int* numMatches) override;
 
     std::vector<std::string> getMimeTypes() override;
 

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -44,9 +44,9 @@
 static void setJpegResolutionResource(const std::shared_ptr<CdsItem>& item, size_t res_num)
 {
     try {
-        auto fio_h = std::unique_ptr<IOHandler>(std::make_unique<FileIOHandler>(item->getLocation()));
+        auto fio_h = std::make_unique<FileIOHandler>(item->getLocation());
         fio_h->open(UPNP_READ);
-        std::string resolution = get_jpeg_resolution(fio_h);
+        const std::string resolution = get_jpeg_resolution(std::move(fio_h));
 
         if (res_num >= item->getResourceCount())
             throw_std_runtime_error("Invalid resource index");
@@ -266,10 +266,10 @@ void LibExifHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
 
     if (ed->size) {
         try {
-            auto io_h = std::unique_ptr<IOHandler>(std::make_unique<MemIOHandler>(ed->data, ed->size));
+            auto io_h = std::make_unique<MemIOHandler>(ed->data, ed->size);
             io_h->open(UPNP_READ);
-            auto&& th_resolution = get_jpeg_resolution(io_h);
-            log_debug("RESOLUTION: {}", th_resolution.c_str());
+            const std::string th_resolution = get_jpeg_resolution(std::move(io_h));
+            log_debug("RESOLUTION: {}", th_resolution);
 
             auto resource = std::make_shared<CdsResource>(CH_LIBEXIF);
             resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(item->getMimeType()));

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -91,11 +91,11 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     if (config->getBoolOption(CFG_SERVER_HIDE_PC_DIRECTORY))
         flag |= BROWSE_HIDE_FS_ROOT;
 
-    auto param = std::make_unique<BrowseParam>(parent, flag);
+    auto param = BrowseParam(parent, flag);
 
-    param->setStartingIndex(stoiString(startingIndex));
-    param->setRequestedCount(stoiString(requestedCount));
-    param->setSortCriteria(trimString(sortCriteria));
+    param.setStartingIndex(stoiString(startingIndex));
+    param.setRequestedCount(stoiString(requestedCount));
+    param.setSortCriteria(trimString(sortCriteria));
 
     std::vector<std::shared_ptr<CdsObject>> arr;
     try {
@@ -136,7 +136,7 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     auto resp_root = response->document_element();
     resp_root.append_child("Result").append_child(pugi::node_pcdata).set_value(didl_lite_xml.c_str());
     resp_root.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(arr.size()).c_str());
-    resp_root.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(param->getTotalMatches()).c_str());
+    resp_root.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(param.getTotalMatches()).c_str());
     resp_root.append_child("UpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     request->setResponse(std::move(response));
 
@@ -173,13 +173,13 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     didl_lite_root.append_attribute(UPNP_XML_UPNP_NAMESPACE_ATTR) = UPNP_XML_UPNP_NAMESPACE;
     didl_lite_root.append_attribute(UPNP_XML_SEC_NAMESPACE_ATTR) = UPNP_XML_SEC_NAMESPACE;
 
-    auto searchParam = std::make_unique<SearchParam>(containerID, searchCriteria, sortCriteria,
+    const auto searchParam = SearchParam(containerID, searchCriteria, sortCriteria,
         stoiString(startingIndex), stoiString(requestedCount));
 
     std::vector<std::shared_ptr<CdsObject>> results;
     int numMatches = 0;
     try {
-        results = database->search(std::move(searchParam), &numMatches);
+        results = database->search(searchParam, &numMatches);
         log_debug("Found {}/{} items", results.size(), numMatches);
     } catch (const std::runtime_error& e) {
         log_debug(e.what());

--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -85,9 +85,7 @@ static int ioh_fgetc(const std::unique_ptr<IOHandler>& ioh)
 
 static void get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh, int* w, int* h)
 {
-    int a;
-
-    a = ioh_fgetc(ioh);
+    int a = ioh_fgetc(ioh);
 
     if (a != 0xff || ioh_fgetc(ioh) != M_SOI)
         throw_std_runtime_error("get_jpeg_resolution: could not read jpeg specs");
@@ -162,7 +160,7 @@ static void get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh, int* w, i
 }
 
 // IOHandler must be opened
-std::string get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh)
+std::string get_jpeg_resolution(std::unique_ptr<IOHandler>&& ioh)
 {
     int w, h;
     try {

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -198,7 +198,8 @@ std::string millisecondsToHMSF(int milliseconds);
 int HMSFToMilliseconds(std::string_view time);
 
 /// \brief Extracts resolution from a JPEG image
-std::string get_jpeg_resolution(const std::unique_ptr<IOHandler>& ioh);
+/// \param ioh the IOHandler must be opened. The function will read data and close the handler.
+std::string get_jpeg_resolution(std::unique_ptr<IOHandler>&& ioh);
 
 /// \brief checks if the given string has the format xr x yr (i.e. 320x200 etc.)
 bool checkResolution(std::string_view resolution, int* x = nullptr, int* y = nullptr);

--- a/src/web/containers.cc
+++ b/src/web/containers.cc
@@ -62,8 +62,8 @@ void Web::Containers::process()
     if (!param("select_it").empty())
         containers.append_attribute("select_it") = param("select_it").c_str();
 
-    auto parent = database->loadObject(parentID);
-    auto arr = database->browse(std::make_unique<BrowseParam>(parent, BROWSE_DIRECT_CHILDREN | BROWSE_CONTAINERS));
+    auto browseParam = BrowseParam(database->loadObject(parentID), BROWSE_DIRECT_CHILDREN | BROWSE_CONTAINERS);
+    auto arr = database->browse(browseParam);
     for (auto&& obj : arr) {
         //if (obj->isContainer())
         //{

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -64,19 +64,19 @@ void Web::Items::process()
     items.append_attribute("parent_id") = parentID;
 
     auto container = database->loadObject(parentID);
-    auto param = std::make_unique<BrowseParam>(container, BROWSE_DIRECT_CHILDREN | BROWSE_ITEMS);
-    param->setRange(start, count);
+    auto param = BrowseParam(container, BROWSE_DIRECT_CHILDREN | BROWSE_ITEMS);
+    param.setRange(start, count);
 
     auto c = container->getClass();
     if (c == UPNP_CLASS_MUSIC_ALBUM || c == UPNP_CLASS_PLAYLIST_CONTAINER)
-        param->setFlag(BROWSE_TRACK_SORT);
+        param.setFlag(BROWSE_TRACK_SORT);
 
     // get contents of request
     auto arr = database->browse(param);
     items.append_attribute("virtual") = container->isVirtual();
     items.append_attribute("start") = start;
     //items.append_attribute("returned") = arr->size();
-    items.append_attribute("total_matches") = param->getTotalMatches();
+    items.append_attribute("total_matches") = param.getTotalMatches();
 
     bool protectContainer = false;
     bool protectItems = false;

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -26,8 +26,8 @@ public:
 
     void updateObject(const std::shared_ptr<CdsObject>& object, int* changedContainer) override { }
 
-    std::vector<std::shared_ptr<CdsObject>> browse(const std::unique_ptr<BrowseParam>& param) override { return {}; }
-    std::vector<std::shared_ptr<CdsObject>> search(std::unique_ptr<SearchParam> param, int* numMatches) override { return {}; }
+    std::vector<std::shared_ptr<CdsObject>> browse(BrowseParam& param) override { return {}; }
+    std::vector<std::shared_ptr<CdsObject>> search(const SearchParam& param, int* numMatches) override { return {}; }
 
     std::vector<std::string> getMimeTypes() override { return {}; }
     std::shared_ptr<CdsObject> findObjectByPath(const fs::path& path, bool wasRegularFile = false) override { return nullptr; }


### PR DESCRIPTION
The parameters to browse/search look odd when a unique_ptr needs to be passed to them. Since both parameter objects are rather small in memory footprint and there is no obvious advantage for dynamic allocation, simply allocate the parameters objects on the caller stack. This increases performance and makes the code more readable.