### PR TITLE
Refactor database schema to remove unused indices

### DIFF
--- a/src/database/mysql/mysql-upgrade.xml
+++ b/src/database/mysql/mysql-upgrade.xml
@@ -76,4 +76,7 @@
         <script>CREATE INDEX `grb_cds_resource_id` ON `grb_cds_resource`(`item_id`,`res_id`)</script>
         <script migration="resources">ALTER TABLE `mt_cds_object` DROP COLUMN `resources`</script>
     </version>
+    <version number="14" remark="drop redundant index">
+        <script>DROP INDEX `grb_config_value_item` ON `grb_config_value`</script>
+    </version>
 </upgrade>

--- a/src/database/mysql/mysql.sql
+++ b/src/database/mysql/mysql.sql
@@ -82,7 +82,6 @@ CREATE TABLE `grb_config_value` (
   `item_value` varchar(255) NOT NULL,
   `status` varchar(20) NOT NULL)
   ENGINE=MyISAM CHARSET=utf8;
-CREATE INDEX grb_config_value_item ON grb_config_value(item);
 CREATE TABLE `grb_cds_resource` (
     `id` int(11) primary key auto_increment,
     `item_id` int(11) NOT NULL,

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -56,7 +56,7 @@ MySQLDatabase::MySQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mim
     table_quote_end = '`';
 
     // if mysql.sql or mysql-upgrade.xml is changed hashies have to be updated, index 0 is used for create script
-    hashies = { 3398516749, 928913698, 1984244483, 2241152998, 1748460509, 2860006966, 974692115, 70310290, 1863649106, 4238128129, 2979337694, 1512596496, 507706380 };
+    hashies = { 878627993, 928913698, 1984244483, 2241152998, 1748460509, 2860006966, 974692115, 70310290, 1863649106, 4238128129, 2979337694, 1512596496, 507706380, 3545156190 };
 }
 
 MySQLDatabase::~MySQLDatabase()

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1848,11 +1848,11 @@ std::string SQLDatabase::getInternalSetting(const std::string& key)
     auto res = select(fmt::format("SELECT {0} FROM {1} WHERE {2} = {3} LIMIT 1",
         identifier("value"), identifier(INTERNAL_SETTINGS_TABLE), identifier("key"), quote(key)));
     if (!res)
-        return "";
+        return {};
 
     auto row = res->nextRow();
     if (!row)
-        return "";
+        return {};
     return row->col(0);
 }
 

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -48,7 +48,7 @@ class CdsResource;
 class SQLResult;
 class SQLEmitter;
 
-#define DBVERSION 13
+#define DBVERSION 14
 
 #define CDS_OBJECT_TABLE "mt_cds_object"
 #define INTERNAL_SETTINGS_TABLE "mt_internal_setting"

--- a/src/database/sqlite3/sqlite3-upgrade.xml
+++ b/src/database/sqlite3/sqlite3-upgrade.xml
@@ -178,4 +178,7 @@
         VACUUM;
         </script>
     </version>
+    <version number="14" remark="drop redundant index">
+        <script>DROP INDEX grb_config_value_item;</script>
+    </version>
 </upgrade>

--- a/src/database/sqlite3/sqlite3.sql
+++ b/src/database/sqlite3/sqlite3.sql
@@ -82,5 +82,4 @@ CREATE INDEX mt_internal_setting_key ON mt_internal_setting(key);
 CREATE UNIQUE INDEX mt_autoscan_obj_id ON mt_autoscan(obj_id);
 CREATE INDEX mt_cds_object_service_id ON mt_cds_object(service_id);
 CREATE INDEX mt_metadata_item_id ON mt_metadata(item_id);
-CREATE INDEX grb_config_value_item ON grb_config_value(item);
 COMMIT;

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -49,7 +49,7 @@ Sqlite3Database::Sqlite3Database(std::shared_ptr<Config> config, std::shared_ptr
     table_quote_end = '"';
 
     // if sqlite3.sql or sqlite3-upgrade.xml is changed hashies have to be updated, index 0 is used for create script
-    hashies = { 3147846384, 778996897, 3362507034, 853149842, 4035419264, 3497064885, 974692115, 119767663, 3167732653, 2427825904, 3305506356, 43189396, 2767540493 };
+    hashies = { 3888119908, 778996897, 3362507034, 853149842, 4035419264, 3497064885, 974692115, 119767663, 3167732653, 2427825904, 3305506356, 43189396, 2767540493, 2512852146 };
 }
 
 void Sqlite3Database::prepare()


### PR DESCRIPTION
I found some sub-optimal database schema settings I want to fix in this PR.

- The index `grb_config_value_item` is redundant as it references only the primary key of `grb_config_value`. It can be removed without side-effects
```SQL
CREATE TABLE "grb_config_value" (
            "item" varchar(255) primary key,
            "key" varchar(255) NOT NULL,
            "item_value" varchar(255) NOT NULL,
            "status" varchar(20) NOT NULL)
CREATE INDEX grb_config_value_item ON grb_config_value(item)
```
