### PR TITLE
Use better primary key for grb_cds_resource 

### DIFF
--- a/src/database/mysql/mysql-upgrade.xml
+++ b/src/database/mysql/mysql-upgrade.xml
@@ -79,4 +79,9 @@
     <version number="14" remark="drop redundant index">
         <script>DROP INDEX `grb_config_value_item` ON `grb_config_value`</script>
     </version>
+    <version number="15" remark="Replace primary key on grb_cds_resource">
+        <script>DROP INDEX `grb_cds_resource_id` ON `grb_cds_resource`</script>
+        <script>ALTER TABLE `grb_cds_resource` DROP COLUMN `id`</script>
+        <script>ALTER TABLE `grb_cds_resource` ADD PRIMARY KEY (`item_id`, `res_id`)</script>
+    </version>
 </upgrade>

--- a/src/database/mysql/mysql.sql
+++ b/src/database/mysql/mysql.sql
@@ -83,16 +83,15 @@ CREATE TABLE `grb_config_value` (
   `status` varchar(20) NOT NULL)
   ENGINE=MyISAM CHARSET=utf8;
 CREATE TABLE `grb_cds_resource` (
-    `id` int(11) primary key auto_increment,
     `item_id` int(11) NOT NULL,
     `res_id` int(11) NOT NULL,
     `handlerType` int(11) NOT NULL,
     `options` text default NULL,
     `parameters` text default NULL,
+    PRIMARY KEY (`item_id`, `res_id`),
     CONSTRAINT `grb_cds_resource_fk` FOREIGN KEY (`item_id`) REFERENCES `mt_cds_object` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=MyISAM CHARSET=utf8;
 INSERT INTO `mt_internal_setting` VALUES('resource_attribute', '');
-CREATE INDEX `grb_cds_resource_id` ON `grb_cds_resource`(`item_id`,`res_id`);
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -56,7 +56,7 @@ MySQLDatabase::MySQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mim
     table_quote_end = '`';
 
     // if mysql.sql or mysql-upgrade.xml is changed hashies have to be updated, index 0 is used for create script
-    hashies = { 878627993, 928913698, 1984244483, 2241152998, 1748460509, 2860006966, 974692115, 70310290, 1863649106, 4238128129, 2979337694, 1512596496, 507706380, 3545156190 };
+    hashies = { 2405141071, 928913698, 1984244483, 2241152998, 1748460509, 2860006966, 974692115, 70310290, 1863649106, 4238128129, 2979337694, 1512596496, 507706380, 3545156190, 31528140 };
 }
 
 MySQLDatabase::~MySQLDatabase()

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -183,7 +183,7 @@ void MySQLDatabase::init()
         log_info("Database created successfully!");
     }
 
-    upgradeDatabase(std::move(dbVersion), hashies, CFG_SERVER_STORAGE_MYSQL_UPGRADE_FILE, MYSQL_UPDATE_VERSION, MYSQL_ADD_RESOURCE_ATTR);
+    upgradeDatabase(std::stoul(dbVersion), hashies, CFG_SERVER_STORAGE_MYSQL_UPGRADE_FILE, MYSQL_UPDATE_VERSION, MYSQL_ADD_RESOURCE_ATTR);
 
     lock.unlock();
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -120,8 +120,7 @@ enum class MetadataCol {
 
 /// \brief resource column ids
 enum class ResourceCol {
-    Id = 0,
-    ItemId,
+    ItemId = 0,
     ResId,
     HandlerType,
     Options,
@@ -332,14 +331,12 @@ void SQLDatabase::init()
     // entries are handled sequentially,
     // duplicate entries are added to statement in same order if key is present in SortCriteria
     std::vector<std::pair<std::string, int>> resourceTagMap {
-        { "id", to_underlying(ResourceCol::Id) },
         { UPNP_SEARCH_ID, to_underlying(ResourceCol::ItemId) },
         { "res@id", to_underlying(ResourceCol::ResId) },
     };
     /// \brief Map resource column ids to column names
     // map ensures entries are in correct order, each value of ResourceCol must be present
     std::map<int, std::pair<std::string, std::string>> resourceColMap {
-        { to_underlying(ResourceCol::Id), { RES_ALIAS, "id" } },
         { to_underlying(ResourceCol::ItemId), { RES_ALIAS, "item_id" } },
         { to_underlying(ResourceCol::ResId), { RES_ALIAS, "res_id" } },
         { to_underlying(ResourceCol::HandlerType), { RES_ALIAS, "handlerType" } },
@@ -2347,8 +2344,8 @@ void SQLDatabase::generateMetaDataDBOperations(const std::shared_ptr<CdsObject>&
 
 std::vector<std::shared_ptr<CdsResource>> SQLDatabase::retrieveResourcesForObject(int objectId)
 {
-    auto rsql = fmt::format("{3} FROM {0}{2}{1} WHERE {0}item_id{1} = {4} ORDER BY {0}res_id{1}",
-        table_quote_begin, table_quote_end, RESOURCE_TABLE, sql_resource_query, objectId);
+    auto rsql = fmt::format("{} FROM {} WHERE {} = {} ORDER BY {}",
+        sql_resource_query, identifier(RESOURCE_TABLE), identifier("item_id"), objectId, identifier("res_id"));
     log_debug("SQLDatabase::retrieveResourcesForObject {}", rsql);
     auto&& res = select(rsql);
 
@@ -2607,8 +2604,7 @@ bool SQLDatabase::doResourceMigration()
     log_debug("{} rows having resources: {}", CDS_OBJECT_TABLE, expectedConversionCount);
 
     res = select(
-        fmt::format("SELECT COUNT(*) FROM {}",
-            identifier(RESOURCE_TABLE)));
+        fmt::format("SELECT COUNT(*) FROM {}", identifier(RESOURCE_TABLE)));
     int resourceRowCount = res->nextRow()->col_int(0, 0);
     log_debug("{} rows having entries: {}", RESOURCE_TABLE, resourceRowCount);
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -112,8 +112,7 @@ enum class SearchCol {
 
 /// \brief meta column ids
 enum class MetadataCol {
-    Id = 0,
-    ItemId,
+    ItemId = 0,
     PropertyName,
     PropertyValue
 };
@@ -200,7 +199,6 @@ static const std::map<SearchCol, std::pair<std::string, std::string>> searchColM
 /// \brief Map meta column ids to column names
 // map ensures entries are in correct order, each value of MetadataCol must be present
 static const std::map<MetadataCol, std::pair<std::string, std::string>> metaColMap {
-    { MetadataCol::Id, { MTA_ALIAS, "id" } },
     { MetadataCol::ItemId, { MTA_ALIAS, "item_id" } },
     { MetadataCol::PropertyName, { MTA_ALIAS, "property_name" } },
     { MetadataCol::PropertyValue, { MTA_ALIAS, "property_value" } },
@@ -265,7 +263,6 @@ static const std::vector<std::pair<std::string, SearchCol>> searchSortMap {
 // entries are handled sequentially,
 // duplicate entries are added to statement in same order if key is present in SortCriteria
 static const std::vector<std::pair<std::string, MetadataCol>> metaTagMap {
-    { "id", MetadataCol::Id },
     { UPNP_SEARCH_ID, MetadataCol::ItemId },
     { META_NAME, MetadataCol::PropertyName },
     { META_VALUE, MetadataCol::PropertyValue },

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -213,7 +213,7 @@ protected:
     using SqlAutoLock = std::lock_guard<decltype(sqlMutex)>;
     std::map<int, std::shared_ptr<CdsContainer>> dynamicContainers;
 
-    void upgradeDatabase(std::string&& dbVersion, const std::array<unsigned int, DBVERSION>& hashies, config_option_t upgradeOption, const std::string& updateVersionCommand, const std::string& addResourceColumnCmd);
+    void upgradeDatabase(unsigned int dbVersion, const std::array<unsigned int, DBVERSION>& hashies, config_option_t upgradeOption, const std::string& updateVersionCommand, const std::string& addResourceColumnCmd);
     virtual void _exec(const std::string& query) = 0;
 
 private:

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -48,7 +48,7 @@ class CdsResource;
 class SQLResult;
 class SQLEmitter;
 
-#define DBVERSION 14
+#define DBVERSION 15
 
 #define CDS_OBJECT_TABLE "mt_cds_object"
 #define INTERNAL_SETTINGS_TABLE "mt_internal_setting"

--- a/src/database/sqlite3/sqlite3-upgrade.xml
+++ b/src/database/sqlite3/sqlite3-upgrade.xml
@@ -181,4 +181,25 @@
     <version number="14" remark="drop redundant index">
         <script>DROP INDEX grb_config_value_item;</script>
     </version>
+    <version number="15" remark="Replace primary key on grb_cds_resource">
+        <script>
+        CREATE TABLE "grb_cds_resource_new" (
+            "item_id" integer NOT NULL,
+            "res_id" integer NOT NULL,
+            "handlerType" integer NOT NULL,
+            "options" text default NULL,
+            "parameters" text default NULL,
+            "size" varchar(255) default NULL, "duration" varchar(255) default NULL, "bitrate" varchar(255) default NULL, "sampleFrequency" varchar(255) default NULL, "nrAudioChannels" varchar(255) default NULL, "resolution" varchar(255) default NULL, "colorDepth" varchar(255) default NULL, "protocolInfo" varchar(255) default NULL, "resFile" varchar(255) default NULL, "type" varchar(255) default NULL, "fanArtObject" varchar(255) default NULL, "fanArtResource" varchar(255) default NULL, "bitsPerSample" varchar(255) default NULL, "dc:language" varchar(255) default NULL, "sec:acodec" varchar(255) default NULL, "sec:vcodec" varchar(255) default NULL,
+            PRIMARY KEY ("item_id", "res_id"),
+            CONSTRAINT "grb_cds_resource_fk" FOREIGN KEY ("item_id") REFERENCES "mt_cds_object" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+        );
+        INSERT INTO "grb_cds_resource_new" (
+            "item_id", "res_id", "handlerType", "options", "parameters", "size", "duration", "bitrate", "sampleFrequency", "nrAudioChannels", "resolution", "colorDepth", "protocolInfo", "resFile", "type", "fanArtObject", "fanArtResource", "bitsPerSample", "dc:language", "sec:acodec", "sec:vcodec"
+        ) SELECT
+            "item_id", "res_id", "handlerType", "options", "parameters", "size", "duration", "bitrate", "sampleFrequency", "nrAudioChannels", "resolution", "colorDepth", "protocolInfo", "resFile", "type", "fanArtObject", "fanArtResource", "bitsPerSample", "dc:language", "sec:acodec", "sec:vcodec"
+        FROM "grb_cds_resource";
+        DROP TABLE grb_cds_resource;
+        ALTER TABLE grb_cds_resource_new RENAME TO grb_cds_resource;
+        </script>
+    </version>
 </upgrade>

--- a/src/database/sqlite3/sqlite3.sql
+++ b/src/database/sqlite3/sqlite3.sql
@@ -63,16 +63,15 @@ CREATE TABLE "grb_config_value" (
   "status" varchar(20) NOT NULL
 );
 CREATE TABLE "grb_cds_resource" (
-    "id" integer primary key,
     "item_id" integer NOT NULL,
     "res_id" integer NOT NULL,
     "handlerType" integer NOT NULL,
     "options" text default NULL,
     "parameters" text default NULL,
+    PRIMARY KEY ("item_id", "res_id"),
     CONSTRAINT "grb_cds_resource_fk" FOREIGN KEY ("item_id") REFERENCES "mt_cds_object" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );
 INSERT INTO "mt_internal_setting" VALUES('resource_attribute', '');
-CREATE INDEX grb_cds_resource_id ON grb_cds_resource(item_id,res_id);
 CREATE INDEX mt_cds_object_ref_id ON mt_cds_object(ref_id);
 CREATE INDEX mt_cds_object_parent_id ON mt_cds_object(parent_id,object_type,dc_title);
 CREATE INDEX mt_object_type ON mt_cds_object(object_type);

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -49,7 +49,7 @@ Sqlite3Database::Sqlite3Database(std::shared_ptr<Config> config, std::shared_ptr
     table_quote_end = '"';
 
     // if sqlite3.sql or sqlite3-upgrade.xml is changed hashies have to be updated, index 0 is used for create script
-    hashies = { 3888119908, 778996897, 3362507034, 853149842, 4035419264, 3497064885, 974692115, 119767663, 3167732653, 2427825904, 3305506356, 43189396, 2767540493, 2512852146 };
+    hashies = { 3035716215, 778996897, 3362507034, 853149842, 4035419264, 3497064885, 974692115, 119767663, 3167732653, 2427825904, 3305506356, 43189396, 2767540493, 2512852146, 1273710965 };
 }
 
 void Sqlite3Database::prepare()

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -142,7 +142,7 @@ void Sqlite3Database::init()
     }
 
     try {
-        upgradeDatabase(std::move(dbVersion), hashies, CFG_SERVER_STORAGE_SQLITE_UPGRADE_FILE, SQLITE3_UPDATE_VERSION, SQLITE3_ADD_RESOURCE_ATTR);
+        upgradeDatabase(std::stoul(dbVersion), hashies, CFG_SERVER_STORAGE_SQLITE_UPGRADE_FILE, SQLITE3_UPDATE_VERSION, SQLITE3_ADD_RESOURCE_ATTR);
         if (config->getBoolOption(CFG_SERVER_STORAGE_SQLITE_BACKUP_ENABLED) && timer) {
             // do a backup now
             auto btask = std::make_shared<SLBackupTask>(config, false);


### PR DESCRIPTION
In database table `grb_cds_resource`, there is a primary key `id` which is not used anywhere in the code. What is actually used is the tuple `(item_id, res_id)` which is perfectly suited as a primary key. `item_id` is a foreign key and `res_id` is always created such that there are only unique `(item_id, res_id)` pairs.
In addition, with the new primary key, we can drop the index on `(item_id, res_id)`.

This change should not change the behavior of the current code but reduce the database size (fewer columns, fewer indices) as well as increase the speed of creating a database (no additional index update).