### PR TITLE
Unify simple SQL queries

### DIFF
--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1186,14 +1186,14 @@ int SQLDatabase::createContainer(int parentID, const std::string& name, const st
     return newId;
 }
 
-int SQLDatabase::insert(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId)
+int SQLDatabase::insert(std::string_view tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId)
 {
     assert(fields.size() == values.size());
     auto sql = fmt::format("INSERT INTO {} ({}) VALUES ({})", identifier(tableName), fmt::join(fields, ","), fmt::join(values, ","));
     return exec(sql, getLastInsertId);
 }
 
-void SQLDatabase::insertMultipleRows(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets)
+void SQLDatabase::insertMultipleRows(std::string_view tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets)
 {
     if (valuesets.size() == 1) {
         insert(tableName, fields, valuesets.front());
@@ -1209,18 +1209,12 @@ void SQLDatabase::insertMultipleRows(const std::string_view& tableName, const st
     }
 }
 
-void SQLDatabase::deleteAll(const std::string_view& tableName)
+void SQLDatabase::deleteAll(std::string_view tableName)
 {
     exec(fmt::format("DELETE FROM {}", identifier(tableName)));
 }
 
-template <typename T>
-void SQLDatabase::deleteRow(const std::string_view& tableName, const std::string_view& key, const T& value)
-{
-    exec(fmt::format("DELETE FROM {} WHERE {} = {}", identifier(tableName), identifier(key), quote(value)));
-}
-
-void SQLDatabase::deleteRows(const std::string_view& tableName, const std::string_view& key, const std::vector<int>& values)
+void SQLDatabase::deleteRows(std::string_view tableName, std::string_view key, const std::vector<int>& values)
 {
     exec(fmt::format("DELETE FROM {} WHERE {} IN ({})", identifier(tableName), identifier(key), fmt::join(values, ",")));
 }

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -179,8 +179,12 @@ public:
 protected:
     explicit SQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime);
     void init() override;
-    int insert(const char* tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
-    void insertMultipleRows(const char* tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets);
+    int insert(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
+    void insertMultipleRows(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets);
+    void deleteAll(const std::string_view& tableName);
+    template <typename T>
+    void deleteRow(const std::string_view& tableName, const std::string_view& where_key, const T& where_value);
+    void deleteRows(const std::string_view& tableName, const std::string_view& where_key, const std::vector<int>& where_values);
 
     /// \brief migrate metadata from mt_cds_objects to mt_metadata before removing the column (DBVERSION 12)
     bool doMetadataMigration();

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -176,15 +176,16 @@ public:
     void clearFlagInDB(int flag) override;
     unsigned int getHash(std::size_t index) const { return index < DBVERSION ? hashies[index] : 0; }
 
-protected:
-    explicit SQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime);
-    void init() override;
     int insert(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
     void insertMultipleRows(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets);
     void deleteAll(const std::string_view& tableName);
     template <typename T>
     void deleteRow(const std::string_view& tableName, const std::string_view& where_key, const T& where_value);
     void deleteRows(const std::string_view& tableName, const std::string_view& where_key, const std::vector<int>& where_values);
+
+protected:
+    explicit SQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime);
+    void init() override;
 
     /// \brief migrate metadata from mt_cds_objects to mt_metadata before removing the column (DBVERSION 12)
     bool doMetadataMigration();

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -176,12 +176,12 @@ public:
     void clearFlagInDB(int flag) override;
     unsigned int getHash(std::size_t index) const { return index < DBVERSION ? hashies[index] : 0; }
 
-    int insert(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
-    void insertMultipleRows(const std::string_view& tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets);
-    void deleteAll(const std::string_view& tableName);
+    int insert(std::string_view tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
+    void insertMultipleRows(std::string_view tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets);
+    void deleteAll(std::string_view tableName);
     template <typename T>
-    void deleteRow(const std::string_view& tableName, const std::string_view& where_key, const T& where_value);
-    void deleteRows(const std::string_view& tableName, const std::string_view& where_key, const std::vector<int>& where_values);
+    void deleteRow(std::string_view tableName, std::string_view where_key, const T& where_value);
+    void deleteRows(std::string_view tableName, std::string_view where_key, const std::vector<int>& where_values);
 
 protected:
     explicit SQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime);
@@ -301,6 +301,12 @@ private:
 
     using AutoLock = std::lock_guard<std::mutex>;
 };
+
+template <typename T>
+void SQLDatabase::deleteRow(std::string_view tableName, std::string_view key, const T& value)
+{
+    exec(fmt::format("DELETE FROM {} WHERE {} = {}", identifier(tableName), identifier(key), quote(value)));
+}
 
 class SqlWithTransactions {
 protected:

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -291,6 +291,7 @@ private:
 
     std::string mapBool(bool val) const { return quote((val ? 1 : 0)); }
     static bool remapBool(const std::string& field) { return field == "1"; }
+    static bool remapBool(int field) { return field == 1; }
 
     void setFsRootName(const std::string& rootName = "");
 

--- a/test/database/CMakeLists.txt
+++ b/test/database/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(testdb
     main.cc
     test_database.cc
+    test_sql_generators.cc
     mysql_config_fake.h
     sqlite_config_fake.h)
 

--- a/test/database/test_sql_generators.cc
+++ b/test/database/test_sql_generators.cc
@@ -1,0 +1,113 @@
+/*GRB*
+
+Gerbera - https://gerbera.io/
+
+    test_database.cc - this file is part of Gerbera.
+
+    Copyright (C) 2021 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file test_sql_generators.cc
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include "database/sql_database.h"
+
+using namespace ::testing;
+
+class TestDatabase : public SQLDatabase, public std::enable_shared_from_this<SQLDatabase> {
+public:
+    using SQLDatabase::identifier;
+
+    TestDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime)
+        : SQLDatabase(config, mime)
+    {
+        table_quote_begin = '[';
+        table_quote_end = ']';
+    }
+
+    void storeInternalSetting(const std::string& key, const std::string& value) override { }
+
+    bool threadCleanupRequired() const override { return false; }
+
+    void threadCleanup() override { }
+
+    std::shared_ptr<Database> getSelf() override { return this->shared_from_this(); }
+
+    void shutdownDriver() override { }
+
+    std::string quote(const std::string& str) const override
+    {
+        return fmt::format("\"{}\"", str);
+    }
+
+    int exec(const std::string& query, bool) override
+    {
+        last_statement = query;
+        return 0;
+    }
+
+    void _exec(const std::string& query) override
+    {
+        last_statement = query;
+    }
+
+    std::shared_ptr<SQLResult> select(const std::string& query) override
+    {
+        last_statement = query;
+        return {};
+    }
+
+    std::string last_statement;
+};
+
+class DatabaseTest : public ::testing::Test {
+public:
+    void SetUp() override
+    {
+        database = std::make_shared<TestDatabase>(config, mime);
+    }
+
+    void TearDown() override
+    {
+        database = {};
+    }
+
+protected:
+    std::shared_ptr<Config> config;
+    std::shared_ptr<Mime> mime;
+    std::shared_ptr<TestDatabase> database;
+};
+
+TEST_F(DatabaseTest, BasicFormattingTest)
+{
+    EXPECT_EQ(database->quote("123"), "\"123\"");
+    EXPECT_EQ(fmt::to_string(database->identifier("id")), "[id]");
+}
+
+TEST_F(DatabaseTest, DeleteTest)
+{
+    database->deleteAll("Table");
+    EXPECT_EQ(database->last_statement, "DELETE FROM [Table]");
+
+    database->deleteRow("Table", "id", 123);
+    EXPECT_EQ(database->last_statement, "DELETE FROM [Table] WHERE [id] = 123");
+
+    database->deleteRow("Table", "id", std::string("Text"));
+    EXPECT_EQ(database->last_statement, "DELETE FROM [Table] WHERE [id] = \"Text\"");
+
+    database->deleteRows("Table", "id", { 1, 2, 3 });
+    EXPECT_EQ(database->last_statement, "DELETE FROM [Table] WHERE [id] IN (1,2,3)");
+}


### PR DESCRIPTION
Simple SQL queries such as INSERT and DELETE often follow the same pattern. Provide simple methods that automatically handle quoting of identifiers and values and remove code redundancy.

Code for UPDATE methods will be added soon.