### PR TITLE
simplify init

### DIFF
--- a/src/config/config_generator.cc
+++ b/src/config/config_generator.cc
@@ -34,11 +34,7 @@
 
 std::shared_ptr<pugi::xml_node> ConfigGenerator::init()
 {
-    if (generated.find("") == generated.end()) {
-        auto config = doc.append_child("config");
-        generated[""] = std::make_shared<pugi::xml_node>(config);
-    }
-    return generated[""];
+    return generated[""] = std::make_shared<pugi::xml_node>(doc.append_child("config"));
 }
 
 std::shared_ptr<pugi::xml_node> ConfigGenerator::getNode(const std::string& tag) const


### PR DESCRIPTION
std::map's operator[] calls try_emplace by default. There's no need to
check if it exists.

Signed-off-by: Rosen Penev <rosenp@gmail.com>