### PR TITLE
Enable colour log levels

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -212,10 +212,10 @@ int main(int argc, char** argv, char** envp)
         bool debug = opts["debug"].as<bool>();
         if (debug) {
             spdlog::set_level(spdlog::level::debug);
-            spdlog::set_pattern("%Y-%m-%d %X.%e %6l: [%s:%#] %!(): %v");
+            spdlog::set_pattern("%Y-%m-%d %X.%e %^%6l%$: [%s:%#] %!(): %v");
         } else {
             spdlog::set_level(spdlog::level::info);
-            spdlog::set_pattern("%Y-%m-%d %X %6l: %v");
+            spdlog::set_pattern("%Y-%m-%d %X %^%6l%$: %v");
         }
 
         std::optional<std::string> logfile;


### PR DESCRIPTION
Automatically disabled when spdlog detects its not writing to a console
