### PR TITLE
const ref conversion

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -325,10 +325,10 @@ public:
     }
 
     /// \brief Add resource tag
-    void addResource(std::shared_ptr<CdsResource> resource)
+    void addResource(const std::shared_ptr<CdsResource>& resource)
     {
         resource->setResId(resources.size());
-        resources.push_back(move(resource));
+        resources.push_back(resource);
     }
 
     /// \brief Copies all object properties to another object.

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -616,7 +616,7 @@ std::shared_ptr<CdsObject> Script::dukObject2cdsObject(const std::shared_ptr<Cds
                 auto resource = std::make_shared<CdsResource>(CH_DEFAULT);
                 resource->addAttribute(R_PROTOCOLINFO, protocolInfo);
 
-                item->addResource(move(resource));
+                item->addResource(resource);
             }
         }
     }

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -942,7 +942,7 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::browse(BrowseParam& param)
                             resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(mimeType));
                             resource->addAttribute(R_RESOURCE_FILE, image);
                             resource->addParameter(RESOURCE_CONTENT_TYPE, ID3_ALBUM_ART);
-                            dynFolder->addResource(std::move(resource));
+                            dynFolder->addResource(resource);
                         }
                         dynamicContainers.emplace(dynId, std::move(dynFolder));
                     }

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -275,7 +275,7 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
             x = config->getIntOption(CFG_SERVER_EXTOPTS_FFMPEGTHUMBNAILER_THUMBSIZE);
             std::string resolution = fmt::format("{}x{}", x, y);
             ffres->addAttribute(R_RESOLUTION, resolution);
-            item->addResource(move(ffres));
+            item->addResource(ffres);
             log_debug("Adding resource for video thumbnail");
         }
     }

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -275,7 +275,7 @@ void LibExifHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
             resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(item->getMimeType()));
             resource->addAttribute(R_RESOLUTION, th_resolution);
             resource->addParameter(RESOURCE_CONTENT_TYPE, EXIF_THUMBNAIL);
-            item->addResource(move(resource));
+            item->addResource(resource);
         } catch (const std::runtime_error& e) {
             log_error("Something bad happened! {}", e.what());
         }

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -264,7 +264,7 @@ void MatroskaHandler::addArtworkResource(const std::shared_ptr<CdsItem>& item, c
         auto resource = std::make_shared<CdsResource>(CH_MATROSKA);
         resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(art_mimetype));
         resource->addParameter(RESOURCE_CONTENT_TYPE, ID3_ALBUM_ART);
-        item->addResource(move(resource));
+        item->addResource(resource);
     }
 }
 

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -187,7 +187,7 @@ void FanArtHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
             resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(mimeType));
             resource->addAttribute(R_RESOURCE_FILE, path.string());
             resource->addParameter(RESOURCE_CONTENT_TYPE, ID3_ALBUM_ART);
-            obj->addResource(move(resource));
+            obj->addResource(resource);
         }
     }
 }
@@ -238,7 +238,7 @@ void ContainerArtHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
             resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(mimeType));
             resource->addAttribute(R_RESOURCE_FILE, path.string());
             resource->addParameter(RESOURCE_CONTENT_TYPE, ID3_ALBUM_ART);
-            obj->addResource(move(resource));
+            obj->addResource(resource);
         }
     }
 }
@@ -296,7 +296,7 @@ void SubtitleHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
             resource->addAttribute(R_LANGUAGE, path.stem().string()); // assume file name is related to some language
             resource->addParameter(RESOURCE_CONTENT_TYPE, VIDEO_SUB);
             resource->addParameter("type", type);
-            obj->addResource(move(resource));
+            obj->addResource(resource);
         }
     }
 }
@@ -341,7 +341,7 @@ void ResourceHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
             auto resource = std::make_shared<CdsResource>(CH_RESOURCE);
             resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo("res"));
             resource->addAttribute(R_RESOURCE_FILE, path.string());
-            obj->addResource(move(resource));
+            obj->addResource(resource);
         }
     }
 }

--- a/src/metadata/metadata_handler.cc
+++ b/src/metadata/metadata_handler.cc
@@ -78,7 +78,7 @@ void MetadataHandler::setMetadata(const std::shared_ptr<Context>& context, const
     resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(mimetype));
     resource->addAttribute(R_SIZE, fmt::to_string(filesize));
 
-    item->addResource(move(resource));
+    item->addResource(resource);
 
     auto mappings = context->getConfig()->getDictionaryOption(CFG_IMPORT_MAPPINGS_MIMETYPE_TO_CONTENTTYPE_LIST);
     std::string content_type = getValueOrDefault(mappings, mimetype);

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -290,7 +290,7 @@ void TagLibHandler::addArtworkResource(const std::shared_ptr<CdsItem>& item, con
         auto resource = std::make_shared<CdsResource>(CH_ID3);
         resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(art_mimetype));
         resource->addParameter(RESOURCE_CONTENT_TYPE, ID3_ALBUM_ART);
-        item->addResource(move(resource));
+        item->addResource(resource);
     }
 }
 

--- a/src/web/add_object.cc
+++ b/src/web/add_object.cc
@@ -104,7 +104,7 @@ std::shared_ptr<CdsObject> Web::AddObject::addUrl(int parentID, const std::share
 
     auto resource = std::make_shared<CdsResource>(CH_DEFAULT);
     resource->addAttribute(R_PROTOCOLINFO, protocolInfo);
-    item->addResource(move(resource));
+    item->addResource(resource);
 
     return item;
 }


### PR DESCRIPTION
This can't be converted to an rvalue ref to force moves, so make it a
normal ref.

Signed-off-by: Rosen Penev <rosenp@gmail.com>