### PR TITLE
Change compare order for to IPV6 then IPV4

### DIFF
--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -67,7 +67,7 @@ void Web::ConfigLoad::addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<Co
 
 void Web::ConfigLoad::createItem(pugi::xml_node& item, const std::string& name, config_option_t id, config_option_t aid, const std::shared_ptr<ConfigSetup>& cs)
 {
-    allItems[name] = item;
+    allItems[name] = &item;
     item.append_attribute("item") = name.c_str();
     item.append_attribute("id") = fmt::format("{:03d}", id).c_str();
     item.append_attribute("aid") = fmt::format("{:03d}", aid).c_str();
@@ -506,9 +506,8 @@ void Web::ConfigLoad::process()
         auto exItem = allItems.find(entry.item);
         if (exItem != allItems.end()) {
             auto item = exItem->second;
-            item.attribute("source") = "database";
-            setValue(item, entry.value);
-            item.attribute("status") = entry.status.c_str();
+            item->attribute("source") = "database";
+            item->attribute("status") = entry.status.c_str();
         } else {
             auto cs = ConfigDefinition::findConfigSetupByPath(entry.item, true);
             auto acs = ConfigDefinition::findConfigSetupByPath(entry.item, true, cs);

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -189,7 +189,7 @@ public:
 class ConfigLoad : public WebRequestHandler {
 protected:
     std::vector<ConfigValue> dbEntries;
-    std::map<std::string, pugi::xml_node> allItems;
+    std::map<std::string, pugi::xml_node*> allItems;
     void createItem(pugi::xml_node& item, const std::string& name, config_option_t id, config_option_t aid, const std::shared_ptr<ConfigSetup>& cs = nullptr);
     template <typename T>
     static void setValue(pugi::xml_node& item, const T& value);


### PR DESCRIPTION
My home network is a mixed IPV6 and IPV4 network. This leads to the situation that my Samsung TV gets its IPV4 address mapped to an IPV6 address. So IPV4 = 192.168.178.25 will be shown as ::FFFF:192.168.178.25 in the logs.

Unfortunately this IPV6 address is not being recognized since the check for "." in the address triggers the IPV4 comparison which will not match for "::FFFF:" prefixed IPV4.
The later check for IPV6 would also be executed since ":" is contained, but the path is never reached.

My proposal in this pull request: change the order of IPV4/IPV6 check, because IPV6 has ":" character inside and IPV4 can contain both "." and ":".

