### PR TITLE
remove sort of redundant std::move

### DIFF
--- a/src/content/onlineservice/atrailers_content_handler.cc
+++ b/src/content/onlineservice/atrailers_content_handler.cc
@@ -215,7 +215,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
     item->setFlag(OBJECT_FLAG_ONLINE_SERVICE);
     try {
         item->validate();
-        return std::move(item);
+        return item;
     } catch (const std::runtime_error& ex) {
         log_warning("Failed to validate newly created Trailer item: {}",
             ex.what());

--- a/src/content/onlineservice/sopcast_content_handler.cc
+++ b/src/content/onlineservice/sopcast_content_handler.cc
@@ -194,7 +194,7 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& g
 
     try {
         item->validate();
-        return std::move(item);
+        return item;
     } catch (const std::runtime_error& ex) {
         log_warning("Failed to validate newly created SopCast item: {}",
             ex.what());

--- a/src/device_description_handler.cc
+++ b/src/device_description_handler.cc
@@ -52,7 +52,7 @@ std::unique_ptr<IOHandler> DeviceDescriptionHandler::open(const char* filename, 
 {
     log_debug("Device description requested");
 
-    auto t = std::make_unique<MemIOHandler>(deviceDescription);
-    t->open(mode);
-    return std::move(t);
+    auto io_handler = std::make_unique<MemIOHandler>(deviceDescription);
+    io_handler->open(mode);
+    return io_handler;
 }

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -277,5 +277,5 @@ std::unique_ptr<IOHandler> FileRequestHandler::open(const char* filename, enum U
     content->triggerPlayHook(obj);
 
     log_debug("end");
-    return std::move(io_handler);
+    return io_handler;
 }

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -302,8 +302,8 @@ std::unique_ptr<IOHandler> LibExifHandler::serveContent(const std::shared_ptr<Cd
     if (!(ed->size))
         throw_std_runtime_error("Resource {} has no exif thumbnail", resNum);
 
-    auto h = std::make_unique<MemIOHandler>(ed->data, ed->size);
+    auto io_handler = std::make_unique<MemIOHandler>(ed->data, ed->size);
     exif_data_unref(ed);
-    return std::move(h);
+    return io_handler;
 }
 #endif // HAVE_LIBEXIF

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -133,7 +133,7 @@ std::unique_ptr<IOHandler> MatroskaHandler::serveContent(const std::shared_ptr<C
     std::unique_ptr<MemIOHandler> io_handler;
     parseMKV(item, &io_handler);
 
-    return std::move(io_handler);
+    return io_handler;
 }
 
 void MatroskaHandler::parseMKV(const std::shared_ptr<CdsItem>& item, std::unique_ptr<MemIOHandler>* p_io_handler) const

--- a/src/serve_request_handler.cc
+++ b/src/serve_request_handler.cc
@@ -132,5 +132,5 @@ std::unique_ptr<IOHandler> ServeRequestHandler::open(const char* filename, enum 
 
     auto io_handler = std::make_unique<FileIOHandler>(path);
     io_handler->open(mode);
-    return std::move(io_handler);
+    return io_handler;
 }

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -157,7 +157,7 @@ std::unique_ptr<IOHandler> URLRequestHandler::open(const char* filename, enum Up
     auto io_handler = std::make_unique<CurlIOHandler>(config, url, nullptr, 1024 * 1024, 0);
     io_handler->open(mode);
     content->triggerPlayHook(obj);
-    return std::move(io_handler);
+    return io_handler;
 }
 
 #endif // HAVE_CURL

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -213,7 +213,7 @@ std::unique_ptr<IOHandler> WebRequestHandler::open(enum UpnpOpenFileMode mode)
 
     auto io_handler = std::make_unique<MemIOHandler>(output);
     io_handler->open(mode);
-    return std::move(io_handler);
+    return io_handler;
 }
 
 std::unique_ptr<IOHandler> WebRequestHandler::open(const char* filename, enum UpnpOpenFileMode mode)


### PR DESCRIPTION
If the return type matches the function, copy elision applies. In this
case, since the types don't match, the variables get copied. But because
unique_ptr has copy operations deleted, These types get moved.

This reintroduces the clang warning that this breaks under C++11 but
fixes GCC's -Wredundant-move one. The latter is probably more
applicable.

Signed-off-by: Rosen Penev <rosenp@gmail.com>