### PR TITLE
Optimize SQL Statements / result gathering

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -269,6 +269,12 @@ public:
         this->metaData = metaData;
     }
 
+    /// \brief Set entire metadata dictionary by moving
+    void setMetaData(std::vector<std::pair<std::string, std::string>>&& metaData)
+    {
+        this->metaData = std::move(metaData);
+    }
+
     /// \brief Add a single metadata value.
     void addMetaData(const metadata_fields_t key, const std::string& value)
     {
@@ -328,6 +334,12 @@ public:
     void setResources(const std::vector<std::shared_ptr<CdsResource>>& res)
     {
         resources = res;
+    }
+
+    /// \brief Set resources by move
+    void setResources(std::vector<std::shared_ptr<CdsResource>>&& res)
+    {
+        resources = std::move(res);
     }
 
     /// \brief Search resources for given handler id

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1380,26 +1380,29 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromRow(const std::unique_pt
 
     auto metaData = retrieveMetaDataForObject(obj->getID());
     if (!metaData.empty()) {
-        obj->setMetaData(metaData);
+        obj->setMetaData(std::move(metaData));
     } else if (obj->getRefID() != CDS_ID_ROOT) {
         metaData = retrieveMetaDataForObject(obj->getRefID());
         if (!metaData.empty())
-            obj->setMetaData(metaData);
+            obj->setMetaData(std::move(metaData));
     }
 
     std::string auxdataStr = fallbackString(getCol(row, BrowseCol::Auxdata), getCol(row, BrowseCol::RefAuxdata));
     std::map<std::string, std::string> aux = dictDecode(auxdataStr);
     obj->setAuxData(aux);
 
+    bool resourceZeroOk = false;
     auto resources = retrieveResourcesForObject(obj->getID());
     if (!resources.empty()) {
-        obj->setResources(resources);
+        resourceZeroOk = true;
+        obj->setResources(std::move(resources));
     } else if (obj->getRefID() != CDS_ID_ROOT) {
         resources = retrieveResourcesForObject(obj->getRefID());
-        if (!resources.empty())
-            obj->setResources(resources);
+        if (!resources.empty()) {
+            resourceZeroOk = true;
+            obj->setResources(std::move(resources));
+        }
     }
-    auto resourceZeroOk = !resources.empty();
 
     obj->setVirtual((obj->getRefID() && obj->isPureItem()) || (obj->isItem() && !obj->isPureItem())); // gets set to true for virtual containers below
 
@@ -1475,18 +1478,20 @@ std::shared_ptr<CdsObject> SQLDatabase::createObjectFromSearchRow(const std::uni
 
     auto metaData = retrieveMetaDataForObject(obj->getID());
     if (!metaData.empty())
-        obj->setMetaData(metaData);
+        obj->setMetaData(std::move(metaData));
 
+    bool resourceZeroOk = false;
     auto resources = retrieveResourcesForObject(obj->getID());
     if (!resources.empty()) {
-        obj->setResources(resources);
+        resourceZeroOk = true;
+        obj->setResources(std::move(resources));
     } else if (obj->getRefID() != CDS_ID_ROOT) {
         resources = retrieveResourcesForObject(obj->getRefID());
-        if (!resources.empty())
-            obj->setResources(resources);
+        if (!resources.empty()) {
+            resourceZeroOk = true;
+            obj->setResources(std::move(resources));
+        }
     }
-
-    auto resourceZeroOk = !resources.empty();
 
     if (obj->isItem()) {
         if (!resourceZeroOk)


### PR DESCRIPTION
In` SQLDatabase::getChildCounts`, we can require the database to return ordered `parent_id`s and speedup map insertion (the `ORDER BY` is only there for readability as the result should be ordered by default in both SQLite and MySQL because is uses an index on `parent_id`).

Also, some more libfmt-identifier() conversions.