### PR TITLE
Only count items with distinct IDs in TotalMatches search result.

### DIFF
--- a/src/database/search_handler.cc
+++ b/src/database/search_handler.cc
@@ -451,15 +451,15 @@ std::string DefaultSQLEmitter::emit(const ASTParenthesis* node, const std::strin
 //    2: property statement lower case
 //    3: value
 static const std::map<std::string, std::string> logicOperator {
-    { "contains", "({2} LIKE LOWER('%{3}%') AND {0} IS NOT NULL)" }, // lower
-    { "doesnotcontain", "({2} NOT LIKE LOWER('%{3}%') AND {0} IS NOT NULL)" }, // lower
-    { "startswith", "({2} LIKE LOWER('{3}%') AND {0} IS NOT NULL)" }, // lower
+    { "contains", "({2} LIKE LOWER('%{3}%'))" }, // lower
+    { "doesnotcontain", "({2} NOT LIKE LOWER('%{3}%'))" }, // lower
+    { "startswith", "({2} LIKE LOWER('{3}%'))" }, // lower
     { "derivedfrom", "(LOWER({0}) LIKE LOWER('{3}%'))" },
     //{ "derivedfrom", "{0} LIKE LOWER('{3}%')" },
-    { "exists", "({1} IS {3} AND {0} IS NOT NULL)" },
+    { "exists", "({1} IS {3})" },
     { "@exists", "({1} IS {3})" },
     { "newer", "({1} {3})" },
-    { "compare", "({2}LOWER('{3}') AND {0} IS NOT NULL)" }, // lower
+    { "compare", "({2}LOWER('{3}'))" }, // lower
     { "@compare", "({2}LOWER('{3}'))" }, // lower
 };
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -976,7 +976,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::search(const SearchParam& p
         throw_std_runtime_error("failed to generate SQL for search");
 
     beginTransaction("search");
-    auto countSQL = fmt::format("SELECT COUNT(*) FROM {} WHERE {}", sql_search_query, searchSQL);
+    auto countSQL = fmt::format("SELECT COUNT(DISTINCT {}) FROM {} WHERE {}", searchColumnMapper->mapQuoted(UPNP_SEARCH_ID), sql_search_query, searchSQL);
     log_debug("Search count resolves to SQL [{}]", countSQL);
     auto sqlResult = select(countSQL);
     commit("search");

--- a/test/core/test_searchhandler.cc
+++ b/test/core/test_searchhandler.cc
@@ -322,22 +322,22 @@ TEST(SearchParser, SimpleSearchCriteriaUsingEqualsOperator)
     // equalsOpExpr
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "dc:title=\"Hospital Roll Call\"",
-        "(_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call'))"));
 
     // equalsOpExpr
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "upnp:album=\"Scraps At Midnight\"",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight'))"));
 
     // equalsOpExpr or equalsOpExpr
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "upnp:album=\"Scraps At Midnight\" or dc:title=\"Hospital Roll Call\"",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call'))"));
 
     // equalsOpExpr or equalsOpExpr or equalsOpExpr
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "upnp:album=\"Scraps At Midnight\" or dc:title=\"Hospital Roll Call\" or upnp:artist=\"Deafheaven\"",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven'))"));
 }
 
 TEST(SearchParser, SearchCriteriaUsingEqualsOperatorParenthesesForSqlite)
@@ -347,37 +347,37 @@ TEST(SearchParser, SearchCriteriaUsingEqualsOperatorParenthesesForSqlite)
     // (equalsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "(upnp:album=\"Scraps At Midnight\")",
-        "((_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL))"));
+        "((_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')))"));
 
     // (equalsOpExpr or equalsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "(upnp:album=\"Scraps At Midnight\" or dc:title=\"Hospital Roll Call\")",
-        "((_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL))"));
+        "((_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call')))"));
 
     // (equalsOpExpr or equalsOpExpr) or equalsOpExpr
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "(upnp:album=\"Scraps At Midnight\" or dc:title=\"Hospital Roll Call\") or upnp:artist=\"Deafheaven\"",
-        "((_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL)) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven') AND _t_._upnp_class_ IS NOT NULL)"));
+        "((_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')) OR (_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call'))) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven'))"));
 
     // equalsOpExpr or (equalsOpExpr or equalsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "upnp:album=\"Scraps At Midnight\" or (dc:title=\"Hospital Roll Call\" or upnp:artist=\"Deafheaven\")",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL) OR ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven') AND _t_._upnp_class_ IS NOT NULL))"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')) OR ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven')))"));
 
     // equalsOpExpr and (equalsOpExpr or equalsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "upnp:album=\"Scraps At Midnight\" and (dc:title=\"Hospital Roll Call\" or upnp:artist=\"Deafheaven\")",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven') AND _t_._upnp_class_ IS NOT NULL))"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven')))"));
 
     // equalsOpExpr and (equalsOpExpr or equalsOpExpr or equalsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "upnp:album=\"Scraps At Midnight\" and (dc:title=\"Hospital Roll Call\" or upnp:artist=\"Deafheaven\" or upnp:artist=\"Pavement\")",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight') AND _t_._upnp_class_ IS NOT NULL) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Pavement') AND _t_._upnp_class_ IS NOT NULL))"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Scraps At Midnight')) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Pavement')))"));
 
     // (equalsOpExpr or equalsOpExpr or equalsOpExpr) and equalsOpExpr and equalsOpExpr
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter,
         "(dc:title=\"Hospital Roll Call\" or upnp:artist=\"Deafheaven\" or upnp:artist=\"Pavement\") and upnp:album=\"Nevermind\" and upnp:album=\"Sunbather\"",
-        "((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Pavement') AND _t_._upnp_class_ IS NOT NULL)) AND (_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Nevermind') AND _t_._upnp_class_ IS NOT NULL) AND (_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Sunbather') AND _t_._upnp_class_ IS NOT NULL)"));
+        "((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_)=LOWER('Hospital Roll Call')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Deafheaven')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_)=LOWER('Pavement'))) AND (_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Nevermind')) AND (_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_)=LOWER('Sunbather'))"));
 }
 
 TEST(SearchParser, SearchCriteriaUsingContainsOperator)
@@ -385,11 +385,11 @@ TEST(SearchParser, SearchCriteriaUsingContainsOperator)
     auto columnMapper = std::make_shared<EnumColumnMapper<TestCol>>('_', '_', "t", "TestTable", testSortMap, testColMap);
     DefaultSQLEmitter sqlEmitter(columnMapper, columnMapper, columnMapper);
     // (containsOpExpr)
-    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album contains \"Midnight\"", "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('%Midnight%') AND _t_._upnp_class_ IS NOT NULL)"));
+    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album contains \"Midnight\"", "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('%Midnight%'))"));
 
     // (containsOpExpr or containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album contains \"Midnight\" OR upnp:artist contains \"HEAVE\"",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('%Midnight%') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_) LIKE LOWER('%HEAVE%') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('%Midnight%')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_) LIKE LOWER('%HEAVE%'))"));
 }
 
 TEST(SearchParser, SearchCriteriaUsingDoesNotContainOperator)
@@ -398,11 +398,11 @@ TEST(SearchParser, SearchCriteriaUsingDoesNotContainOperator)
     DefaultSQLEmitter sqlEmitter(columnMapper, columnMapper, columnMapper);
     // (containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album doesnotcontain \"Midnight\"",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) NOT LIKE LOWER('%Midnight%') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) NOT LIKE LOWER('%Midnight%'))"));
 
     // (containsOpExpr or containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album doesNotContain \"Midnight\" or upnp:artist doesnotcontain \"HEAVE\"",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) NOT LIKE LOWER('%Midnight%') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_) NOT LIKE LOWER('%HEAVE%') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) NOT LIKE LOWER('%Midnight%')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_) NOT LIKE LOWER('%HEAVE%'))"));
 }
 
 TEST(SearchParser, SearchCriteriaUsingStartsWithOperator)
@@ -410,11 +410,11 @@ TEST(SearchParser, SearchCriteriaUsingStartsWithOperator)
     auto columnMapper = std::make_shared<EnumColumnMapper<TestCol>>('_', '_', "t", "TestTable", testSortMap, testColMap);
     DefaultSQLEmitter sqlEmitter(columnMapper, columnMapper, columnMapper);
     // (containsOpExpr)
-    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album startswith \"Midnight\"", "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('Midnight%') AND _t_._upnp_class_ IS NOT NULL)"));
+    EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album startswith \"Midnight\"", "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('Midnight%'))"));
 
     // (containsOpExpr or containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album startsWith \"Midnight\" or upnp:artist startswith \"HEAVE\"",
-        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('Midnight%') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_) LIKE LOWER('HEAVE%') AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND LOWER(_t_._property_value_) LIKE LOWER('Midnight%')) OR (_t_._property_name_='upnp:artist' AND LOWER(_t_._property_value_) LIKE LOWER('HEAVE%'))"));
 }
 
 TEST(SearchParser, SearchCriteriaUsingExistsOperator)
@@ -423,11 +423,11 @@ TEST(SearchParser, SearchCriteriaUsingExistsOperator)
     DefaultSQLEmitter sqlEmitter(columnMapper, columnMapper, columnMapper);
     // (containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album exists true",
-        "(_t_._property_name_='upnp:album' AND _t_._property_value_ IS NOT NULL AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND _t_._property_value_ IS NOT NULL)"));
 
     // (containsOpExpr or containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:album exists true or upnp:artist exists false",
-        "(_t_._property_name_='upnp:album' AND _t_._property_value_ IS NOT NULL AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND _t_._property_value_ IS NULL AND _t_._upnp_class_ IS NOT NULL)"));
+        "(_t_._property_name_='upnp:album' AND _t_._property_value_ IS NOT NULL) OR (_t_._property_name_='upnp:artist' AND _t_._property_value_ IS NULL)"));
 }
 
 TEST(SearchParser, SearchCriteriaWithExtendsOperator)
@@ -440,11 +440,11 @@ TEST(SearchParser, SearchCriteriaWithExtendsOperator)
 
     // derivedfromOpExpr and (containsOpExpr or containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:class derivedfrom \"object.item.audioItem\" and (dc:title contains \"britain\" or dc:creator contains \"britain\"",
-        "(LOWER(_t_._upnp_class_) LIKE LOWER('object.item.audioItem%')) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='dc:creator' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%') AND _t_._upnp_class_ IS NOT NULL))"));
+        "(LOWER(_t_._upnp_class_) LIKE LOWER('object.item.audioItem%')) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%')) OR (_t_._property_name_='dc:creator' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%')))"));
 
     // derivedFromOpExpr and (containsOpExpr or containsOpExpr)
     EXPECT_TRUE(executeSearchParserTest(sqlEmitter, "upnp:class derivedFrom \"object.item.audioItem\" and (dc:title contains \"britain\" or dc:creator contains \"britain\"",
-        "(LOWER(_t_._upnp_class_) LIKE LOWER('object.item.audioItem%')) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%') AND _t_._upnp_class_ IS NOT NULL) OR (_t_._property_name_='dc:creator' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%') AND _t_._upnp_class_ IS NOT NULL))"));
+        "(LOWER(_t_._upnp_class_) LIKE LOWER('object.item.audioItem%')) AND ((_t_._property_name_='dc:title' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%')) OR (_t_._property_name_='dc:creator' AND LOWER(_t_._property_value_) LIKE LOWER('%britain%')))"));
 }
 
 TEST(SearchParser, SearchCriteriaWindowMedia)


### PR DESCRIPTION
When performing searches only count rows with distinct IDs for TotalMatches. Close #1852. This fixes the behavior of "Shuffle All" on Hi-Fi Cast and "Random tracks" on BubbleUpnp.

Additionally, eliminate the repeated ` AND "c"."upnp_class" IS NOT NULL`  conditions in the emitted SQL query. I am fairly certain these are redundant as any rows with NULL `upnp_class` will be excluded by the original `LOWER("c"."upnp_class") LIKE ...` condition.

For example. A search from foobar2000 had this WHERE condition
```sql
WHERE (LOWER("c"."upnp_class") LIKE LOWER('object.item.audioItem%')) AND
(
  (LOWER("c"."dc_title") LIKE LOWER('%bag%') AND "c"."upnp_class" IS NOT NULL) OR 
  ("m"."property_name"='upnp:genre' AND LOWER("m"."property_value") LIKE LOWER('%bag%') AND "c"."upnp_class" IS NOT NULL) OR 
  ("m"."property_name"='upnp:album' AND LOWER("m"."property_value") LIKE LOWER('%bag%') AND "c"."upnp_class" IS NOT NULL) OR 
  ("m"."property_name"='upnp:artist' AND LOWER("m"."property_value") LIKE LOWER('%bag%') AND "c"."upnp_class" IS NOT NULL)
)
```

which now has the following form
```sql
WHERE (LOWER("c"."upnp_class") LIKE LOWER('object.item.audioItem%')) AND 
(
  (LOWER("c"."dc_title") LIKE LOWER('%bag%')) OR 
  ("m"."property_name"='upnp:genre' AND LOWER("m"."property_value") LIKE LOWER('%bag%')) OR 
  ("m"."property_name"='upnp:album' AND LOWER("m"."property_value") LIKE LOWER('%bag%')) OR 
  ("m"."property_name"='upnp:artist' AND LOWER("m"."property_value") LIKE LOWER('%bag%'))
)
```