### PR TITLE
clang-tidy: remove redundant c_str

### DIFF
--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -170,7 +170,7 @@ void MySQLDatabase::init()
                     throw DatabaseException(myError, fmt::format("Mysql: error while creating db: {}", myError));
                 }
             }
-            _exec(fmt::format(MYSQL_SET_VERSION, DBVERSION).c_str());
+            _exec(fmt::format(MYSQL_SET_VERSION, DBVERSION));
         } else {
             log_warning("Wrong hash for create script {}: {} != {}", DBVERSION, myHash, hashies[0]);
             throw_std_runtime_error("Wrong hash for create script {}", DBVERSION);


### PR DESCRIPTION
Found with readability-redundant-string-cstr

Signed-off-by: Rosen Penev <rosenp@gmail.com>