### PR TITLE
clang-tidy: performance fixes

### DIFF
--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -256,7 +256,7 @@ void ContentManager::registerExecutor(std::shared_ptr<Executor> exec)
     process_list.push_back(std::move(exec));
 }
 
-void ContentManager::unregisterExecutor(std::shared_ptr<Executor> exec)
+void ContentManager::unregisterExecutor(const std::shared_ptr<Executor>& exec)
 {
     // when shutting down we will kill the transcoding processes,
     // which if given enough time will get a close in the io handler and
@@ -269,7 +269,7 @@ void ContentManager::unregisterExecutor(std::shared_ptr<Executor> exec)
 
     auto lock = threadRunner->lockGuard("unregisterExecutor");
 
-    process_list.erase(std::remove(process_list.begin(), process_list.end(), std::move(exec)), process_list.end());
+    process_list.erase(std::remove(process_list.begin(), process_list.end(), exec), process_list.end());
 }
 
 void ContentManager::timerNotify(std::shared_ptr<Timer::Parameter> parameter)

--- a/src/content/content_manager.h
+++ b/src/content/content_manager.h
@@ -297,7 +297,7 @@ public:
     /// When the the process io handler receives a close on a stream that is
     /// currently being processed by an external process, it will kill it.
     /// The handler will then remove the executor from the list.
-    void unregisterExecutor(std::shared_ptr<Executor> exec);
+    void unregisterExecutor(const std::shared_ptr<Executor>& exec);
 
     void triggerPlayHook(const std::shared_ptr<CdsObject>& obj);
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1132,7 +1132,7 @@ int SQLDatabase::ensurePathExistence(const fs::path& path, int* changedContainer
     return createContainer(parentID, f2i->convert(path.filename()), path, false, "", INVALID_OBJECT_ID, std::map<std::string, std::string>());
 }
 
-int SQLDatabase::createContainer(int parentID, std::string name, const std::string& virtualPath, bool isVirtual, const std::string& upnpClass, int refID, const std::map<std::string, std::string>& itemMetadata)
+int SQLDatabase::createContainer(int parentID, const std::string& name, const std::string& virtualPath, bool isVirtual, const std::string& upnpClass, int refID, const std::map<std::string, std::string>& itemMetadata)
 {
     // log_debug("Creating Container: parent: {}, name: {}, path {}, isVirt: {}, upnpClass: {}, refId: {}",
     // parentID, name.c_str(), path.c_str(), isVirtual, upnpClass.c_str(), refID);
@@ -1156,7 +1156,7 @@ int SQLDatabase::createContainer(int parentID, std::string name, const std::stri
         fmt::to_string(parentID),
         fmt::to_string(OBJECT_TYPE_CONTAINER),
         !upnpClass.empty() ? quote(upnpClass) : quote(UPNP_CLASS_CONTAINER),
-        quote(std::move(name)),
+        quote(name),
         quote(dbLocation),
         quote(stringHash(dbLocation)),
         (refID > 0) ? fmt::to_string(refID) : fmt::to_string(SQL_NULL),

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -279,7 +279,7 @@ private:
     static fs::path stripLocationPrefix(std::string_view dbLocation, char* prefix = nullptr);
 
     std::shared_ptr<CdsObject> checkRefID(const std::shared_ptr<CdsObject>& obj);
-    int createContainer(int parentID, std::string name, const std::string& virtualPath, bool isVirtual, const std::string& upnpClass, int refID, const std::map<std::string, std::string>& itemMetadata);
+    int createContainer(int parentID, const std::string& name, const std::string& virtualPath, bool isVirtual, const std::string& upnpClass, int refID, const std::map<std::string, std::string>& itemMetadata);
 
     std::string mapBool(bool val) const { return quote((val ? 1 : 0)); }
     static bool remapBool(const std::string& field) { return field == "1"; }

--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -98,7 +98,7 @@ void ProcessIOHandler::unregisterAll()
     for (auto&& i : procList) {
         auto exec = i->getExecutor();
         if (exec)
-            content->unregisterExecutor(std::move(exec));
+            content->unregisterExecutor(exec);
     }
 }
 


### PR DESCRIPTION
std::remove expects a reference, not a moved value.

Same with quote().

Signed-off-by: Rosen Penev <rosenp@gmail.com>