### PR TITLE
Use lambda in UpnpXMLBuilder::renderObject to trim strings

### DIFF
--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -153,7 +153,7 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
 
         for (auto&& [key, val] : meta) {
             // Trim metadata value as needed
-            const char* str = trimString(val).c_str();
+            auto str = trimString(val).c_str();
 
             if (key == MetadataHandler::getMetaFieldName(M_DESCRIPTION))
                 result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(str);

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -127,8 +127,8 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
     result.append_attribute("restricted") = obj->isRestricted() ? "1" : "0";
 
     auto trimString = [stringLimit](const std::string& s) {
-        // Do nothing if limit is negative, or string is already short enough
-        if (stringLimit < 0 || s.length() <= stringLimit)
+        // Do nothing if disabled, or string is already short enough
+        if (stringLimit == std::string::npos || s.length() <= stringLimit)
             return s;
 
         ssize_t cutPosition = getValidUTF8CutPosition(s, stringLimit - strlen("..."));

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -163,12 +163,11 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
                 addField(result, key, str);
         }
         
-        {
-            auto [url, artAdded] = renderItemImage(virtualURL, item);
-            if (artAdded) {
-                meta[MetadataHandler::getMetaFieldName(M_ALBUMARTURI)] = url;
-            }
+        auto [url, artAdded] = renderItemImage(virtualURL, item);
+        if (artAdded) {
+            meta[MetadataHandler::getMetaFieldName(M_ALBUMARTURI)] = url;
         }
+
         addPropertyList(result, meta, auxData, CFG_UPNP_TITLE_PROPERTIES, CFG_UPNP_TITLE_NAMESPACES);
         addResources(item, &result, quirks);
 

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -153,12 +153,12 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
 
         for (auto&& [key, val] : meta) {
             // Trim metadata value as needed
-            auto str = trimString(val).c_str();
+            auto str = trimString(val);
 
             if (key == MetadataHandler::getMetaFieldName(M_DESCRIPTION))
-                result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(str);
+                result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(str.c_str());
             else if ((upnp_class == UPNP_CLASS_MUSIC_TRACK) && key == MetadataHandler::getMetaFieldName(M_TRACKNUMBER))
-                result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(str);
+                result.append_child(key.c_str()).append_child(pugi::node_pcdata).set_value(str.c_str());
             else if (key != MetadataHandler::getMetaFieldName(M_TITLE))
                 addField(result, key, str);
         }

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -180,7 +180,6 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
         if (childCount >= 0)
             result.append_attribute("childCount") = childCount;
 
-        std::string upnp_class = obj->getClass();
         log_debug("container is class: {}", upnp_class.c_str());
         auto meta = obj->getMetadata();
         if (upnp_class == UPNP_CLASS_MUSIC_ALBUM) {

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -162,7 +162,7 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, size_t 
             else if (key != MetadataHandler::getMetaFieldName(M_TITLE))
                 addField(result, key, str);
         }
-        
+
         auto [url, artAdded] = renderItemImage(virtualURL, item);
         if (artAdded) {
             meta[MetadataHandler::getMetaFieldName(M_ALBUMARTURI)] = url;


### PR DESCRIPTION
Just a minor cleanup opportunity I noticed when digging into the search title issue.

- Use a lambda to perform string truncation when over `upnp-string-limit`. This unifies the behavior as one was checking for string::npos,and  the other was only looking for a negative value. According to the documentation "A negative value will disable this feature..." so I took this implementation as correct.
- Apply string truncation to all metadata values, instead of just title and description.
- Removed unnecessary brackets around album art