### PR TITLE
remove last std::list

### DIFF
--- a/src/util/timer.cc
+++ b/src/util/timer.cc
@@ -143,7 +143,7 @@ void Timer::notify()
     auto lock = threadRunner->uniqueLock();
     assert(lock.owns_lock());
 
-    std::list<TimerSubscriberElement> toNotify;
+    std::deque<TimerSubscriberElement> toNotify;
 
     if (!subscribers.empty()) {
         for (auto it = subscribers.begin(); it != subscribers.end(); /*++it*/) {

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -34,7 +34,7 @@
 
 #include <algorithm>
 #include <atomic>
-#include <list>
+#include <deque>
 #include <memory>
 
 #include "common.h"
@@ -141,7 +141,7 @@ protected:
     };
 
     std::mutex waitMutex;
-    std::list<TimerSubscriberElement> subscribers;
+    std::deque<TimerSubscriberElement> subscribers;
     std::atomic_bool shutdownFlag {};
 
     void notify();


### PR DESCRIPTION
Removes compiler warnings on ARM regarding changed ABI.

Signed-off-by: Rosen Penev <rosenp@gmail.com>