### PR TITLE
Add Composer Tag to Metacontent Handler

### DIFF
--- a/doc/config-import.rst
+++ b/doc/config-import.rst
@@ -663,6 +663,7 @@ You can set up your correct fanart file by yourself, if no image is embedded in 
         - ``%filename%``: Name of the file without extension or name of the container
         - ``%genre%``: Value of the genre tag
         - ``%title%``: Value of the title tag
+        - ``%composer%``: Value of the composer tag
 
 
 ``add-dir``

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -136,6 +136,7 @@ static constexpr auto metaTags = std::array {
     std::pair("%artist%", M_ARTIST),
     std::pair("%genre%", M_GENRE),
     std::pair("%title%", M_TITLE),
+    std::pair("%composer%", M_COMPOSER),
 };
 
 std::string ContentPathSetup::expandName(std::string_view name, const std::shared_ptr<CdsObject>& obj)


### PR DESCRIPTION
Added the `%composer%` pattern for resources. Should be useful for others looking to add composer artwork to their browsing experience.