### PR TITLE
Optimize the use of references

### DIFF
--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -1166,7 +1166,7 @@ bool ConfigTranscodingSetup::createOptionFromNode(const pugi::xml_node& element,
     }
 
     // validate profiles
-    auto tpl = result->getList();
+    auto&& tpl = result->getList();
     for (auto&& [key, val] : mtMappings) {
         if (tpl.find(key) == tpl.end()) {
             log_error("Error in configuration: you specified a mimetype to transcoding profile mapping, but the profile \"{}\" for mimetype \"{}\" does not exists", val, key);

--- a/src/transcoding/transcoding.cc
+++ b/src/transcoding/transcoding.cc
@@ -62,7 +62,7 @@ void TranscodingProfile::setAVIFourCCList(const std::vector<std::string>& list, 
     fourcc_mode = mode;
 }
 
-std::vector<std::string> TranscodingProfile::getAVIFourCCList() const
+const std::vector<std::string>& TranscodingProfile::getAVIFourCCList() const
 {
     return fourcc_list;
 }

--- a/src/transcoding/transcoding.h
+++ b/src/transcoding/transcoding.h
@@ -170,7 +170,7 @@ public:
         avi_fourcc_listmode_t mode = FCC_Ignore);
 
     /// \brief Retrieves the FourCC list
-    std::vector<std::string> getAVIFourCCList() const;
+    const std::vector<std::string>& getAVIFourCCList() const;
     /// \brief Provides information on the mode of the list
     avi_fourcc_listmode_t getAVIFourCCListMode() const { return fourcc_mode; }
 
@@ -220,7 +220,7 @@ public:
     void add(const std::string& sourceMimeType, const std::shared_ptr<TranscodingProfile>& prof);
 
     std::shared_ptr<TranscodingProfileMap> get(const std::string& sourceMimeType) const;
-    std::map<std::string, std::shared_ptr<TranscodingProfileMap>> getList() const { return list; }
+    const std::map<std::string, std::shared_ptr<TranscodingProfileMap>>& getList() const { return list; }
     std::shared_ptr<TranscodingProfile> getByName(const std::string& name, bool getAll = false) const;
     std::size_t size() const { return list.size(); }
     void setKey(const std::string& oldKey, const std::string& newKey)

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -193,7 +193,7 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, std::si
             result.append_attribute("childCount") = childCount;
 
         log_debug("container is class: {}", upnpClass.c_str());
-        auto meta = obj->getMetaData();
+        auto&& meta = obj->getMetaData();
         if (upnpClass == UPNP_CLASS_MUSIC_ALBUM) {
             addPropertyList(result, meta, auxData, CFG_UPNP_ALBUM_PROPERTIES, CFG_UPNP_ALBUM_NAMESPACES);
         } else if (upnpClass == UPNP_CLASS_MUSIC_ARTIST) {
@@ -492,13 +492,13 @@ std::deque<std::shared_ptr<CdsResource>> UpnpXMLBuilder::getOrderedResources(con
     // Order resources according to index defined by orderedHandler
     std::deque<std::shared_ptr<CdsResource>> orderedResources;
     auto&& resources = object->getResources();
-    for (auto&& oh : orderedHandler) {
-        std::copy_if(resources.begin(), resources.end(), std::back_inserter(orderedResources), [&](auto res) { return oh == res->getHandlerType(); });
+    for (int oh : orderedHandler) {
+        std::copy_if(resources.begin(), resources.end(), std::back_inserter(orderedResources), [oh](auto&& res) { return oh == res->getHandlerType(); });
     }
 
     // Append resources not listed in orderedHandler
     for (auto&& res : resources) {
-        auto ch = res->getHandlerType();
+        int ch = res->getHandlerType();
         if (std::find(orderedHandler.begin(), orderedHandler.end(), ch) == orderedHandler.end()) {
             orderedResources.push_back(res);
         }
@@ -546,7 +546,7 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
                 // check user fourcc settings
                 avi_fourcc_listmode_t fccMode = tp->getAVIFourCCListMode();
 
-                std::vector<std::string> fccList = tp->getAVIFourCCList();
+                const auto& fccList = tp->getAVIFourCCList();
                 // mode is either process or ignore, so we will have to take a
                 // look at the settings
                 if (fccMode != FCC_None) {
@@ -645,7 +645,7 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
                   if (mimeType.empty()) mimeType = DEFAULT_MIMETYPE; */
 
         auto resAttrs = res->getAttributes();
-        auto resParams = res->getParameters();
+        auto&& resParams = res->getParameters();
         std::string protocolInfo = getValueOrDefault(resAttrs, MetadataHandler::getResAttrName(R_PROTOCOLINFO));
         std::string mimeType = getMTFromProtocolInfo(protocolInfo);
 

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -399,7 +399,7 @@ void Web::ConfigLoad::process()
             createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_MODE), cs->option, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_MODE);
             setValue(item, TranscodingProfile::mapFourCcMode(fourCCMode));
 
-            const auto fourCCList = entry->getAVIFourCCList();
+            const auto& fourCCList = entry->getAVIFourCCList();
             if (!fourCCList.empty()) {
                 item = values.append_child("item");
                 createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC), cs->option, ATTR_TRANSCODING_PROFILES_PROFLE_AVI4CC_4CC);


### PR DESCRIPTION
Basically, add references where complex objects are returned and remove references for simple datatypes.