### PR TITLE
Simplify AddUpdateTable vectors without shared_ptr

### DIFF
--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -734,7 +734,7 @@ void SQLDatabase::updateObject(const std::shared_ptr<CdsObject>& obj, int* chang
     }
 
     beginTransaction("updateObject");
-    for (const auto& addUpdateTable : data) {
+    for (auto&& addUpdateTable : data) {
         auto qb = [this, &obj, &addUpdateTable]() {
             Operation op = addUpdateTable.getOperation();
             switch (op) {

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -236,8 +236,8 @@ private:
             , operation(operation)
         {
         }
-        AddUpdateTable(const AddUpdateTable&) = delete;
         AddUpdateTable(AddUpdateTable&&) = default;
+        AddUpdateTable& operator=(AddUpdateTable&&) = default;
         [[nodiscard]] const std::string& getTableName() const noexcept { return tableName; }
         [[nodiscard]] const std::map<std::string, std::string>& getDict() const noexcept { return dict; }
         [[nodiscard]] Operation getOperation() const noexcept { return operation; }

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -236,6 +236,8 @@ private:
             , operation(operation)
         {
         }
+        AddUpdateTable(const AddUpdateTable&) = delete;
+        AddUpdateTable(AddUpdateTable&&) = default;
         [[nodiscard]] const std::string& getTableName() const noexcept { return tableName; }
         [[nodiscard]] const std::map<std::string, std::string>& getDict() const noexcept { return dict; }
         [[nodiscard]] Operation getOperation() const noexcept { return operation; }
@@ -245,17 +247,17 @@ private:
         std::map<std::string, std::string> dict;
         Operation operation;
     };
-    std::vector<std::shared_ptr<AddUpdateTable>> _addUpdateObject(const std::shared_ptr<CdsObject>& obj, Operation op, int* changedContainer);
+    std::vector<AddUpdateTable> _addUpdateObject(const std::shared_ptr<CdsObject>& obj, Operation op, int* changedContainer);
 
     void generateMetadataDBOperations(const std::shared_ptr<CdsObject>& obj, Operation op,
-        std::vector<std::shared_ptr<AddUpdateTable>>& operations);
+        std::vector<AddUpdateTable>& operations);
 
     void generateResourceDBOperations(const std::shared_ptr<CdsObject>& obj, Operation op,
-        std::vector<std::shared_ptr<AddUpdateTable>>& operations);
+        std::vector<AddUpdateTable>& operations);
 
-    std::string sqlForInsert(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<AddUpdateTable>& addUpdateTable) const;
-    std::string sqlForUpdate(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<AddUpdateTable>& addUpdateTable) const;
-    std::string sqlForDelete(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<AddUpdateTable>& addUpdateTable) const;
+    std::string sqlForInsert(const std::shared_ptr<CdsObject>& obj, const AddUpdateTable& addUpdateTable) const;
+    std::string sqlForUpdate(const std::shared_ptr<CdsObject>& obj, const AddUpdateTable& addUpdateTable) const;
+    std::string sqlForDelete(const std::shared_ptr<CdsObject>& obj, const AddUpdateTable& addUpdateTable) const;
 
     /* helper for removeObject(s) */
     void _removeObjects(const std::vector<int32_t>& objectIDs);


### PR DESCRIPTION
There is no benefit in using shared_ptr for AddUpdateTable objects. This PR simplifies the use of this helper which reduces the code size and removes access-indirections. Dynamically growing the vector of objects is ensured to only use std::move operations.