### PR TITLE
remove pointless while loop

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -289,9 +289,7 @@ public:
     /// \brief Removes metadata with the given key
     void removeMetaData(const metadata_fields_t key)
     {
-        auto&& field = MetadataHandler::getMetaFieldName(key);
-        while (std::find_if(metaData.begin(), metaData.end(), [=](auto&& md) { return md.first == field; }) != metaData.end())
-            metaData.erase(std::remove_if(metaData.begin(), metaData.end(), [=](auto&& md) { return md.first == field; }));
+        metaData.erase(std::remove_if(metaData.begin(), metaData.end(), [field = MetadataHandler::getMetaFieldName(key)](auto&& md) { return md.first == field; }), metaData.end());
     }
 
     /// \brief Query single auxdata value.


### PR DESCRIPTION
There's no need to call std::find as remove_if uses the same lambda to
remove elements. It also removed multiple elements.

GCC11 is smart enough to see through this and optimizes the original
code away.

Signed-off-by: Rosen Penev <rosenp@gmail.com>