### PR TITLE
Change compare order for to IPV6 then IPV4

### DIFF
--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -193,15 +193,7 @@ const ClientInfo* Clients::getInfoByAddr(const struct sockaddr_storage* addr)
             return false;
         }
 
-        if (c.match.find('.') != std::string::npos) {
-            // IPv4
-            struct sockaddr_in clientAddr = {};
-            clientAddr.sin_family = AF_INET;
-            clientAddr.sin_addr.s_addr = inet_addr(c.match.c_str());
-            if (sockAddrCmpAddr(reinterpret_cast<const struct sockaddr*>(&clientAddr), reinterpret_cast<const struct sockaddr*>(addr)) == 0) {
-                return true;
-            }
-        } else if (c.match.find(':') != std::string::npos) {
+        if (c.match.find(':') != std::string::npos) {
             // IPv6
             struct sockaddr_in6 clientAddr = {};
             clientAddr.sin6_family = AF_INET6;
@@ -209,6 +201,14 @@ const ClientInfo* Clients::getInfoByAddr(const struct sockaddr_storage* addr)
                 if (sockAddrCmpAddr(reinterpret_cast<const struct sockaddr*>(&clientAddr), reinterpret_cast<const struct sockaddr*>(addr)) == 0) {
                     return true;
                 }
+            }
+        } else if (c.match.find('.') != std::string::npos) {
+            // IPv4
+            struct sockaddr_in clientAddr = {};
+            clientAddr.sin_family = AF_INET;
+            clientAddr.sin_addr.s_addr = inet_addr(c.match.c_str());
+            if (sockAddrCmpAddr(reinterpret_cast<const struct sockaddr*>(&clientAddr), reinterpret_cast<const struct sockaddr*>(addr)) == 0) {
+                return true;
             }
         }
 


### PR DESCRIPTION
Rejected and re-issued the pull request to change compare order of IPV6 and IPV4.

IPV4 addresses in IPV6 networks are mapped to something like ::FFFF:127.0.0.1

Therefore checking for "." to detect IPV4 can falsely identify such a mapped IPV4 address and the compare will not match.

The token ":" will only be present in IPV6 addresses and should be checked first.