### PR TITLE
test: Use correct option for test discovery timeout

### DIFF
--- a/test/config/CMakeLists.txt
+++ b/test/config/CMakeLists.txt
@@ -18,4 +18,4 @@ target_compile_definitions(testconfig PRIVATE CMAKE_BINARY_DIR="${CMAKE_BINARY_D
 add_dependencies(testconfig gerbera)
 
 include(GoogleTest)
-gtest_discover_tests(testconfig PROPERTIES TIMEOUT 600)
+gtest_discover_tests(testconfig DISCOVERY_TIMEOUT 60)

--- a/test/content/CMakeLists.txt
+++ b/test/content/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(testcontent PRIVATE
 )
 
 include(GoogleTest)
-gtest_discover_tests(testcontent PROPERTIES TIMEOUT 600)
+gtest_discover_tests(testcontent DISCOVERY_TIMEOUT 60)

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -25,4 +25,4 @@ target_compile_definitions(testcore PRIVATE GIT_BRANCH="${GIT_BRANCH}")
 target_compile_definitions(testcore PRIVATE GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
 
 include(GoogleTest)
-gtest_discover_tests(testcore PROPERTIES TIMEOUT 600)
+gtest_discover_tests(testcore DISCOVERY_TIMEOUT 60)

--- a/test/database/CMakeLists.txt
+++ b/test/database/CMakeLists.txt
@@ -19,4 +19,4 @@ target_link_libraries(testdb PUBLIC
 )
 
 include(GoogleTest)
-gtest_discover_tests(testdb PROPERTIES TIMEOUT 600)
+gtest_discover_tests(testdb DISCOVERY_TIMEOUT 60)

--- a/test/scripting/CMakeLists.txt
+++ b/test/scripting/CMakeLists.txt
@@ -23,5 +23,5 @@ target_link_libraries(testscripting PRIVATE
 target_compile_definitions(testscripting PRIVATE SCRIPTS_DIR="${CMAKE_SOURCE_DIR}/scripts")
 
 include(GoogleTest)
-gtest_discover_tests(testscripting PROPERTIES TIMEOUT 600)
+gtest_discover_tests(testscripting DISCOVERY_TIMEOUT 60)
 

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -10,4 +10,4 @@ target_link_libraries(testutil PRIVATE
 )
 
 include(GoogleTest)
-gtest_discover_tests(testutil PROPERTIES TIMEOUT 600)
+gtest_discover_tests(testutil DISCOVERY_TIMEOUT 60)


### PR DESCRIPTION
From: https://cmake.org/cmake/help/latest/module/GoogleTest.html#DISCOVERY_TIMEOUT

> In CMake versions 3.10.1 and 3.10.2, this option was called TIMEOUT.
> This clashed with the TIMEOUT test property, which is one of the common
> properties that would be set with the PROPERTIES keyword, usually
> leading to legal but unintended behavior. The keyword was changed to
> DISCOVERY_TIMEOUT in CMake 3.10.3 to address this problem. The ambiguous
> behavior of the TIMEOUT keyword in 3.10.1 and 3.10.2 has not been
> preserved.
