### PR TITLE
don't assign nullptr to std::string

### DIFF
--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -242,10 +242,11 @@ bool isExecutable(const fs::path& path, int* err)
 
 fs::path findInPath(const fs::path& exec)
 {
-    std::string PATH = getenv("PATH");
-    if (PATH.empty())
+    auto p = getenv("PATH");
+    if (!p)
         return {};
 
+    std::string PATH = p;
     std::error_code ec;
     auto pathAr = splitString(PATH, ':');
     for (auto&& path : pathAr) {


### PR DESCRIPTION
Basic godbolt test shows that assigning to nullptr calls
std::__throw_logic_error

Signed-off-by: Rosen Penev <rosenp@gmail.com>