### PR TITLE
remove pointless size_t casts

### DIFF
--- a/src/server.cc
+++ b/src/server.cc
@@ -162,7 +162,7 @@ void Server::run()
     ret = UpnpRegisterRootDevice2(
         UPNPREG_BUF_DESC,
         deviceDescription.c_str(),
-        size_t(deviceDescription.length()) + 1,
+        deviceDescription.length() + 1,
         true,
         handleUpnpRootDeviceEventCallback,
         this,

--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -64,7 +64,7 @@ std::string StringConverter::convert(std::string str, bool validate)
             break;
 
         ret = ret + "?";
-        if ((stoppedAt + 1) < size_t(str.length()))
+        if ((stoppedAt + 1) < str.length())
             str = str.substr(stoppedAt + 1);
         else
             break;
@@ -112,7 +112,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
     const char** input_ptr = &input_copy;
     char** output_ptr = &output_copy;
 
-    auto input_bytes = size_t(str.length());
+    auto input_bytes = str.length();
     auto output_bytes = length;
 
     int ret;
@@ -149,7 +149,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
             }
 
             if (stoppedAt)
-                *stoppedAt = size_t(str.length()) - input_bytes;
+                *stoppedAt = str.length() - input_bytes;
             ret_str = std::string(output, output_copy - output);
             dirty = true;
             *output_copy = 0;


### PR DESCRIPTION
length is usually implemented as size_t anyway.

Signed-off-by: Rosen Penev <rosenp@gmail.com>