### PR TITLE
Remove .c_str() for fmt-string arguments

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -100,7 +100,7 @@ void ActionRequest::update()
         std::ostringstream buf;
         response->print(buf, "", 0);
         std::string xml = buf.str();
-        log_debug("ActionRequest::update(): {}", xml.c_str());
+        log_debug("ActionRequest::update(): {}", xml);
 
 #if defined(USING_NPUPNP)
         UpnpActionRequest_set_xmlResponse(upnp_request, xml);
@@ -127,6 +127,6 @@ void ActionRequest::update()
             UpnpActionRequest_set_ErrCode(upnp_request, UPNP_E_ACTION_FAILED);
         }
 
-        log_error("ActionRequest::update(): response is nullptr, code {} for {}", errCode, actionName.c_str());
+        log_error("ActionRequest::update(): response is nullptr, code {} for {}", errCode, actionName);
     }
 }

--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -192,7 +192,7 @@ ClientType ClientConfig::remapClientType(const std::string& clientType)
         return ClientType::Unknown;
     }
 
-    throw_std_runtime_error("clientType {} invalid", clientType.c_str());
+    throw_std_runtime_error("clientType {} invalid", clientType);
 }
 
 int ClientConfig::remapFlag(const std::string& flag)

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -257,7 +257,7 @@ void ConfigManager::load(const fs::path& userHome)
 #if defined(HAVE_NL_LANGINFO) && defined(HAVE_SETLOCALE)
     if (setlocale(LC_ALL, "")) {
         defaultCharSet = nl_langinfo(CODESET);
-        log_debug("received {} from nl_langinfo", defaultCharSet.c_str());
+        log_debug("received {} from nl_langinfo", defaultCharSet);
     }
 #endif
     // check if the one we take as default is actually available
@@ -275,7 +275,7 @@ void ConfigManager::load(const fs::path& userHome)
     } catch (const std::runtime_error& e) {
         throw_std_runtime_error("Error in config file: unsupported filesystem-charset specified: {}\n{}", charset, e.what());
     }
-    log_debug("Setting filesystem import charset to {}", charset.c_str());
+    log_debug("Setting filesystem import charset to {}", charset);
     co->makeOption(charset, self);
 
     co = ConfigDefinition::findConfigSetup(CFG_IMPORT_METADATA_CHARSET);
@@ -286,7 +286,7 @@ void ConfigManager::load(const fs::path& userHome)
     } catch (const std::runtime_error& e) {
         throw_std_runtime_error("Error in config file: unsupported metadata-charset specified: {}\n{}", charset, e.what());
     }
-    log_debug("Setting metadata import charset to {}", charset.c_str());
+    log_debug("Setting metadata import charset to {}", charset);
     co->makeOption(charset, self);
 
     // read playlist options
@@ -298,7 +298,7 @@ void ConfigManager::load(const fs::path& userHome)
     } catch (const std::runtime_error& e) {
         throw_std_runtime_error("Error in config file: unsupported playlist-charset specified: {}\n{}", charset, e.what());
     }
-    log_debug("Setting playlist charset to {}", charset.c_str());
+    log_debug("Setting playlist charset to {}", charset);
     co->makeOption(charset, self);
 
     // read network options
@@ -319,7 +319,7 @@ void ConfigManager::load(const fs::path& userHome)
             throw_std_runtime_error("Error in config file: \"append-to\" attribute "
                                     "value in <presentationURL> tag is set to \"{}\""
                                     "but no URL is specified",
-                temp.c_str());
+                temp);
         }
     }
 #ifdef HAVE_JS
@@ -480,7 +480,7 @@ void ConfigManager::load(const fs::path& userHome)
 
     std::ostringstream buf;
     xmlDoc->print(buf, "  ");
-    log_debug("Config file dump after validation: {}", buf.str().c_str());
+    log_debug("Config file dump after validation: {}", buf.str());
 
     // now the XML is no longer needed we can destroy it
     xmlDoc = nullptr;

--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -93,7 +93,7 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim)
     if (root.attribute(xAttr.c_str())) {
         std::string optValue = trim ? trimString(root.attribute(xAttr.c_str()).as_string()) : root.attribute(xAttr.c_str()).as_string();
         if (!checkValue(optValue)) {
-            throw_std_runtime_error("Invalid {}/attribute::{} value '{}'", root.path(), xAttr.c_str(), optValue.c_str());
+            throw_std_runtime_error("Invalid {}/attribute::{} value '{}'", root.path(), xAttr, optValue);
         }
         return optValue;
     }
@@ -101,7 +101,7 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim)
     if (root.child(xpath)) {
         std::string optValue = trim ? trimString(root.child(xpath).text().as_string()) : root.child(xpath).text().as_string();
         if (!checkValue(optValue)) {
-            throw_std_runtime_error("Invalid {}/{} value '{}'", root.path(), xpath, optValue.c_str());
+            throw_std_runtime_error("Invalid {}/{} value '{}'", root.path(), xpath, optValue);
         }
         return optValue;
     }
@@ -109,7 +109,7 @@ std::string ConfigSetup::getXmlContent(const pugi::xml_node& root, bool trim)
     if (required)
         throw_std_runtime_error("Error in config file: {}/{} not found", root.path(), xpath);
 
-    log_debug("Config: option not found: '{}/{}' using default value: '{}'", root.path(), xpath, defaultValue.c_str());
+    log_debug("Config: option not found: '{}/{}' using default value: '{}'", root.path(), xpath, defaultValue);
 
     useDefault = true;
     return defaultValue;
@@ -163,7 +163,7 @@ void ConfigStringSetup::makeOption(const pugi::xml_node& root, const std::shared
 std::shared_ptr<ConfigOption> ConfigStringSetup::newOption(const std::string& optValue)
 {
     if (notEmpty && optValue.empty()) {
-        throw_std_runtime_error("Invalid {} empty value '{}'", xpath, optValue.c_str());
+        throw_std_runtime_error("Invalid {} empty value '{}'", xpath, optValue);
     }
     optionValue = std::make_shared<Option>(optValue);
     return optionValue;
@@ -185,21 +185,21 @@ bool ConfigPathSetup::checkAgentPath(std::string& optValue)
         std::error_code ec;
         fs::directory_entry dirEnt(optValue, ec);
         if (!isRegularFile(dirEnt, ec) && !dirEnt.is_symlink(ec)) {
-            log_error("Error in configuration, transcoding profile: could not find transcoding command \"{}\"", optValue.c_str());
+            log_error("Error in configuration, transcoding profile: could not find transcoding command \"{}\"", optValue);
             return false;
         }
         tmp_path = optValue;
     } else {
         tmp_path = findInPath(optValue);
         if (tmp_path.empty()) {
-            log_error("Error in configuration, transcoding profile: could not find transcoding command \"{}\" in $PATH", optValue.c_str());
+            log_error("Error in configuration, transcoding profile: could not find transcoding command \"{}\" in $PATH", optValue);
             return false;
         }
     }
 
     int err = 0;
     if (!isExecutable(tmp_path, &err)) {
-        log_error("Error in configuration, transcoding profile: transcoder {} is not executable: {}", optValue.c_str(), std::strerror(err));
+        log_error("Error in configuration, transcoding profile: transcoder {} is not executable: {}", optValue, std::strerror(err));
         return false;
     }
     return true;
@@ -283,7 +283,7 @@ std::shared_ptr<ConfigOption> ConfigPathSetup::newOption(std::string& optValue)
 {
     auto pathValue = optValue;
     if (!checkPathValue(optValue, pathValue)) {
-        throw_std_runtime_error("Invalid {} resolves to empty value '{}'", xpath, optValue.c_str());
+        throw_std_runtime_error("Invalid {} resolves to empty value '{}'", xpath, optValue);
     }
     optionValue = std::make_shared<Option>(pathValue);
     return optionValue;
@@ -301,22 +301,22 @@ void ConfigIntSetup::makeOption(std::string optValue, const std::shared_ptr<Conf
 {
     if (rawCheck) {
         if (!rawCheck(optValue)) {
-            throw_std_runtime_error("Invalid {} value '{}'", xpath, optValue.c_str());
+            throw_std_runtime_error("Invalid {} value '{}'", xpath, optValue);
         }
     } else if (valueCheck) {
         if (!valueCheck(std::stoi(optValue))) {
-            throw_std_runtime_error("Invalid {} value '{}'", xpath, optValue.c_str());
+            throw_std_runtime_error("Invalid {} value '{}'", xpath, optValue);
         }
     } else if (minCheck) {
         if (!minCheck(std::stoi(optValue), minValue)) {
-            throw_std_runtime_error("Invalid {} value '{}', must be at least {}", xpath, optValue.c_str(), minValue);
+            throw_std_runtime_error("Invalid {} value '{}', must be at least {}", xpath, optValue, minValue);
         }
     }
     try {
         optionValue = std::make_shared<IntOption>(std::stoi(optValue));
         setOption(config);
     } catch (const std::runtime_error& e) {
-        throw_std_runtime_error("Error in config file: {} unsupported int value '{}'", xpath, optValue.c_str());
+        throw_std_runtime_error("Error in config file: {} unsupported int value '{}'", xpath, optValue);
     }
 }
 
@@ -345,7 +345,7 @@ int ConfigIntSetup::checkIntValue(std::string& sVal, const std::string& pathName
 int ConfigIntSetup::getXmlContent(const pugi::xml_node& root)
 {
     std::string sVal = ConfigSetup::getXmlContent(root, true);
-    log_debug("Config: option: '{}/{}' value: '{}'", root.path(), xpath, sVal.c_str());
+    log_debug("Config: option: '{}/{}' value: '{}'", root.path(), xpath, sVal);
     return checkIntValue(sVal, root.path());
 }
 
@@ -426,7 +426,7 @@ static bool validateTrueFalse(const std::string& optValue)
 void ConfigBoolSetup::makeOption(std::string optValue, const std::shared_ptr<Config>& config, const std::map<std::string, std::string>* arguments)
 {
     if (!validateTrueFalse(optValue) && !validateYesNo(optValue))
-        throw_std_runtime_error("Invalid {} value {}", xpath, optValue.c_str());
+        throw_std_runtime_error("Invalid {} value {}", xpath, optValue);
     optionValue = std::make_shared<BoolOption>(optValue == YES || optValue == "true");
     setOption(config);
 }
@@ -441,12 +441,12 @@ bool ConfigBoolSetup::checkValue(std::string& optValue, const std::string& pathN
 {
     if (rawCheck) {
         if (!rawCheck(optValue)) {
-            throw_std_runtime_error("Invalid {}/{} value '{}'", pathName, xpath, optValue.c_str());
+            throw_std_runtime_error("Invalid {}/{} value '{}'", pathName, xpath, optValue);
         }
     }
 
     if (!validateTrueFalse(optValue) && !validateYesNo(optValue))
-        throw_std_runtime_error("Invalid {}/{} value {}", pathName, xpath, optValue.c_str());
+        throw_std_runtime_error("Invalid {}/{} value {}", pathName, xpath, optValue);
     return optValue == YES || optValue == "true";
 }
 
@@ -572,7 +572,7 @@ bool ConfigArraySetup::updateDetail(const std::string& optItem, std::string& opt
 {
     if (startswith(optItem, xpath) && optionValue) {
         auto value = std::dynamic_pointer_cast<ArrayOption>(optionValue);
-        log_debug("Updating Array Detail {} {} {}", xpath, optItem, optValue.c_str());
+        log_debug("Updating Array Detail {} {} {}", xpath, optItem, optValue);
 
         std::size_t i = extractIndex(optItem);
         if (i < std::numeric_limits<std::size_t>::max()) {
@@ -758,7 +758,7 @@ bool ConfigDictionarySetup::updateItem(std::size_t i, const std::string& optItem
             value->setValue(i, config->getOrigValue(valIndex));
             log_debug("Reset Dictionary value {} {}", valIndex, config->getDictionaryOption(option)[optKey]);
         }
-        log_debug("New Dictionary key {} {}", keyIndex, optValue.c_str());
+        log_debug("New Dictionary key {} {}", keyIndex, optValue);
         return true;
     }
     if (optItem == valIndex) {
@@ -774,7 +774,7 @@ bool ConfigDictionarySetup::updateDetail(const std::string& optItem, std::string
 {
     if (startswith(optItem, xpath) && optionValue) {
         auto value = std::dynamic_pointer_cast<DictionaryOption>(optionValue);
-        log_debug("Updating Dictionary Detail {} {} {}", xpath, optItem, optValue.c_str());
+        log_debug("Updating Dictionary Detail {} {} {}", xpath, optItem, optValue);
 
         std::size_t i = extractIndex(optItem);
         if (i < std::numeric_limits<std::size_t>::max()) {
@@ -902,7 +902,7 @@ bool ConfigAutoscanSetup::createOptionFromNode(const pugi::xml_node& element, st
         try {
             result->add(dir);
         } catch (const std::runtime_error& e) {
-            log_error("Could not add {}: {}", location.string().c_str(), e.what());
+            log_error("Could not add {}: {}", location.string(), e.what());
             return false;
         }
     }
@@ -967,7 +967,7 @@ bool ConfigAutoscanSetup::updateDetail(const std::string& optItem, std::string& 
 {
     auto uPath = getUniquePath();
     if (startswith(optItem, uPath)) {
-        log_debug("Updating Autoscan Detail {} {} {}", uPath, optItem, optValue.c_str());
+        log_debug("Updating Autoscan Detail {} {} {}", uPath, optItem, optValue);
         auto value = std::dynamic_pointer_cast<AutoscanListOption>(optionValue);
 
         auto list = value->getAutoscanListOption();
@@ -1134,11 +1134,11 @@ bool ConfigTranscodingSetup::createOptionFromNode(const pugi::xml_node& element,
         std::size_t fill = ConfigDefinition::findConfigSetup<ConfigIntSetup>(ATTR_TRANSCODING_PROFILES_PROFLE_BUFFER_FILL)->getXmlContent(sub);
 
         if (chunk > buffer) {
-            log_error("Error in configuration: transcoding profile \"{}\" chunk size can not be greater than buffer size", prof->getName().c_str());
+            log_error("Error in configuration: transcoding profile \"{}\" chunk size can not be greater than buffer size", prof->getName());
             return false;
         }
         if (fill > buffer) {
-            log_error("Error in configuration: transcoding profile \"{}\" fill size can not be greater than buffer size", prof->getName().c_str());
+            log_error("Error in configuration: transcoding profile \"{}\" fill size can not be greater than buffer size", prof->getName());
             return false;
         }
 
@@ -1153,7 +1153,7 @@ bool ConfigTranscodingSetup::createOptionFromNode(const pugi::xml_node& element,
         }
 
         if (!set) {
-            log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but no match for profile \"{}\" exists", prof->getName().c_str());
+            log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but no match for profile \"{}\" exists", prof->getName());
             if (!allow_unused_profiles) {
                 return false;
             }
@@ -1164,7 +1164,7 @@ bool ConfigTranscodingSetup::createOptionFromNode(const pugi::xml_node& element,
     auto tpl = result->getList();
     for (auto&& [key, val] : mt_mappings) {
         if (tpl.find(key) == tpl.end()) {
-            log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but the profile \"{}\" for mimetype \"{}\" does not exists", val.c_str(), key.c_str());
+            log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but the profile \"{}\" for mimetype \"{}\" does not exists", val, key);
             if (!ConfigDefinition::findConfigSetup<ConfigBoolSetup>(CFG_TRANSCODING_MIMETYPE_PROF_MAP_ALLOW_UNUSED)->getXmlContent(root)) {
                 return false;
             }
@@ -1214,7 +1214,7 @@ bool ConfigTranscodingSetup::updateDetail(const std::string& optItem, std::strin
 {
     if (startswith(optItem, xpath) && optionValue) {
         auto value = std::dynamic_pointer_cast<TranscodingProfileListOption>(optionValue);
-        log_debug("Updating Transcoding Detail {} {} {}", xpath, optItem, optValue.c_str());
+        log_debug("Updating Transcoding Detail {} {} {}", xpath, optItem, optValue);
         std::map<std::string, int> profiles;
         int i = 0;
 
@@ -1414,7 +1414,7 @@ bool ConfigTranscodingSetup::updateDetail(const std::string& optItem, std::strin
             }
             index = getItemPath(i, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC);
             if (optItem == index) {
-                config->setOrigValue(index, std::accumulate(next(fcc_list.begin()), fcc_list.end(), fcc_list[0], [](auto&& a, auto&& b) { return fmt::format("{}, {}", a.c_str(), b.c_str()); }));
+                config->setOrigValue(index, std::accumulate(next(fcc_list.begin()), fcc_list.end(), fcc_list[0], [](auto&& a, auto&& b) { return fmt::format("{}, {}", a, b); }));
                 fcc_list.clear();
                 if (ConfigDefinition::findConfigSetup<ConfigArraySetup>(ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC)->checkArrayValue(optValue, fcc_list)) {
                     set4cc = true;

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -239,7 +239,7 @@ public:
     En getXmlContent(const pugi::xml_node& root)
     {
         std::string optValue = ConfigSetup::getXmlContent(root, true);
-        log_debug("Config: option: '{}' value: '{}'", xpath, optValue.c_str());
+        log_debug("Config: option: '{}' value: '{}'", xpath, optValue);
         if (notEmpty && optValue.empty()) {
             throw_std_runtime_error("Error in config file: Invalid {}/{} empty value '{}'", root.path(), xpath, optValue);
         }

--- a/src/content/autoscan.cc
+++ b/src/content/autoscan.cc
@@ -137,7 +137,7 @@ ScanMode AutoscanDirectory::remapScanmode(const std::string& scanmode)
     if (scanmode == "inotify")
         return ScanMode::INotify;
 
-    throw_std_runtime_error("Illegal scanmode ({}) given to remapScanmode()", scanmode.c_str());
+    throw_std_runtime_error("Illegal scanmode ({}) given to remapScanmode()", scanmode);
 }
 
 void AutoscanDirectory::copyTo(const std::shared_ptr<AutoscanDirectory>& copy) const

--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -161,7 +161,7 @@ void AutoscanInotify::threadProc()
                 int wd = event->wd;
                 int mask = event->mask;
                 std::string name = event->name;
-                log_debug("inotify event: {} 0x{:x} {}", wd, mask, name.c_str());
+                log_debug("inotify event: {} 0x{:x} {}", wd, mask, name);
 
                 std::shared_ptr<Wd> wdObj;
                 try {

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -510,10 +510,10 @@ bool ContentManager::updateAttachedResources(const std::shared_ptr<AutoscanDirec
         auto dirEntry = fs::directory_entry(parentPath, ec);
         if (!ec) {
             addFile(dirEntry, asSetting, true, true, false);
-            log_debug("Forced rescan of {} for resource {}", parentPath.c_str(), obj->getLocation().string().c_str());
+            log_debug("Forced rescan of {} for resource {}", parentPath, obj->getLocation().string());
             parentRemoved = true;
         } else {
-            log_error("Failed to read {}: {}", parentPath.c_str(), ec.message());
+            log_error("Failed to read {}: {}", parentPath, ec.message());
         }
     }
     return parentRemoved;
@@ -875,7 +875,7 @@ void ContentManager::addRecursive(std::shared_ptr<AutoscanDirectory>& adir, cons
 
         // For the Web UI
         if (task) {
-            task->setDescription(fmt::format("Importing: {}", newPath.string().c_str()));
+            task->setDescription(fmt::format("Importing: {}", newPath.string()));
         }
 
         try {
@@ -1022,14 +1022,14 @@ void ContentManager::updateCdsObject(std::shared_ptr<CdsItem>& item, const std::
         cloned_item->removeMetaData(M_DESCRIPTION);
     }
 
-    log_debug("updateCdsObject: checking equality of item {}", item->getTitle().c_str());
+    log_debug("updateCdsObject: checking equality of item {}", item->getTitle());
     if (!item->equals(cloned_item, true)) {
         cloned_item->validate();
         int containerChanged = INVALID_OBJECT_ID;
         database->updateObject(clone, &containerChanged);
         update_manager->containerChanged(containerChanged);
         session_manager->containerChangedUI(containerChanged);
-        log_debug("updateObject: calling containerChanged on item {}", item->getTitle().c_str());
+        log_debug("updateObject: calling containerChanged on item {}", item->getTitle());
         update_manager->containerChanged(item->getParentID());
     }
 }
@@ -1416,7 +1416,7 @@ void ContentManager::threadProc()
         currentTask = task;
         lock.unlock();
 
-        // log_debug("content manager Async START {}", task->getDescription().c_str());
+        // log_debug("content manager Async START {}", task->getDescription());
         try {
             if (task->isValid())
                 task->run();
@@ -1425,7 +1425,7 @@ void ContentManager::threadProc()
         } catch (const std::runtime_error& e) {
             log_error("Exception caught: {}", e.what());
         }
-        // log_debug("content manager ASYNC STOP  {}", task->getDescription().c_str());
+        // log_debug("content manager ASYNC STOP  {}", task->getDescription());
 
         if (!shutdownFlag) {
             lock.lock();
@@ -1474,7 +1474,7 @@ int ContentManager::addFileInternal(
     if (async) {
         auto self = shared_from_this();
         auto task = std::make_shared<CMAddFileTask>(self, dirEnt, rootpath, asSetting, cancellable);
-        task->setDescription(fmt::format("Importing: {}", dirEnt.path().string().c_str()));
+        task->setDescription(fmt::format("Importing: {}", dirEnt.path().string()));
         task->setParentID(parentTaskID);
         addTask(task, lowPriority);
         return INVALID_OBJECT_ID;
@@ -1503,7 +1503,7 @@ void ContentManager::fetchOnlineContent(service_type_t serviceType, bool lowPrio
 
 void ContentManager::cleanupOnlineServiceObjects(const std::shared_ptr<OnlineService>& service)
 {
-    log_debug("Finished fetch cycle for service: {}", service->getServiceName().c_str());
+    log_debug("Finished fetch cycle for service: {}", service->getServiceName());
 
     if (service->getItemPurgeInterval() > std::chrono::seconds::zero()) {
         auto ids = database->getServiceObjectIDs(service->getDatabasePrefix());
@@ -1524,7 +1524,7 @@ void ContentManager::cleanupOnlineServiceObjects(const std::shared_ptr<OnlineSer
             last = std::chrono::seconds(std::stoll(temp));
 
             if ((service->getItemPurgeInterval() > std::chrono::seconds::zero()) && ((current - last) > service->getItemPurgeInterval())) {
-                log_debug("Purging old online service object {}", obj->getTitle().c_str());
+                log_debug("Purging old online service object {}", obj->getTitle());
                 removeObject(nullptr, object_id, false);
             }
         }
@@ -1650,7 +1650,7 @@ void ContentManager::rescanDirectory(const std::shared_ptr<AutoscanDirectory>& a
     if (descPath.empty())
         descPath = adir->getLocation();
 
-    task->setDescription(fmt::format("Scan: {}", descPath.string().c_str()));
+    task->setDescription(fmt::format("Scan: {}", descPath.string()));
     addTask(task, true); // adding with low priority
 }
 
@@ -1854,7 +1854,7 @@ void ContentManager::triggerPlayHook(const std::shared_ptr<CdsObject>& obj)
             obj->setFlag(OBJECT_FLAG_PLAYED);
 
             bool supress = config->getBoolOption(CFG_SERVER_EXTOPTS_MARK_PLAYED_ITEMS_SUPPRESS_CDS_UPDATES);
-            log_debug("Marking object {} as played", obj->getTitle().c_str());
+            log_debug("Marking object {} as played", obj->getTitle());
             updateObject(obj, !supress);
         }
     }

--- a/src/content/layout/builtin_layout.cc
+++ b/src/content/layout/builtin_layout.cc
@@ -116,7 +116,7 @@ void BuiltinLayout::addVideo(const std::shared_ptr<CdsObject>& obj, const fs::pa
         dir = esc(f2i->convert(getLastPath(obj->getLocation())));
 
     if (!dir.empty()) {
-        id = content->addContainerChain(fmt::format("/Video/Directories/{}", dir.string().c_str()));
+        id = content->addContainerChain(fmt::format("/Video/Directories/{}", dir.string()));
         add(obj, id);
     }
 }
@@ -170,7 +170,7 @@ void BuiltinLayout::addImage(const std::shared_ptr<CdsObject>& obj, const fs::pa
         dir = esc(f2i->convert(getLastPath(obj->getLocation())));
 
     if (!dir.empty()) {
-        id = content->addContainerChain(fmt::format("/Photos/Directories/{}", dir.string().c_str()));
+        id = content->addContainerChain(fmt::format("/Photos/Directories/{}", dir.string()));
         add(obj, id);
     }
 }
@@ -313,7 +313,7 @@ void BuiltinLayout::addAudio(const std::shared_ptr<CdsObject>& obj, const fs::pa
         dir = esc(f2i->convert(getLastPath(obj->getLocation())));
 
     if (!dir.empty()) {
-        id = content->addContainerChain(fmt::format("/Audio/Directories/{}", dir.string().c_str()));
+        id = content->addContainerChain(fmt::format("/Audio/Directories/{}", dir.string()));
         add(obj, id);
     }
 }
@@ -407,7 +407,7 @@ std::string BuiltinLayout::mapGenre(const std::string& genre)
 
 void BuiltinLayout::processCdsObject(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath, const std::string& mimetype, const std::string& content_type)
 {
-    log_debug("Process CDS Object: {}", obj->getTitle().c_str());
+    log_debug("Process CDS Object: {}", obj->getTitle());
 #ifdef ENABLE_PROFILING
     PROF_START(&layout_profiling);
 #endif

--- a/src/content/onlineservice/atrailers_content_handler.cc
+++ b/src/content/onlineservice/atrailers_content_handler.cc
@@ -102,7 +102,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
     if (temp.empty()) {
         log_warning("Failed to retrieve Trailer ID for \"{}\", "
                     "skipping...\n",
-            item->getTitle().c_str());
+            item->getTitle());
         return nullptr;
     }
 
@@ -113,7 +113,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
     if (!preview) {
         log_warning("Failed to retrieve Trailer location for \"{}\", "
                     "skipping...\n",
-            item->getTitle().c_str());
+            item->getTitle());
         return nullptr;
     }
 
@@ -123,7 +123,7 @@ std::shared_ptr<CdsObject> ATrailersContentHandler::getObject(const pugi::xml_no
     } else {
         log_error("Could not get location for Trailers item {}, "
                   "skipping.\n",
-            item->getTitle().c_str());
+            item->getTitle());
         return nullptr;
     }
 

--- a/src/content/onlineservice/curl_online_service.cc
+++ b/src/content/onlineservice/curl_online_service.cc
@@ -66,7 +66,7 @@ std::unique_ptr<pugi::xml_document> CurlOnlineService::getData()
     std::string buffer;
 
     try {
-        log_debug("DOWNLOADING URL: {}", service_url.c_str());
+        log_debug("DOWNLOADING URL: {}", service_url);
         buffer = URL::download(service_url, &retcode,
             curl_handle, false, true, true);
     } catch (const std::runtime_error& ex) {
@@ -80,7 +80,7 @@ std::unique_ptr<pugi::xml_document> CurlOnlineService::getData()
     if (retcode != 200)
         return nullptr;
 
-    log_debug("GOT BUFFER{}", buffer.c_str());
+    log_debug("GOT BUFFER{}", buffer);
     auto doc = std::make_unique<pugi::xml_document>();
     pugi::xml_parse_result result = doc->load_string(sc->convert(buffer).c_str());
     if (result.status != pugi::xml_parse_status::status_ok) {

--- a/src/content/onlineservice/lastfm_scrobbler.cc
+++ b/src/content/onlineservice/lastfm_scrobbler.cc
@@ -76,13 +76,11 @@ void LastFm::startedPlaying(const std::shared_ptr<CdsItem>& item)
 
     currentTrackId = item->getID();
 
-    log_debug("Artist:\t{}",
-        item->getMetaData(M_ARTIST).c_str());
-    log_debug("Title:\t{}",
-        item->getMetaData(M_TITLE).c_str());
-
     std::string artist = item->getMetaData(M_ARTIST);
     std::string title = item->getMetaData(M_TITLE);
+
+    log_debug("Artist:\t{}", artist);
+    log_debug("Title:\t{}", title);
 
     if (artist.empty() || title.empty()) {
         scrobbler->finishedPlaying();

--- a/src/content/onlineservice/sopcast_content_handler.cc
+++ b/src/content/onlineservice/sopcast_content_handler.cc
@@ -140,7 +140,7 @@ std::shared_ptr<CdsObject> SopCastContentHandler::getObject(const std::string& g
     std::string mt = getValueOrDefault(mappings, temp, "*");
     if (mt == "*") {
         mt = getValueOrDefault(mappings, "*");
-        log_warning("Could not determine mimetype for SopCast channel (stream_type: {})", temp.c_str());
+        log_warning("Could not determine mimetype for SopCast channel (stream_type: {})", temp);
     }
 
     resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(mt, SOPCAST_PROTOCOL));

--- a/src/content/onlineservice/task_processor.cc
+++ b/src/content/onlineservice/task_processor.cc
@@ -186,8 +186,7 @@ void TPFetchOnlineContentTask::run()
     try {
         //cm->_fetchOnlineContent(service, getParentID(), unscheduled_refresh);
         if (service->refreshServiceData(layout) && (isValid())) {
-            log_debug("Scheduling another task for online service: {}",
-                service->getServiceName().c_str());
+            log_debug("Scheduling another task for online service: {}", service->getServiceName());
 
             if ((service->getRefreshInterval() > std::chrono::seconds::zero()) || unscheduled_refresh) {
                 auto t = std::make_shared<TPFetchOnlineContentTask>(

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -320,8 +320,7 @@ Script::Script(std::shared_ptr<ContentManager> content,
             _load(common_scr_path);
             _execute();
         } catch (const std::runtime_error& e) {
-            log_js("Unable to load {}: {}", common_scr_path.c_str(),
-                e.what());
+            log_js("Unable to load {}: {}", common_scr_path, e.what());
         }
     }
     std::string custom_scr_path = config->getOption(CFG_IMPORT_SCRIPTING_CUSTOM_SCRIPT);
@@ -330,8 +329,7 @@ Script::Script(std::shared_ptr<ContentManager> content,
             _load(custom_scr_path);
             _execute();
         } catch (const std::runtime_error& e) {
-            log_js("Unable to load {}: {}", custom_scr_path.c_str(),
-                e.what());
+            log_js("Unable to load {}: {}", custom_scr_path, e.what());
         }
     }
 }
@@ -384,7 +382,7 @@ void Script::_load(const std::string& scriptPath)
     duk_push_string(ctx, scriptPath.c_str());
     if (duk_pcompile_lstring_filename(ctx, 0, scriptText.c_str(), scriptText.length()) != 0) {
         log_error("Failed to load script: {}", duk_safe_to_string(ctx, -1));
-        throw_std_runtime_error("Scripting: failed to compile {}", scriptPath.c_str());
+        throw_std_runtime_error("Scripting: failed to compile {}", scriptPath);
     }
 }
 

--- a/src/content/update_manager.cc
+++ b/src/content/update_manager.cc
@@ -203,7 +203,7 @@ void UpdateManager::threadProc()
                 lock.unlock(); // we don't need to hold the lock during the sending of the updates
                 if (!updateString.empty()) {
                     try {
-                        log_debug("updates sent: \"{}\"", updateString.c_str());
+                        log_debug("updates sent: \"{}\"", updateString);
                         server->sendCDSSubscriptionUpdate(updateString);
                         lastUpdate = currentTimeMS();
                     } catch (const std::runtime_error& e) {

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -153,7 +153,7 @@ void MySQLDatabase::init()
     if (dbVersion.empty()) {
         log_info("Database doesn't seem to exist. Creating database...");
         auto sqlFilePath = config->getOption(CFG_SERVER_STORAGE_MYSQL_INIT_SQL_FILE);
-        log_debug("Loading initialisation SQL from: {}", sqlFilePath.c_str());
+        log_debug("Loading initialisation SQL from: {}", sqlFilePath);
         auto sql = readTextFile(sqlFilePath);
         auto&& myHash = stringHash(sql);
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -479,7 +479,7 @@ void SQLDatabase::upgradeDatabase(std::string&& dbVersion, const std::array<unsi
             }
             _exec(fmt::format(updateVersionCommand, version + 1, version));
             dbVersion = fmt::to_string(version + 1);
-            log_info("Database upgrade to version {} successful.", dbVersion.c_str());
+            log_info("Database upgrade to version {} successful.", dbVersion);
         }
         version++;
     }
@@ -1300,7 +1300,7 @@ void SQLDatabase::addContainerChain(std::string virtualPath, const std::string& 
 
 std::string SQLDatabase::addLocationPrefix(char prefix, const fs::path& path)
 {
-    return fmt::format("{}{}", prefix, path.string().c_str());
+    return fmt::format("{}{}", prefix, path.string());
 }
 
 fs::path SQLDatabase::stripLocationPrefix(std::string_view dbLocation, char* prefix)

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -70,7 +70,7 @@ void Sqlite3Database::init()
 
     // check for db-file
     if (access(dbFilePath.c_str(), R_OK | W_OK) != 0 && errno != ENOENT)
-        throw DatabaseException("", fmt::format("Error while accessing sqlite database file ({}): {}", dbFilePath.c_str(), std::strerror(errno)));
+        throw DatabaseException("", fmt::format("Error while accessing sqlite database file ({}): {}", dbFilePath, std::strerror(errno)));
 
     taskQueueOpen = true;
     threadRunner = std::make_unique<StdThreadRunner>("SQLiteThread", Sqlite3Database::staticThreadProc, this, config);
@@ -399,7 +399,7 @@ void SLTask::waitForTask()
     }
 
     if (!getError().empty()) {
-        log_debug("{}", getError().c_str());
+        log_debug("{}", getError());
         throw_std_runtime_error(getError());
     }
 }
@@ -417,7 +417,7 @@ void SLInitTask::run(sqlite3** db, Sqlite3Database* sl)
         throw DatabaseException("", "SQLite: Failed to create new database");
 
     auto sqlFilePath = config->getOption(CFG_SERVER_STORAGE_SQLITE_INIT_SQL_FILE);
-    log_debug("Loading initialisation SQL from: {}", sqlFilePath.c_str());
+    log_debug("Loading initialisation SQL from: {}", sqlFilePath);
     auto sql = readTextFile(sqlFilePath);
     auto&& myHash = stringHash(sql);
 

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -147,7 +147,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
         auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
                       ->getByName(tr_profile);
         if (!tp)
-            throw_std_runtime_error("Transcoding of file {} but no profile matching the name {} found", path.c_str(), tr_profile.c_str());
+            throw_std_runtime_error("Transcoding of file {} but no profile matching the name {} found", path.c_str(), tr_profile);
 
         mimeType = tp->getTargetMimeType();
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -275,7 +275,7 @@ int main(int argc, char** argv, char** envp)
                 log_error("Unable to change user.");
                 std::exit(EXIT_FAILURE);
             }
-            log_info("Dropped to User: {}", user->c_str());
+            log_info("Dropped to User: {}", *user);
         }
 
         // are we requested to daemonize?
@@ -453,7 +453,7 @@ int main(int argc, char** argv, char** envp)
             configManager->load(home.value_or(""));
             portnum = in_port_t(configManager->getIntOption(CFG_SERVER_PORT));
         } catch (const ConfigParseException& ce) {
-            log_error("Error parsing config file '{}': {}", (*config_file).c_str(), ce.what());
+            log_error("Error parsing config file '{}': {}", (*config_file), ce.what());
             std::exit(EXIT_FAILURE);
         } catch (const std::runtime_error& e) {
             log_error("{}", e.what());
@@ -521,7 +521,7 @@ int main(int argc, char** argv, char** envp)
                         asSetting.mergeOptions(configManager, f);
                         server->getContent()->addFile(dirEnt, asSetting, true);
                     } else {
-                        log_error("Failed to read {}: {}", f.c_str(), ec.message());
+                        log_error("Failed to read {}: {}", f, ec.message());
                     }
                 } catch (const std::runtime_error& e) {
                     log_error("{}", e.what());
@@ -551,7 +551,7 @@ int main(int argc, char** argv, char** envp)
                             ip.value_or(""), interface.value_or(""), portnum.value_or(-1),
                             debug);
                     } catch (const ConfigParseException& ce) {
-                        log_error("Error parsing config file '{}': {}", (*config_file).c_str(), ce.what());
+                        log_error("Error parsing config file '{}': {}", (*config_file), ce.what());
                         log_error("Could not restart Gerbera");
                         // at this point upnp shutdown has already been called
                         // so it is safe to exit
@@ -594,7 +594,7 @@ int main(int argc, char** argv, char** envp)
         }
 
         // remove pidfile if one was written
-        if (opts.count("pidfile") > 0) {
+        if (pidfile) {
             if (fs::remove(*pidfile)) {
                 log_debug("Pidfile {} removed.", pidfile->c_str());
             } else {

--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -68,7 +68,7 @@ void Exiv2Handler::fillMetadata(const std::shared_ptr<CdsObject>& item)
             // from YYYY:MM:DD to YYYY-MM-DD
             if (value.length() >= 11) {
                 value = fmt::format("{}-{}-{}", value.substr(0, 4), value.substr(5, 2), value.substr(8, 2));
-                log_debug("date: {}", value.c_str());
+                log_debug("date: {}", value);
                 item->addMetaData(M_DATE, value);
             }
         }
@@ -79,7 +79,7 @@ void Exiv2Handler::fillMetadata(const std::shared_ptr<CdsObject>& item)
             md = exifData.findKey(Exiv2::ExifKey("Exif.Photo.UserComment"));
             if (md != exifData.end())
                 comment = md->toString();
-            log_debug("Comment: {}", comment.c_str());
+            log_debug("Comment: {}", comment);
         }
 
         // if the image has no comment, compose something nice out of the exiv information

--- a/src/metadata/libexif_handler.cc
+++ b/src/metadata/libexif_handler.cc
@@ -168,7 +168,7 @@ static int getTagFromString(const std::string& tag)
     auto result = getValueOrDefault(exifTagMap, tag, -1);
 
     if (result == -1)
-        log_warning("Ignoring unknown libexif tag: {}", tag.c_str());
+        log_warning("Ignoring unknown libexif tag: {}", tag);
     return result;
 }
 

--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -258,7 +258,7 @@ void MatroskaHandler::addArtworkResource(const std::shared_ptr<CdsItem>& item, c
 {
     // if we could not determine the mimetype, then there is no
     // point to add the resource - it's probably garbage
-    log_debug("Found artwork of type {} in file {}", art_mimetype.c_str(), item->getLocation().c_str());
+    log_debug("Found artwork of type {} in file {}", art_mimetype, item->getLocation().c_str());
 
     if (art_mimetype != MIMETYPE_DEFAULT) {
         auto resource = std::make_shared<CdsResource>(CH_MATROSKA);

--- a/src/metadata/metacontent_handler.cc
+++ b/src/metadata/metacontent_handler.cc
@@ -80,7 +80,7 @@ std::vector<fs::path> ContentPathSetup::getContentPath(const std::shared_ptr<Cds
                 auto fileName = toLower(expandName(name, obj));
                 for (auto&& [f, s] : fileNames) {
                     if (f == fileName) {
-                        log_debug("{}: found", f.c_str());
+                        log_debug("{}: found", f);
                         result.push_back(s);
                     }
                 }
@@ -94,8 +94,8 @@ std::vector<fs::path> ContentPathSetup::getContentPath(const std::shared_ptr<Cds
                 if (extn.has_extension()) {
                     extn = isCaseSensitive ? extn.extension().string() : toLower(extn.extension().string());
                 } else {
-                    extn = isCaseSensitive ? fmt::format(".{}", ext) : toLower(fmt::format(".{}", ext));
-                    stem = "";
+                    extn = fmt::format(".{}", isCaseSensitive ? ext : toLower(ext));
+                    stem.clear();
                 }
                 std::error_code ec;
                 if (found.is_relative()) {
@@ -148,14 +148,14 @@ std::string ContentPathSetup::expandName(std::string_view name, const std::share
 
     if (obj->isItem()) {
         fs::path location = obj->getLocation();
-        replaceString(copy, "%filename%", location.stem().string().c_str());
+        replaceString(copy, "%filename%", location.stem().string());
     }
     if (obj->isContainer()) {
         auto title = obj->getTitle();
         if (!title.empty())
             replaceString(copy, "%filename%", title);
         fs::path location = obj->getLocation();
-        replaceString(copy, "%filename%", location.filename().string().c_str());
+        replaceString(copy, "%filename%", location.filename().string());
     }
     return copy;
 }
@@ -335,7 +335,7 @@ void ResourceHandler::fillMetadata(const std::shared_ptr<CdsObject>& obj)
         obj->removeResource(CH_RESOURCE);
 
     for (auto&& path : pathList) {
-        log_debug("Running resource handler check on {} -> {}", obj->getLocation().string().c_str(), path.string().c_str());
+        log_debug("Running resource handler check on {} -> {}", obj->getLocation().string(), path.string());
 
         if (!path.empty() && toLower(path.string()) == toLower(obj->getLocation().string())) {
             auto resource = std::make_shared<CdsResource>(CH_RESOURCE);
@@ -352,11 +352,11 @@ std::unique_ptr<IOHandler> ResourceHandler::serveContent(const std::shared_ptr<C
     if (path.empty()) {
         path = setup->getContentPath(obj, SETTING_RESOURCE)[0];
     }
-    log_debug("Resource: Opening name: {}", path.c_str());
+    log_debug("Resource: Opening name: {}", path.string());
     struct stat statbuf;
     int ret = stat(path.c_str(), &statbuf);
     if (ret != 0) {
-        log_warning("File does not exist: {} ({})", path.c_str(), std::strerror(errno));
+        log_warning("File does not exist: {} ({})", path.string(), std::strerror(errno));
         return nullptr;
     }
     return std::make_unique<FileIOHandler>(path);

--- a/src/metadata/taglib_handler.cc
+++ b/src/metadata/taglib_handler.cc
@@ -469,7 +469,7 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
                 }
             }
             if (!content.empty()) {
-                log_debug("Adding auxdata: {} with value '{}'", desiredFrame, fmt::join(content, entrySeparator));
+                log_debug("Adding auxdata: {} with value '{}'", desiredFrame, fmt::to_string(fmt::join(content, entrySeparator)));
                 item->setAuxData(desiredFrame, fmt::format("{}", fmt::join(content, entrySeparator)));
             }
         } else if (hasTXXXFrames && startswith(desiredFrame, "TXXX:")) {
@@ -497,13 +497,13 @@ void TagLibHandler::extractMP3(TagLib::IOStream* roStream, const std::shared_ptr
                             content.push_back(sc->convert(val.toCString(true)));
                     }
                 }
-                log_debug("TXXX Tag: {}", subTag.c_str());
+                log_debug("TXXX Tag: {}", subTag);
 
                 if (desiredSubTag == subTag && !content.empty()) {
                     if (content[0] == subTag)
                         content.erase(content.begin()); // Avoid leading tag for options unknown to taglib
 
-                    log_debug("Adding auxdata: '{}' with value '{}'", desiredFrame, fmt::join(content, entrySeparator));
+                    log_debug("Adding auxdata: '{}' with value '{}'", desiredFrame, fmt::to_string(fmt::join(content, entrySeparator)));
                     item->setAuxData(desiredFrame, fmt::format("{}", fmt::join(content, entrySeparator)));
                     break;
                 }

--- a/src/server.cc
+++ b/src/server.cc
@@ -114,7 +114,7 @@ void Server::run()
         iface = ipToInterface(ip);
 
     if (!ip.empty() && iface.empty())
-        throw_std_runtime_error("Could not find IP: {}", ip.c_str());
+        throw_std_runtime_error("Could not find IP: {}", ip);
 
     // check webroot directory
     std::string web_root = config->getOption(CFG_SERVER_WEBROOT);
@@ -132,9 +132,9 @@ void Server::run()
         throw UpnpException(ret, fmt::format("run: UpnpSetWebServerRootDir failed {}", web_root));
     }
 
-    log_debug("webroot: {}", web_root.c_str());
+    log_debug("webroot: {}", web_root);
 
-    log_debug("Setting virtual dir to: {}", virtual_directory.c_str());
+    log_debug("Setting virtual dir to: {}", virtual_directory);
     ret = UpnpAddVirtualDir(virtual_directory.c_str(), this, nullptr);
     if (ret != UPNP_E_SUCCESS) {
         throw UpnpException(ret, fmt::format("run: UpnpAddVirtualDir failed {}", virtual_directory));
@@ -272,7 +272,7 @@ void Server::writeBookmark(const std::string& addr)
 
 void Server::emptyBookmark()
 {
-    const std::string data = "<html><body><h1>Gerbera Media Server is not running.</h1><p>Please start it and try again.</p></body></html>";
+    const std::string_view data = "<html><body><h1>Gerbera Media Server is not running.</h1><p>Please start it and try again.</p></body></html>";
 
     fs::path path = config->getOption(CFG_SERVER_BOOKMARK_FILE);
     log_debug("Clearing bookmark file at: {}", path.c_str());
@@ -458,8 +458,7 @@ void Server::routeSubscriptionRequest(const std::unique_ptr<SubscriptionRequest>
     // make sure that the request is for our device
     if (request->getUDN() != serverUDN) {
         // not for us
-        log_debug("routeSubscriptionRequest: request not for this device: {} vs {}",
-            request->getUDN().c_str(), serverUDN.c_str());
+        log_debug("routeSubscriptionRequest: request not for this device: {} vs {}", request->getUDN(), serverUDN);
         throw UpnpException(UPNP_E_BAD_REQUEST, "routeActionRequest: request not for this device");
     }
 

--- a/src/transcoding/transcode_dispatcher.cc
+++ b/src/transcoding/transcode_dispatcher.cc
@@ -48,12 +48,12 @@ std::unique_ptr<IOHandler> TranscodeDispatcher::serveContent(std::shared_ptr<Tra
     std::string range)
 {
     if (!profile)
-        throw_std_runtime_error("Transcoding of file {} requested but no profile given ", location.c_str());
+        throw_std_runtime_error("Transcoding of file {} requested but no profile given ", location);
 
     if (profile->getType() == TR_External) {
         auto tr_ext = std::make_unique<TranscodeExternalHandler>(std::move(content));
         return tr_ext->serveContent(std::move(profile), std::move(location), std::move(obj), std::move(range));
     }
 
-    throw_std_runtime_error("Unknown transcoding type for profile {}", profile->getName().c_str());
+    throw_std_runtime_error("Unknown transcoding type for profile {}", profile->getName());
 }

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -110,7 +110,7 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(std::shared_pt
 
     std::vector<std::string> arglist = populateCommandLine(profile->getArguments(), location, fifo_name, range, obj->getTitle());
 
-    log_debug("Running profile command: '{}', arguments: '{}'", profile->getCommand().c_str(), fmt::join(arglist, " "));
+    log_debug("Running profile command: '{}', arguments: '{}'", profile->getCommand().c_str(), fmt::to_string(fmt::join(arglist, " ")));
     auto main_proc = std::make_shared<TranscodingProcessExecutor>(profile->getCommand(), arglist);
     main_proc->removeFile(fifo_name);
     if (isURL && (!profile->acceptURL())) {

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -72,7 +72,7 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     std::string sortCriteria = req_root.child("SortCriteria").text().as_string();
 
     log_debug("Browse received parameters: ObjectID [{}] BrowseFlag [{}] StartingIndex [{}] RequestedCount [{}] SortCriteria [{}]",
-        objID.c_str(), browseFlag.c_str(), startingIndex.c_str(), requestedCount.c_str(), sortCriteria.c_str());
+        objID, browseFlag, startingIndex, requestedCount, sortCriteria);
 
     if (objID.empty())
         throw UpnpException(UPNP_E_NO_SUCH_ID, "empty object id");
@@ -164,7 +164,7 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     std::string sortCriteria = req_root.child("SortCriteria").text().as_string();
 
     log_debug("Search received parameters: ContainerID [{}] SearchCriteria [{}] StartingIndex [{}] RequestedCount [{}] RequestedCount [{}]",
-        containerID.c_str(), searchCriteria.c_str(), startingIndex.c_str(), requestedCount.c_str(), requestedCount.c_str());
+        containerID, searchCriteria, startingIndex, requestedCount, requestedCount);
 
     pugi::xml_document didl_lite;
     auto decl = didl_lite.prepend_child(pugi::node_declaration);

--- a/src/upnp_mrreg.cc
+++ b/src/upnp_mrreg.cc
@@ -95,7 +95,7 @@ void MRRegistrarService::processActionRequest(const std::unique_ptr<ActionReques
         doIsValidated(request);
     } else {
         // invalid or unsupported action
-        log_debug("unrecognized action {}", request->getActionName().c_str());
+        log_debug("unrecognized action {}", request->getActionName());
         request->setErrorCode(UPNP_E_INVALID_ACTION);
         //throw UpnpException(UPNP_E_INVALID_ACTION, "unrecognized action");
     }

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -59,7 +59,7 @@ UpnpXMLBuilder::UpnpXMLBuilder(const std::shared_ptr<Context>& context,
 std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createResponse(const std::string& actionName, const std::string& serviceType)
 {
     auto response = std::make_unique<pugi::xml_document>();
-    auto root = response->append_child(fmt::format("u:{}Response", actionName.c_str()).c_str());
+    auto root = response->append_child(fmt::format("u:{}Response", actionName).c_str());
     root.append_attribute("xmlns:u") = serviceType.c_str();
 
     return response;
@@ -378,11 +378,11 @@ std::string UpnpXMLBuilder::getFirstResourcePath(const std::shared_ptr<CdsItem>&
     }
 
     if (urlBase->addResID) { // a proxy, remote, resource
-        return fmt::format(SERVER_VIRTUAL_DIR "{}0", urlBase->pathBase.c_str());
+        return fmt::format(SERVER_VIRTUAL_DIR "{}0", urlBase->pathBase);
     }
 
     // a local resource
-    return fmt::format(SERVER_VIRTUAL_DIR "{}", urlBase->pathBase.c_str());
+    return fmt::format(SERVER_VIRTUAL_DIR "{}", urlBase->pathBase);
 }
 
 std::string UpnpXMLBuilder::getArtworkUrl(const std::shared_ptr<CdsItem>& item) const
@@ -433,7 +433,7 @@ std::string UpnpXMLBuilder::renderOneResource(const std::string& virtualURL, con
     auto urlBase = getPathBase(item);
     std::string url;
     if (urlBase->addResID) {
-        url = fmt::format("{}{}{}{}", virtualURL.c_str(), urlBase->pathBase.c_str(), res->getResId(), _URL_PARAM_SEPARATOR);
+        url = fmt::format("{}{}{}{}", virtualURL, urlBase->pathBase, res->getResId(), _URL_PARAM_SEPARATOR);
     } else
         url = virtualURL + urlBase->pathBase;
 

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -71,7 +71,7 @@ void URLRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
         auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
                       ->getByName(tr_profile);
         if (!tp)
-            throw_std_runtime_error("Transcoding requested but no profile matching the name {} found", tr_profile.c_str());
+            throw_std_runtime_error("Transcoding requested but no profile matching the name {} found", tr_profile);
 
         mimeType = tp->getTargetMimeType();
         UpnpFileInfo_set_FileLength(info, -1);
@@ -81,12 +81,12 @@ void URLRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 #else
         std::string url = item->getLocation();
 #endif
-        log_debug("Online content url: {}", url.c_str());
+        log_debug("Online content url: {}", url);
         try {
             auto st = URL::getInfo(url);
             UpnpFileInfo_set_FileLength(info, st->getSize());
             header = "Accept-Ranges: bytes";
-            log_debug("URL used for request: {}", st->getURL().c_str());
+            log_debug("URL used for request: {}", st->getURL());
         } catch (const std::runtime_error& ex) {
             log_warning("{}", ex.what());
             UpnpFileInfo_set_FileLength(info, -1);
@@ -136,14 +136,14 @@ std::unique_ptr<IOHandler> URLRequestHandler::open(const char* filename, enum Up
 #else
     std::string url = item->getLocation();
 #endif
-    log_debug("Online content url: {}", url.c_str());
+    log_debug("Online content url: {}", url);
 
     std::string tr_profile = getValueOrDefault(params, URL_PARAM_TRANSCODE_PROFILE_NAME);
     if (!tr_profile.empty()) {
         auto tp = config->getTranscodingProfileListOption(CFG_TRANSCODING_PROFILE_LIST)
                       ->getByName(tr_profile);
         if (!tp)
-            throw_std_runtime_error("Transcoding of file {} but no profile matching the name {} found", url.c_str(), tr_profile.c_str());
+            throw_std_runtime_error("Transcoding of file {} but no profile matching the name {} found", url, tr_profile);
 
         auto tr_d = std::make_unique<TranscodeDispatcher>(content);
         auto io_handler = tr_d->serveContent(tp, url, item, "");

--- a/src/util/process_executor.cc
+++ b/src/util/process_executor.cc
@@ -56,19 +56,19 @@ ProcessExecutor::ProcessExecutor(const std::string& command, const std::vector<s
     process_id = fork();
     switch (process_id) {
     case -1:
-        throw_std_runtime_error("Failed to launch process {}", command.c_str());
+        throw_std_runtime_error("Failed to launch process {}", command);
 
     case 0:
         sigset_t mask_set;
         pthread_sigmask(SIG_SETMASK, &mask_set, nullptr);
-        log_debug("Launching process: {}", command.c_str());
+        log_debug("Launching process: {}", command);
         execvp(command.c_str(), const_cast<char**>(argv));
         break;
     default:
         break;
     }
 
-    log_debug("Launched process {}, pid: {}", command.c_str(), process_id);
+    log_debug("Launched process {}, pid: {}", command, process_id);
 }
 
 bool ProcessExecutor::isAlive()

--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -164,7 +164,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
             break;
         }
         *output_copy = 0;
-        log_error("{}", err.c_str());
+        log_error("{}", err);
         //        log_debug("iconv: input: {}", input);
         //        log_debug("iconv: converted part:  {}", output);
         dirty = true;

--- a/src/util/thread_runner.h
+++ b/src/util/thread_runner.h
@@ -57,7 +57,7 @@ public:
 
     ~ThreadRunner() override
     {
-        log_debug("ThreadRunner: Destroying {}", threadName.c_str());
+        log_debug("ThreadRunner: Destroying {}", threadName);
         if (attr) {
             pthread_attr_destroy(attr);
             delete attr;
@@ -171,7 +171,7 @@ protected:
     void threadProc() override
     {
         targetProc(target);
-        log_debug("ThreadRunner: Terminating {}", threadName.c_str());
+        log_debug("ThreadRunner: Terminating {}", threadName);
     }
 
     /// \brief start the thread
@@ -197,7 +197,7 @@ protected:
             this);
 
         if (ret != 0) {
-            log_error("Could not start thread {}: {}", threadName.c_str(), std::strerror(ret));
+            log_error("Could not start thread {}: {}", threadName, std::strerror(ret));
         } else {
             threadRunning = true;
         }

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -211,7 +211,7 @@ bool Clients::getInfoByAddr(const struct sockaddr_storage* addr, const ClientInf
     if (it != clientInfo.end()) {
         *ppInfo = &(*it);
         auto ip = getHostName(reinterpret_cast<const struct sockaddr*>(addr));
-        log_debug("found client by IP (ip='{}')", ip.c_str());
+        log_debug("found client by IP (ip='{}')", ip);
         return true;
     }
 
@@ -225,7 +225,7 @@ bool Clients::getInfoByType(const std::string& match, ClientMatchType type, cons
         auto it = std::find_if(clientInfo.rbegin(), clientInfo.rend(), [=](auto&& c) { return c.matchType == type && match.find(c.match) != std::string::npos; });
         if (it != clientInfo.rend()) {
             *ppInfo = &(*it);
-            log_debug("found client by type (match='{}')", match.c_str());
+            log_debug("found client by type (match='{}')", match);
             return true;
         }
     }
@@ -244,7 +244,7 @@ bool Clients::getInfoByCache(const struct sockaddr_storage* addr, const ClientIn
     if (it != cache.end()) {
         *ppInfo = it->pInfo;
         auto hostName = getHostName(reinterpret_cast<const struct sockaddr*>(&it->addr));
-        log_debug("found client by cache (hostname='{}')", hostName.c_str());
+        log_debug("found client by cache (hostname='{}')", hostName);
         return true;
     }
 

--- a/src/util/upnp_headers.cc
+++ b/src/util/upnp_headers.cc
@@ -63,7 +63,7 @@ void Headers::addHeader(const std::string& key, const std::string& value)
         return;
     }
 
-    log_debug("Adding header: '{}: {}'", cleanKey.c_str(), cleanValue.c_str());
+    log_debug("Adding header: '{}: {}'", cleanKey, cleanValue);
     headers.emplace(cleanKey, cleanValue);
 }
 

--- a/src/web/action.cc
+++ b/src/web/action.cc
@@ -47,7 +47,7 @@ void Web::Action::process()
     std::string action = param("action");
     if (action.empty())
         throw_std_runtime_error("No action given");
-    log_debug("action: {}", action.c_str());
+    log_debug("action: {}", action);
 
     log_debug("action: returning");
 }

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -399,7 +399,7 @@ void Web::ConfigLoad::process()
             if (!fourCCList.empty()) {
                 item = values.append_child("item");
                 createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC), cs->option, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC);
-                setValue(item, std::accumulate(next(fourCCList.begin()), fourCCList.end(), fourCCList[0], [](auto&& a, auto&& b) { return fmt::format("{}, {}", a.c_str(), b.c_str()); }));
+                setValue(item, std::accumulate(next(fourCCList.begin()), fourCCList.end(), fourCCList[0], [](auto&& a, auto&& b) { return fmt::format("{}, {}", a, b); }));
             }
         }
         pr++;

--- a/src/web/config_save.cc
+++ b/src/web/config_save.cc
@@ -170,7 +170,7 @@ void Web::ConfigSave::process()
                 taskEl.append_attribute("text") = fmt::format("Rescanning directory {}", target).c_str();
                 log_info("Rescanning directory {}", target);
             } else {
-                log_error("No such autoscan or dir: {} ({})", target.c_str(), objectID);
+                log_error("No such autoscan or dir: {} ({})", target, objectID);
             }
         } else {
             auto autoScans = content->getAutoscanDirectories();

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -162,21 +162,21 @@ void Web::EditLoad::process()
         // write resource parameters
         for (auto&& [key, val] : resItem->getParameters()) {
             auto resEntry = resources.append_child("resources");
-            resEntry.append_attribute("resname") = fmt::format(".{}", key.c_str()).c_str();
+            resEntry.append_attribute("resname") = fmt::format(".{}", key).c_str();
             resEntry.append_attribute("resvalue") = val.c_str();
             resEntry.append_attribute("editable") = false;
         }
         // write resource attributes
         for (auto&& [key, val] : resItem->getAttributes()) {
             auto resEntry = resources.append_child("resources");
-            resEntry.append_attribute("resname") = fmt::format(" {}", key.c_str()).c_str();
+            resEntry.append_attribute("resname") = fmt::format(" {}", key).c_str();
             resEntry.append_attribute("resvalue") = val.c_str();
             resEntry.append_attribute("editable") = false;
         }
         // write resource options
         for (auto&& [key, val] : resItem->getOptions()) {
             auto resEntry = resources.append_child("resources");
-            resEntry.append_attribute("resname") = fmt::format("-{}", key.c_str()).c_str();
+            resEntry.append_attribute("resname") = fmt::format("-{}", key).c_str();
             resEntry.append_attribute("resvalue") = val.c_str();
             resEntry.append_attribute("editable") = false;
         }

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -234,7 +234,7 @@ void SessionManager::timerNotify(std::shared_ptr<Timer::Parameter> parameter)
         auto&& session = *it;
 
         if (getDeltaMillis(session->getLastAccessTime(), now) > session->getTimeout()) {
-            log_debug("session timeout: {} - diff: {}", session->getID().c_str(), getDeltaMillis(session->getLastAccessTime(), now).count());
+            log_debug("session timeout: {} - diff: {}", session->getID(), getDeltaMillis(session->getLastAccessTime(), now).count());
             checkTimer();
             it = sessions.erase(it);
             continue;

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -247,7 +247,7 @@ void WebRequestHandler::addUpdateIDs(const std::shared_ptr<Session>& session, pu
 {
     std::string updateIDs = session->getUIUpdateIDs();
     if (!updateIDs.empty()) {
-        log_debug("UI: sending update ids: {}", updateIDs.c_str());
+        log_debug("UI: sending update ids: {}", updateIDs);
         updateIDsEl->append_attribute("ids") = updateIDs.c_str();
         updateIDsEl->append_attribute("updates") = true;
     }


### PR DESCRIPTION
There are many calls to fmt::format (or spdlog calls) that call .c_str() on std::string. This makes the code less readable and throws away the string-length information (requires fmt to call strlen). I did a manual search-replace to find such calls and remove the .c_str() call whereever suitable.