### PR TITLE
Remove duplicate logic from file_request_handler

### DIFF
--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -38,14 +38,19 @@
 #include <memory>
 
 class FileRequestHandler : public RequestHandler {
-protected:
-    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
 
 public:
     explicit FileRequestHandler(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
 
     void getInfo(const char* filename, UpnpFileInfo* info) override;
     std::unique_ptr<IOHandler> open(const char* filename, enum UpnpOpenFileMode mode) override;
+
+protected:
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
+
+private:
+    std::shared_ptr<CdsObject> obj;
+    std::unique_ptr<IOHandler> ioHandler;
 };
 
 #endif // __FILE_REQUEST_HANDLER_H__


### PR DESCRIPTION
We were doing a lot of stuff twice due to being unable to keep data
between the the getInfo() and open() calls.

Now that our handler is used accross both we can do all the work just
once in getInfo() and make the IOHandler available for open() which now
contains basically zero logic.

Still lots of room for improvements, but much better than it was.
