### PR TITLE
don't pass string_view by reference

### DIFF
--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -218,7 +218,7 @@ std::string MySQLDatabase::getError(MYSQL* db)
     return res;
 }
 
-void MySQLDatabaseWithTransactions::beginTransaction(const std::string_view& tName)
+void MySQLDatabaseWithTransactions::beginTransaction(std::string_view tName)
 {
     log_debug("START TRANSACTION {} {}", tName, inTransaction);
     StdThreadRunner::waitFor(
@@ -230,7 +230,7 @@ void MySQLDatabaseWithTransactions::beginTransaction(const std::string_view& tNa
         _exec("START TRANSACTION");
 }
 
-void MySQLDatabaseWithTransactions::rollback(const std::string_view& tName)
+void MySQLDatabaseWithTransactions::rollback(std::string_view tName)
 {
     log_debug("ROLLBACK {}", tName);
     if (use_transaction && inTransaction && mysql_rollback(&db)) {
@@ -240,7 +240,7 @@ void MySQLDatabaseWithTransactions::rollback(const std::string_view& tName)
     inTransaction = false;
 }
 
-void MySQLDatabaseWithTransactions::commit(const std::string_view& tName)
+void MySQLDatabaseWithTransactions::commit(std::string_view tName)
 {
     log_debug("COMMIT {}", tName);
     SqlAutoLock lock(sqlMutex);

--- a/src/database/mysql/mysql_database.h
+++ b/src/database/mysql/mysql_database.h
@@ -94,9 +94,9 @@ public:
         , MySQLDatabase(std::move(config), std::move(mime))
     {
     }
-    void beginTransaction(const std::string_view& tName) override;
-    void rollback(const std::string_view& tName) override;
-    void commit(const std::string_view& tName) override;
+    void beginTransaction(std::string_view tName) override;
+    void rollback(std::string_view tName) override;
+    void commit(std::string_view tName) override;
 
     std::shared_ptr<SQLResult> select(const std::string& query) override;
 };

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -107,9 +107,9 @@ public:
     virtual std::string quote(long long val) const = 0;
 
     // hooks for transactions
-    virtual void beginTransaction(const std::string_view& tName) { }
-    virtual void rollback(const std::string_view& tName) { }
-    virtual void commit(const std::string_view& tName) { }
+    virtual void beginTransaction(std::string_view tName) { }
+    virtual void rollback(std::string_view tName) { }
+    virtual void commit(std::string_view tName) { }
 
     virtual int exec(const std::string& query, bool getLastInsertId = false) = 0;
     virtual std::shared_ptr<SQLResult> select(const std::string& query) = 0;

--- a/src/database/sql_format.h
+++ b/src/database/sql_format.h
@@ -29,7 +29,7 @@
 #include <string_view>
 
 struct SQLIdentifier {
-    constexpr SQLIdentifier(const std::string_view& name, char quote_begin, char quote_end)
+    constexpr SQLIdentifier(std::string_view name, char quote_begin, char quote_end)
         : name(name)
         , quote_begin(quote_begin)
         , quote_end(quote_end)

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -189,7 +189,7 @@ std::string Sqlite3Database::getError(const std::string& query, const std::strin
     return fmt::format("SQLITE3: ({}, : {}) {}\nQuery: {}\nerror: {}", sqlite3_errcode(db), sqlite3_extended_errcode(db), sqlite3_errmsg(db), query.empty() ? "unknown" : query, error.empty() ? "unknown" : error);
 }
 
-void Sqlite3DatabaseWithTransactions::beginTransaction(const std::string_view& tName)
+void Sqlite3DatabaseWithTransactions::beginTransaction(std::string_view tName)
 {
     if (use_transaction) {
         log_debug("BEGIN TRANSACTION {} {}", tName, inTransaction);
@@ -201,7 +201,7 @@ void Sqlite3DatabaseWithTransactions::beginTransaction(const std::string_view& t
     }
 }
 
-void Sqlite3DatabaseWithTransactions::rollback(const std::string_view& tName)
+void Sqlite3DatabaseWithTransactions::rollback(std::string_view tName)
 {
     if (use_transaction && inTransaction) {
         log_debug("ROLLBACK {} {}", tName, inTransaction);
@@ -210,7 +210,7 @@ void Sqlite3DatabaseWithTransactions::rollback(const std::string_view& tName)
     }
 }
 
-void Sqlite3DatabaseWithTransactions::commit(const std::string_view& tName)
+void Sqlite3DatabaseWithTransactions::commit(std::string_view tName)
 {
     if (use_transaction && inTransaction) {
         log_debug("COMMIT {} {}", tName, inTransaction);

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -232,9 +232,9 @@ public:
         , Sqlite3Database(std::move(config), std::move(mime), std::move(timer))
     {
     }
-    void beginTransaction(const std::string_view& tName) override;
-    void rollback(const std::string_view& tName) override;
-    void commit(const std::string_view& tName) override;
+    void beginTransaction(std::string_view tName) override;
+    void rollback(std::string_view tName) override;
+    void commit(std::string_view tName) override;
 };
 
 /// \brief Represents a result of a sqlite3 select


### PR DESCRIPTION
It's cheap to copy.

Signed-off-by: Rosen Penev <rosenp@gmail.com>