### PR TITLE
Code cleanup for #2033

### DIFF
--- a/src/config/config_setup.cc
+++ b/src/config/config_setup.cc
@@ -1070,7 +1070,7 @@ bool ConfigTranscodingSetup::createOptionFromNode(const pugi::xml_node& element,
             std::string param = sub.text().as_string();
             if (!param.empty()) {
                 if (checkResolution(param))
-                    prof->addAttribute(MetadataHandler::getResAttrName(R_RESOLUTION), param);
+                    prof->setAttribute(MetadataHandler::getResAttrName(R_RESOLUTION), param);
             }
         }
 
@@ -1292,9 +1292,9 @@ bool ConfigTranscodingSetup::updateDetail(const std::string& optItem, std::strin
             index = getItemPath(i, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_RES);
             if (optItem == index) {
                 if (ConfigDefinition::findConfigSetup<ConfigStringSetup>(ATTR_TRANSCODING_PROFILES_PROFLE_RES)->checkValue(optValue)) {
-                    config->setOrigValue(index, entry->getAttributes()[MetadataHandler::getResAttrName(R_RESOLUTION)]);
-                    entry->addAttribute(MetadataHandler::getResAttrName(R_RESOLUTION), optValue);
-                    log_debug("New Transcoding Detail {} {}", index, config->getTranscodingProfileListOption(option)->getByName(entry->getName(), true)->getAttributes()[MetadataHandler::getResAttrName(R_RESOLUTION)]);
+                    config->setOrigValue(index, entry->getAttribute(MetadataHandler::getResAttrName(R_RESOLUTION)));
+                    entry->setAttribute(MetadataHandler::getResAttrName(R_RESOLUTION), optValue);
+                    log_debug("New Transcoding Detail {} {}", index, config->getTranscodingProfileListOption(option)->getByName(entry->getName(), true)->getAttribute(MetadataHandler::getResAttrName(R_RESOLUTION)));
                     return true;
                 }
             }

--- a/src/transcoding/transcoding.cc
+++ b/src/transcoding/transcoding.cc
@@ -46,14 +46,23 @@ void TranscodingProfile::setBufferOptions(std::size_t bs, std::size_t cs, std::s
     initial_fill_size = ifs;
 }
 
-void TranscodingProfile::addAttribute(const std::string& name, const std::string& value)
+void TranscodingProfile::setAttribute(const std::string& name, const std::string& value)
 {
     attributes[name] = value;
 }
 
-std::map<std::string, std::string> TranscodingProfile::getAttributes() const
+const std::map<std::string, std::string>& TranscodingProfile::getAttributes() const
 {
     return attributes;
+}
+
+std::string TranscodingProfile::getAttribute(const std::string& name) const
+{
+    auto it = attributes.find(name);
+    if (it != attributes.end()) {
+        return it->second;
+    }
+    return {};
 }
 
 void TranscodingProfile::setAVIFourCCList(const std::vector<std::string>& list, avi_fourcc_listmode_t mode)

--- a/src/transcoding/transcoding.h
+++ b/src/transcoding/transcoding.h
@@ -121,15 +121,17 @@ public:
     void setFirstResource(bool fr) { first_resource = fr; }
     bool firstResource() const { return first_resource; }
 
-    /// \brief Adds a resource attribute.
+    /// \brief Adds or overwrites a resource attribute.
     ///
     /// This maps to an attribute of the <res> tag in the DIDL-Lite XML.
     ///
     /// \param name attribute name
     /// \param value attribute value
-    void addAttribute(const std::string& name, const std::string& value);
+    void setAttribute(const std::string& name, const std::string& value);
 
-    std::map<std::string, std::string> getAttributes() const;
+    const std::map<std::string, std::string>& getAttributes() const;
+
+    std::string getAttribute(const std::string& name) const;
 
     /// \brief Override for theora content.
     ///

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -343,7 +343,7 @@ void Web::ConfigLoad::process()
 
         item = values.append_child("item");
         createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_RES), cs->option, ATTR_TRANSCODING_PROFILES_PROFLE_RES);
-        setValue(item, entry->getAttributes()[MetadataHandler::getResAttrName(R_RESOLUTION)]);
+        setValue(item, entry->getAttribute(MetadataHandler::getResAttrName(R_RESOLUTION)));
 
         item = values.append_child("item");
         createItem(item, cs->getItemPath(pr, ATTR_TRANSCODING_PROFILES_PROFLE, ATTR_TRANSCODING_PROFILES_PROFLE_ACCURL), cs->option, ATTR_TRANSCODING_PROFILES_PROFLE_ACCURL);


### PR DESCRIPTION
Cleans up e42678ef76d16385e6df1fae4bde191e625ad334 to fix #2033 and completes reference cleanup of 47ab772be53e1470c06eec8d30d04e9b63025fb8