### PR TITLE
restore log level to debug

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -97,7 +97,7 @@ void ActionRequest::update()
 {
     if (response) {
         std::string xml = UpnpXMLBuilder::printXml(*response, "", 0);
-        log_info("ActionRequest::update(): {}", xml);
+        log_debug("ActionRequest::update(): {}", xml);
 
 #if defined(USING_NPUPNP)
         UpnpActionRequest_set_xmlResponse(upnp_request, xml);


### PR DESCRIPTION
Causes a lot of noise in the non-debug log.