### PR TITLE
clang-tidy: run through readability checks

### DIFF
--- a/test/config/test_configmanager.cc
+++ b/test/config/test_configmanager.cc
@@ -74,7 +74,7 @@ public:
         }
     }
 
-    std::string createConfig()
+    std::string createConfig() const
     {
         ConfigGenerator configGenerator;
         return configGenerator.generate(home, confdir, prefix, magic);

--- a/test/core/test_server.cc
+++ b/test/core/test_server.cc
@@ -48,7 +48,7 @@ TEST_F(ServerTest, ServerOutputsHelpInformation)
     fs::path cmd = fs::path(CMAKE_BINARY_DIR) / "gerbera --help 2>&1";
     std::string output = exec(cmd.c_str());
 
-    ASSERT_THAT(output.c_str(), HasSubstr(expectedOutput.c_str()));
+    ASSERT_THAT(output.c_str(), HasSubstr(expectedOutput));
 }
 
 TEST_F(ServerTest, ServerOutputsCompileInformationIncludingGit)

--- a/test/scripting/mock/script_test_fixture.cc
+++ b/test/scripting/mock/script_test_fixture.cc
@@ -42,7 +42,7 @@ void ScriptTestFixture::TearDown()
     duk_destroy_heap(ctx);
 }
 
-void ScriptTestFixture::loadCommon(duk_context* ctx)
+void ScriptTestFixture::loadCommon(duk_context* ctx) const
 {
     if (scriptName != "common.js") {
         fs::path commonScript = fs::path(SCRIPTS_DIR) / "js" / "common.js";

--- a/test/scripting/mock/script_test_fixture.h
+++ b/test/scripting/mock/script_test_fixture.h
@@ -43,7 +43,7 @@ struct getCdsObjectParams {
 // useful for mocking said functions with expectations.
 class ScriptTestFixture : public ::testing::Test {
     // Loads common.js if running test for another script
-    void loadCommon(duk_context* ctx);
+    void loadCommon(duk_context* ctx) const;
 
 public:
     // Builds up the Duktape context
@@ -56,7 +56,7 @@ public:
     // Creates a mock item(orig) global object in Duktape context
     static duk_ret_t dukMockItem(duk_context* ctx, const std::string& mimetype, const std::string& id, int theora, const std::string& title,
         const std::map<std::string, std::string>& meta, const std::map<std::string, std::string>& aux, const std::map<std::string, std::string>& res,
-        const std::string& location, int online_service);
+        const std::string& location, int onlineService);
 
     // Creates a mock playlist global object in Duktape context
     static duk_ret_t dukMockPlaylist(duk_context* ctx, const std::string& title, const std::string& location, const std::string& mimetype);


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>