### PR TITLE
remove custom merge function

### DIFF
--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -473,13 +473,6 @@ std::map<std::string, std::string> pathToMap(std::string_view url)
     return out;
 }
 
-void dictMerge(std::map<std::string, std::string>& result, const std::map<std::string, std::string>& source)
-{
-    for (auto&& [key, value] : source) {
-        result.emplace(key, value);
-    }
-}
-
 std::string mimeTypesToCsv(const std::vector<std::string>& mimeTypes)
 {
     return mimeTypes.empty() ? "" : fmt::format("http-get:*:{}:*", fmt::join(mimeTypes, ":*,http-get:*:"));

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -151,9 +151,6 @@ std::string dictEncodeSimple(const std::map<std::string, std::string>& dict);
 std::map<std::string, std::string> dictDecode(std::string_view url, bool unEscape = true);
 std::map<std::string, std::string> pathToMap(std::string_view url);
 
-/// \brief Adds elements from source to result if they do not yet exist in result
-void dictMerge(std::map<std::string, std::string>& result, const std::map<std::string, std::string>& source);
-
 /// \brief Convert an array of strings to a CSV list, with additional protocol information
 /// \param array that needs to be converted
 /// \return string containing the CSV list

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -92,7 +92,7 @@ void WebRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     if (params.empty()) {
         params = std::move(decodedParams);
     } else {
-        dictMerge(params, decodedParams);
+        params.merge(decodedParams);
     }
 
     UpnpFileInfo_set_FileLength(info, -1); // length is unknown

--- a/test/util/test_tools.cc
+++ b/test/util/test_tools.cc
@@ -165,26 +165,6 @@ TEST(ToolsTest, dictDecodeTest)
     EXPECT_EQ(values.size(), 0);
 }
 
-TEST(ToolsTest, dictMergeTest)
-{
-    std::map<std::string, std::string> result;
-    result.emplace("A", "1");
-    result.emplace("B", "2");
-
-    std::map<std::string, std::string> source;
-    source.emplace("A", "10");
-    source.emplace("C", "3");
-
-    EXPECT_EQ(result.size(), 2);
-
-    dictMerge(result, source);
-
-    EXPECT_EQ(result.size(), 3);
-    EXPECT_EQ(result["A"], "1");
-    EXPECT_EQ(result["B"], "2");
-    EXPECT_EQ(result["C"], "3");
-}
-
 TEST(ToolsTest, pathToMapTest)
 {
     std::map<std::string, std::string> values = pathToMap("Key 1/Value 1/Key 2/Value 2/Key3//");


### PR DESCRIPTION
std::map::merge() is equivalent.

Signed-off-by: Rosen Penev <rosenp@gmail.com>