### PR TITLE
Modernize parts of the request handling with C++17 and add UTs

### DIFF
--- a/src/request_handler.cc
+++ b/src/request_handler.cc
@@ -47,40 +47,36 @@ RequestHandler::RequestHandler(std::shared_ptr<ContentManager> content)
 {
 }
 
-std::tuple<std::string_view, std::string_view> RequestHandler::splitUrl(std::string_view url, char separator)
+std::pair<std::string_view, std::string_view> RequestHandler::splitUrl(std::string_view url, char separator)
 {
-    std::size_t i1 = 0;
+    std::size_t splitPos = std::string_view::npos;
     switch (separator) {
     case '/':
-        i1 = url.rfind('/');
+        splitPos = url.rfind('/');
         break;
     case '?':
-        i1 = url.find('?');
+        splitPos = url.find('?');
         break;
     default:
         throw_std_runtime_error("Forbidden separator: {}", separator);
     }
 
-    if (i1 == std::string::npos) {
+    if (splitPos == std::string_view::npos)
         return { url, std::string_view() };
-    } else {
-        return { url.substr(0, i1), url.substr(i1 + 1) };
-    }
+
+    return { url.substr(0, splitPos), url.substr(splitPos + 1) };
 }
 
 std::string RequestHandler::joinUrl(const std::vector<std::string>& components, bool addToEnd, std::string_view separator)
 {
-    if (components.empty()) {
+    if (components.empty())
         return std::string(separator);
-    } else {
-        return fmt::format("{}{}{}", separator, fmt::join(components, separator), (addToEnd ? separator : ""));
-    }
+    return fmt::format("{}{}{}", separator, fmt::join(components, separator), (addToEnd ? separator : ""));
 }
 
 std::map<std::string, std::string> RequestHandler::parseParameters(std::string_view filename, std::string_view baseLink)
 {
     const auto parameters = filename.substr(baseLink.size());
-    //log_debug("filename: {} -> parameters: {}", filename, parameters);
     return dictDecodeSimple(parameters);
 }
 
@@ -88,11 +84,9 @@ std::shared_ptr<CdsObject> RequestHandler::getObjectById(const std::map<std::str
 {
     auto it = params.find("object_id");
     if (it == params.end()) {
-        //log_error("object_id not found in url");
         throw_std_runtime_error("getObjectById: object_id not found");
     }
 
     int objectID = std::stoi(it->second);
-    //log_debug("load objectID: {}", objectID);
     return database->loadObject(objectID);
 }

--- a/src/request_handler.cc
+++ b/src/request_handler.cc
@@ -48,22 +48,24 @@ RequestHandler::RequestHandler(std::shared_ptr<ContentManager> content)
 {
 }
 
-void RequestHandler::splitUrl(const std::string& url, char separator, std::string& path, std::string& parameters)
+std::tuple<std::string_view, std::string_view> RequestHandler::splitUrl(std::string_view url, char separator)
 {
-    const auto i1 = std::size_t { [=]() {
-        if (separator == '/')
-            return url.rfind(separator);
-        if (separator == '?')
-            return url.find(separator);
+    std::size_t i1 = 0;
+    switch (separator) {
+    case '/':
+        i1 = url.rfind('/');
+        break;
+    case '?':
+        i1 = url.find('?');
+        break;
+    default:
         throw_std_runtime_error("Forbidden separator: {}", separator);
-    }() };
+    }
 
     if (i1 == std::string::npos) {
-        path = url;
-        parameters.clear();
+        return { url, std::string_view() };
     } else {
-        parameters = url.substr(i1 + 1);
-        path = url.substr(0, i1);
+        return { url.substr(0, i1), url.substr(i1 + 1) };
     }
 }
 

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -36,6 +36,8 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string_view>
+#include <tuple>
 
 #include "common.h"
 #include "context.h"
@@ -68,14 +70,13 @@ public:
     /// Only '?' and '/' separators are allowed, otherwise an exception will
     /// be thrown.
     /// \param url URL that has to be processed
-    /// \param path variable where the path portion will be saved
-    /// \param parameters variable where the parameters portion will be saved
+    /// \return tuple of path and parameters which reference the input-view of url
     ///
-    /// This function splits the url into it's path and parameter components.
+    /// This function splits the url into its path and parameter components.
     /// content/media SEPARATOR object_id=12345&transcode=wav would be transformed to:
     /// path = "content/media"
     /// parameters = "object_id=12345&transcode=wav"
-    static void splitUrl(const std::string& url, char separator, std::string& path, std::string& parameters);
+    static std::tuple<std::string_view, std::string_view> splitUrl(std::string_view url, char separator);
 
     static std::string joinUrl(const std::vector<std::string>& components, bool addToEnd = false, const std::string& separator = _URL_PARAM_SEPARATOR);
 

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -37,7 +37,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <tuple>
+#include <utility>
 #include <vector>
 
 #include "common.h"
@@ -71,13 +71,13 @@ public:
     /// Only '?' and '/' separators are allowed, otherwise an exception will
     /// be thrown.
     /// \param url URL that has to be processed
-    /// \return tuple of path and parameters which reference the input-view of url
+    /// \return pair of path and parameters which reference the input-view of url
     ///
     /// This function splits the url into its path and parameter components.
     /// content/media SEPARATOR object_id=12345&transcode=wav would be transformed to:
     /// path = "content/media"
     /// parameters = "object_id=12345&transcode=wav"
-    static std::tuple<std::string_view, std::string_view> splitUrl(std::string_view url, char separator);
+    static std::pair<std::string_view, std::string_view> splitUrl(std::string_view url, char separator);
 
     static std::string joinUrl(const std::vector<std::string>& components, bool addToEnd = false, std::string_view separator = _URL_PARAM_SEPARATOR);
 

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -38,6 +38,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <vector>
 
 #include "common.h"
 #include "context.h"
@@ -78,10 +79,10 @@ public:
     /// parameters = "object_id=12345&transcode=wav"
     static std::tuple<std::string_view, std::string_view> splitUrl(std::string_view url, char separator);
 
-    static std::string joinUrl(const std::vector<std::string>& components, bool addToEnd = false, const std::string& separator = _URL_PARAM_SEPARATOR);
+    static std::string joinUrl(const std::vector<std::string>& components, bool addToEnd = false, std::string_view separator = _URL_PARAM_SEPARATOR);
 
-    static std::map<std::string, std::string> parseParameters(const char* filename, const char* baseLink);
-    std::shared_ptr<CdsObject> getObjectById(std::map<std::string, std::string> params) const;
+    static std::map<std::string, std::string> parseParameters(std::string_view filename, std::string_view baseLink);
+    std::shared_ptr<CdsObject> getObjectById(const std::map<std::string, std::string>& params) const;
 
 protected:
     std::shared_ptr<ContentManager> content;

--- a/src/server.cc
+++ b/src/server.cc
@@ -497,9 +497,7 @@ std::unique_ptr<RequestHandler> Server::createRequestHandler(const char* filenam
     }
 
     if (startswith(link, fmt::format("/{}/{}", SERVER_VIRTUAL_DIR, CONTENT_UI_HANDLER))) {
-        std::string parameters;
-        std::string path;
-        RequestHandler::splitUrl(filename, URL_UI_PARAM_SEPARATOR, path, parameters);
+        auto&& [path, parameters] = RequestHandler::splitUrl(filename, URL_UI_PARAM_SEPARATOR);
 
         std::map<std::string, std::string> params;
         dictDecode(parameters, params);

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -452,13 +452,14 @@ void dictDecode(std::string_view url, std::map<std::string, std::string>& dict, 
 
 // this is somewhat tricky as we need an exact amount of pairs
 // object_id=720&res_id=0
-void dictDecodeSimple(std::string_view url, std::map<std::string, std::string>& dict)
+std::map<std::string, std::string> dictDecodeSimple(std::string_view url)
 {
+    std::map<std::string, std::string> dict;
     std::size_t pos;
     std::size_t last_pos = 0;
     do {
         pos = url.find('/', last_pos);
-        if (pos == std::string::npos || pos < last_pos + 1)
+        if (pos == std::string_view::npos || pos < last_pos + 1)
             break;
 
         std::string key = urlUnescape(url.substr(last_pos, pos - last_pos));
@@ -474,6 +475,8 @@ void dictDecodeSimple(std::string_view url, std::map<std::string, std::string>& 
 
         dict.emplace(key, value);
     } while (last_pos < url.length());
+
+    return dict;
 }
 
 std::string mimeTypesToCsv(const std::vector<std::string>& mimeTypes)

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -139,7 +139,7 @@ std::string urlUnescape(std::string_view str);
 std::string dictEncode(const std::map<std::string, std::string>& dict);
 std::string dictEncodeSimple(const std::map<std::string, std::string>& dict);
 void dictDecode(std::string_view url, std::map<std::string, std::string>& dict, bool unEscape = true);
-void dictDecodeSimple(std::string_view url, std::map<std::string, std::string>& dict);
+std::map<std::string, std::string> dictDecodeSimple(std::string_view url);
 
 /// \brief Convert an array of strings to a CSV list, with additional protocol information
 /// \param array that needs to be converted

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -91,8 +91,7 @@ void WebRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 {
     this->filename = filename;
 
-    std::string path, parameters;
-    splitUrl(filename, URL_UI_PARAM_SEPARATOR, path, parameters);
+    auto&& [path, parameters] = splitUrl(filename, URL_UI_PARAM_SEPARATOR);
 
     dictDecode(parameters, params);
 
@@ -221,8 +220,7 @@ std::unique_ptr<IOHandler> WebRequestHandler::open(const char* filename, enum Up
     this->filename = filename;
     this->mode = mode;
 
-    std::string path, parameters;
-    splitUrl(filename, URL_UI_PARAM_SEPARATOR, path, parameters);
+    auto&& [path, parameters] = splitUrl(filename, URL_UI_PARAM_SEPARATOR);
 
     dictDecode(parameters, params);
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(testcore
     test_server.cc
     test_upnp_xml.cc
     test_ffmpeg_cache_paths.cc
+    test_request_handler.cc
 )
 
 target_link_libraries(testcore PRIVATE

--- a/test/core/test_request_handler.cc
+++ b/test/core/test_request_handler.cc
@@ -1,0 +1,47 @@
+/*GRB*
+  Gerbera - https://gerbera.io/
+
+  test_request_handler.cc - this file is part of Gerbera.
+
+  Copyright (C) 2021 Gerbera Contributors
+
+  Gerbera is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License version 2
+  as published by the Free Software Foundation.
+
+  Gerbera is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+
+  $Id$
+*/
+
+#include "request_handler.h"
+
+#include <gtest/gtest.h>
+
+using namespace testing;
+
+class RequestHandlerTest : public ::testing::Test {
+
+public:
+    RequestHandlerTest() = default;
+    ~RequestHandlerTest() override = default;
+};
+
+TEST_F(RequestHandlerTest, SplitUrlTest)
+{
+    EXPECT_THROW(RequestHandler::splitUrl("123X456", 'X'), std::runtime_error);
+
+    auto&& [path, parameters] = RequestHandler::splitUrl("content/media?object_id=12345&transcode=wav", '?');
+    EXPECT_EQ(path, "content/media");
+    EXPECT_EQ(parameters, "object_id=12345&transcode=wav");
+
+    std::tie(path, parameters) = RequestHandler::splitUrl("a/very/long/path", '/');
+    EXPECT_EQ(path, "a/very/long");
+    EXPECT_EQ(parameters, "path");
+}

--- a/test/core/test_request_handler.cc
+++ b/test/core/test_request_handler.cc
@@ -45,3 +45,29 @@ TEST_F(RequestHandlerTest, SplitUrlTest)
     EXPECT_EQ(path, "a/very/long");
     EXPECT_EQ(parameters, "path");
 }
+
+TEST_F(RequestHandlerTest, JoinUrlTest)
+{
+    auto components = std::vector<std::string> {
+        "A", "B", "C", "D"
+    };
+    auto url = RequestHandler::joinUrl(components, false);
+    EXPECT_EQ(url, "/A/B/C/D");
+
+    url = RequestHandler::joinUrl(components, false, "&");
+    EXPECT_EQ(url, "&A&B&C&D");
+
+    url = RequestHandler::joinUrl(components, true);
+    EXPECT_EQ(url, "/A/B/C/D/");
+
+    url = RequestHandler::joinUrl({}, true);
+    EXPECT_EQ(url, "/");
+}
+
+TEST_F(RequestHandlerTest, ParseParametersTest)
+{
+    auto m = RequestHandler::parseParameters("url/paramA/value%201/paramB/2", "url/");
+    ASSERT_EQ(m.size(), 2);
+    EXPECT_EQ(m["paramA"], "value 1");
+    EXPECT_EQ(m["paramB"], "2");
+}


### PR DESCRIPTION
I'm going over probably old code that is central to request and URL handling. These methods can strongly benefit from `std::string_view` optimizations to avoid copying string all over the place when dissecting them. While I'm at it, I add unit tests wherever suitable.