### PR TITLE
Add all metadata to search capabilities

### DIFF
--- a/doc/config-server.rst
+++ b/doc/config-server.rst
@@ -805,7 +805,7 @@ This section defines the properties which are send to UPnP clients as part of th
 
         Name of the metadata tag to export in upnp response. The following values are supported: 
         M_TITLE, M_ARTIST, M_ALBUM, M_DATE, M_UPNP_DATE, M_GENRE, M_DESCRIPTION, M_LONGDESCRIPTION, 
-        M_PARTNUMBER, M_TRACKNUMBER, M_ALBUMARTURI, M_REGION, M_AUTHOR, M_DIRECTOR, M_PUBLISHER, 
+        M_PARTNUMBER, M_TRACKNUMBER, M_ALBUMARTURI, M_REGION, M_CREATOR, M_AUTHOR, M_DIRECTOR, M_PUBLISHER, 
         M_RATING, M_ACTOR, M_PRODUCER, M_ALBUMARTIST, M_COMPOSER, M_CONDUCTOR, M_ORCHESTRA.
 
         Instead of metadata, you may also use auxdata entries as defined in ``library-options``.

--- a/doc/scripting.rst
+++ b/doc/scripting.rst
@@ -222,99 +222,47 @@ object.
 
     Array holding the metadata that was extracted from the object (i.e. id3/exif/etc. information). Each value is a list of strings regardless whether the source tag is multi valued or not.
 
+    +---------------+--------------------------------------------------------+------------------------------+
+    | Key           | Description                                            | DIDL-Lite XML element        |
+    +===============+========================================================+==============================+
+    | M_TITLE       | | Extracted title (for example the id3 title if the    | ``dc:title``                 |
+    |               | | object is an mp3 file), if you want that your new    |                              |
+    |               | | virtual object is displayed under this title you will|                              |
+    |               | | have to set ``obj.title = orig.meta[M_TITLE][0]``    |                              |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_ARTIST      | Artist information                                     | ``upnp:artist``              |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_ALBUM       | Album information                                      | ``upnp:album``               |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_DATE        | Date, must be in the format of **YYYY-MM-DD**          | ``dc:date``                  |
+    |               | (required by the UPnP spec)                            |                              |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_GENRE       | Genre of the item                                      | ``upnp:genre``               |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_DESCRIPTION | Description of the item                                | ``dc:description``           |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_REGION      | Region description of the item                         | ``upnp:region``              |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_TRACKNUMBER | Track number of the item                               | ``upnp:originalTrackNumber`` |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_PARTNUMBER  | Part number of the item.                               | ``upnp:episodeSeason``       |
+    |               | This contains the disc number for audio tracks.        |                              |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_CREATOR     | Creator of the media                                   | ``dc:creator``               |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_AUTHOR      | Author of the media                                    | ``upnp:author``              |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_DIRECTOR    | Director of the media                                  | ``upnp:director``            |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_PUBLISHER   | Publisher of the media                                 | ``dc:publisher``             |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_RATING      | Rating of the media                                    | ``upnp:rating``              |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_ACTOR       | Actor of the media                                     | ``upnp:actor``               |
+    +---------------+--------------------------------------------------------+------------------------------+
+    | M_PRODUCER    | Producer of the media                                  | ``upnp:producer``            |
+    +---------------+--------------------------------------------------------+------------------------------+
 
-    .. js:attribute:: orig.metaData[M_TITLE]
-
-        **RW**
-
-        Extracted title (for example the id3 title if the object is an mp3 file), if you want that your new
-        virtual object is displayed under this title you will have to set `obj.title = orig.meta[M_TITLE][0]`
-
-    .. js:attribute:: orig.metaData[M_ARTIST]
-
-        **RW**
-
-        Artist information, this corresponds to ``upnp:artist`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_ALBUM]
-
-        **RW**
-
-        Album information, this corresponds to ``upnp:album`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_DATE]
-
-        **RW**
-
-        Date, must be in the format of **YYYY-MM-DD** (required by the UPnP spec), this corresponds to ``dc:date`` in the
-        DIDL-Lite XML.
-
-
-    .. js:attribute:: orig.metaData[M_GENRE]
-
-        **RW**
-
-        Genre of the item, this corresponds to ``upnp:genre`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_DESCRIPTION]
-
-        **RW**
-
-        Description of the item, this corresponds to ``dc:description`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_REGION]
-
-        **RW**
-
-        Region description of the item, this corresponds to ``upnp:region`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_TRACKNUMBER]
-
-        **RW**
-
-        Track number of the item, this corresponds to ``upnp:originalTrackNumber`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_PARTNUMBER]
-
-        **RW**
-
-        Part number of the item. This contains the disc number for audio tracks.
-
-    .. js:attribute:: orig.metaData[M_AUTHOR]
-
-        **RW**
-
-        Author of the media, this corresponds to ``upnp:author`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_DIRECTOR]
-
-        **RW**
-
-        Director of the media, this corresponds to ``upnp:director`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_PUBLISHER]
-
-        **RW**
-
-        Publisher of the media, this corresponds to ``dc:publisher`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_RATING]
-
-        **RW**
-    
-        Rating of the media, this corresponds to ``upnp:rating`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_ACTOR]
-
-        **RW**
-
-        Actor of the media, this corresponds to ``upnp:actor`` in the DIDL-Lite XML.
-
-    .. js:attribute:: orig.metaData[M_PRODUCER]
-
-        **RW**
-
-        Producer of the media, this corresponds to ``upnp:producer`` in the DIDL-Lite XML.
 
 .. js:attribute:: orig.aux
 

--- a/src/content/scripting/script_names.h
+++ b/src/content/scripting/script_names.h
@@ -64,6 +64,7 @@ static constexpr auto mt_names = std::array<std::pair<metadata_fields_t, const c
     std::pair(M_PARTNUMBER, "M_PARTNUMBER"),
     std::pair(M_ALBUMARTURI, "M_ALBUMARTURI"),
     std::pair(M_REGION, "M_REGION"),
+    std::pair(M_CREATOR, "M_CREATOR"),
     std::pair(M_AUTHOR, "M_AUTHOR"),
     std::pair(M_DIRECTOR, "M_DIRECTOR"),
     std::pair(M_PUBLISHER, "M_PUBLISHER"),

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -509,11 +509,14 @@ std::string SQLDatabase::getSortCapabilities()
 std::string SQLDatabase::getSearchCapabilities()
 {
     auto searchKeys = std::vector {
-        MetadataHandler::getMetaFieldName(M_TITLE),
         std::string(UPNP_SEARCH_CLASS),
+        MetadataHandler::getMetaFieldName(M_TITLE),
+        MetadataHandler::getMetaFieldName(M_CREATOR), // required by HEOS for artist search
         MetadataHandler::getMetaFieldName(M_ARTIST),
+        MetadataHandler::getMetaFieldName(M_ALBUMARTIST),
         MetadataHandler::getMetaFieldName(M_ALBUM),
         MetadataHandler::getMetaFieldName(M_GENRE),
+        std::string("res"),
     };
     for (auto&& resAttrId : ResourceAttributeIterator()) {
         auto attrName = MetadataHandler::getResAttrName(resAttrId);

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -510,14 +510,12 @@ std::string SQLDatabase::getSearchCapabilities()
 {
     auto searchKeys = std::vector {
         std::string(UPNP_SEARCH_CLASS),
-        MetadataHandler::getMetaFieldName(M_TITLE),
-        MetadataHandler::getMetaFieldName(M_CREATOR), // required by HEOS for artist search
-        MetadataHandler::getMetaFieldName(M_ARTIST),
-        MetadataHandler::getMetaFieldName(M_ALBUMARTIST),
-        MetadataHandler::getMetaFieldName(M_ALBUM),
-        MetadataHandler::getMetaFieldName(M_GENRE),
-        std::string("res"),
     };
+    searchKeys.reserve(M_MAX + R_MAX);
+    for (auto&& [field, meta] : mt_keys) {
+        searchKeys.emplace_back(meta);
+    }
+    searchKeys.emplace_back("res");
     for (auto&& resAttrId : ResourceAttributeIterator()) {
         auto attrName = MetadataHandler::getResAttrName(resAttrId);
         searchKeys.push_back(fmt::format("res@{}", attrName));

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -104,6 +104,7 @@ enum metadata_fields_t {
     M_ALBUMARTURI,
     M_REGION,
     /// \todo make sure that those are only used with appropriate upnp classes
+    M_CREATOR,
     M_AUTHOR,
     M_DIRECTOR,
     M_PUBLISHER,
@@ -134,6 +135,7 @@ static constexpr auto mt_keys = std::array<std::pair<metadata_fields_t, const ch
     std::pair(M_TRACKNUMBER, "upnp:originalTrackNumber"),
     std::pair(M_ALBUMARTURI, "upnp:albumArtURI"),
     std::pair(M_REGION, "upnp:region"),
+    std::pair(M_CREATOR, "dc:creator"),
     std::pair(M_AUTHOR, "upnp:author"),
     std::pair(M_DIRECTOR, "upnp:director"),
     std::pair(M_PUBLISHER, "dc:publisher"),


### PR DESCRIPTION
Add M_CREATOR to metadata (with no mapping).

HEOS artist search requires `dc:creator` to be in the SearchCapabilities.
If it not present in SearchCapabilities the app reports "Errorcode -11"