### PR TITLE
remove const from several unique_ptrs

### DIFF
--- a/src/action_request.h
+++ b/src/action_request.h
@@ -85,6 +85,9 @@ public:
     /// \param *upnp_request Pointer to the Upnp_Action_Request structure.
     explicit ActionRequest(const std::shared_ptr<Context>& context, UpnpActionRequest* upnpRequest);
 
+    ActionRequest(ActionRequest&&) = default;
+    ActionRequest& operator=(ActionRequest&&) = default;
+
     /// \brief Returns the name of the action.
     std::string getActionName() const;
 

--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -31,30 +31,23 @@
 #include "util/upnp_clients.h"
 #include "util/upnp_quirks.h"
 
-ClientConfig::ClientConfig()
-    : clientInfo(std::make_unique<ClientInfo>())
-{
-}
-
 ClientConfig::ClientConfig(int flags, std::string_view ip, std::string_view userAgent, int captionInfoCount)
 {
-    auto cInfo = ClientInfo();
-    cInfo.type = ClientType::Unknown;
+    clientInfo.type = ClientType::Unknown;
     if (!ip.empty()) {
-        cInfo.matchType = ClientMatchType::IP;
-        cInfo.match = ip;
+        clientInfo.matchType = ClientMatchType::IP;
+        clientInfo.match = ip;
     } else if (!userAgent.empty()) {
-        cInfo.matchType = ClientMatchType::UserAgent;
-        cInfo.match = userAgent;
+        clientInfo.matchType = ClientMatchType::UserAgent;
+        clientInfo.match = userAgent;
     } else {
-        cInfo.matchType = ClientMatchType::None;
+        clientInfo.matchType = ClientMatchType::None;
     }
-    cInfo.flags = flags;
-    cInfo.captionInfoCount = captionInfoCount;
+    clientInfo.flags = flags;
+    clientInfo.captionInfoCount = captionInfoCount;
     auto sIP = ip.empty() ? "" : fmt::format(" IP {}", ip);
     auto sUA = userAgent.empty() ? "" : fmt::format(" UserAgent {}", userAgent);
-    cInfo.name = fmt::format("Manual Setup for{}{}", sIP, sUA);
-    clientInfo = std::make_unique<ClientInfo>(std::move(cInfo));
+    clientInfo.name = fmt::format("Manual Setup for{}{}", sIP, sUA);
 }
 
 void ClientConfigList::add(const std::shared_ptr<ClientConfig>& client, std::size_t index)

--- a/src/config/client_config.h
+++ b/src/config/client_config.h
@@ -71,7 +71,7 @@ protected:
 /// \brief Provides information about one manual client.
 class ClientConfig {
 public:
-    ClientConfig();
+    ClientConfig() = default;
 
     /// \brief Creates a new ClientConfig object.
     /// \param flags quirks flags
@@ -79,29 +79,29 @@ public:
     /// \param userAgent user agent
     ClientConfig(int flags, std::string_view ip, std::string_view userAgent, int captionInfoCount);
 
-    const std::unique_ptr<ClientInfo>& getClientInfo() const { return clientInfo; }
+    const ClientInfo& getClientInfo() const { return clientInfo; }
 
-    int getFlags() const { return clientInfo->flags; }
-    void setFlags(int flags) { this->clientInfo->flags = flags; }
+    int getFlags() const { return clientInfo.flags; }
+    void setFlags(int flags) { this->clientInfo.flags = flags; }
 
-    int getCaptionInfoCount() const { return this->clientInfo->captionInfoCount; }
+    int getCaptionInfoCount() const { return this->clientInfo.captionInfoCount; }
     void setCaptionInfoCount(int captionInfoCount)
     {
-        this->clientInfo->captionInfoCount = captionInfoCount;
+        this->clientInfo.captionInfoCount = captionInfoCount;
     }
 
-    std::string getIp() const { return (this->clientInfo->matchType == ClientMatchType::IP) ? this->clientInfo->match : ""; }
+    std::string getIp() const { return (this->clientInfo.matchType == ClientMatchType::IP) ? this->clientInfo.match : ""; }
     void setIp(std::string_view ip)
     {
-        this->clientInfo->matchType = ClientMatchType::IP;
-        this->clientInfo->match = ip;
+        this->clientInfo.matchType = ClientMatchType::IP;
+        this->clientInfo.match = ip;
     }
 
-    std::string getUserAgent() const { return (this->clientInfo->matchType == ClientMatchType::UserAgent) ? this->clientInfo->match : ""; }
+    std::string getUserAgent() const { return (this->clientInfo.matchType == ClientMatchType::UserAgent) ? this->clientInfo.match : ""; }
     void setUserAgent(std::string_view userAgent)
     {
-        this->clientInfo->matchType = ClientMatchType::UserAgent;
-        this->clientInfo->match = userAgent;
+        this->clientInfo.matchType = ClientMatchType::UserAgent;
+        this->clientInfo.match = userAgent;
     }
 
     /* helpers for clientType stuff */
@@ -118,7 +118,7 @@ public:
 
 protected:
     bool isOrig {};
-    std::unique_ptr<ClientInfo> clientInfo;
+    ClientInfo clientInfo {};
 };
 
 #endif

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -270,11 +270,11 @@ private:
     /* helper for removeObject(s) */
     void _removeObjects(const std::vector<std::int32_t>& objectIDs);
 
-    std::unique_ptr<ChangedContainers> _recursiveRemove(
+    ChangedContainers _recursiveRemove(
         const std::vector<std::int32_t>& items,
         const std::vector<std::int32_t>& containers, bool all);
 
-    virtual std::unique_ptr<ChangedContainers> _purgeEmptyContainers(const std::unique_ptr<ChangedContainers>& maybeEmpty);
+    virtual std::unique_ptr<ChangedContainers> _purgeEmptyContainers(ChangedContainers maybeEmpty);
 
     /* helpers for autoscan */
     void _removeAutoscanDirectory(int autoscanID);

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -102,7 +102,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     // for transcoded resources res_id will always be negative
     std::string trProfile = getValueOrDefault(params, URL_PARAM_TRANSCODE_PROFILE_NAME);
 
-    auto headers = std::make_unique<Headers>();
+    auto headers = Headers();
     auto item = std::dynamic_pointer_cast<CdsItem>(obj);
     std::string mimeType = item ? item->getMimeType() : "";
 
@@ -159,7 +159,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
         auto mappings = config->getDictionaryOption(CFG_IMPORT_MAPPINGS_MIMETYPE_TO_CONTENTTYPE_LIST);
         std::string dlnaContentHeader = getDLNAContentHeader(config, getValueOrDefault(mappings, mimeType), resource ? resource->getAttribute(R_VIDEOCODEC) : "", resource ? resource->getAttribute(R_AUDIOCODEC) : "");
         if (!dlnaContentHeader.empty()) {
-            headers->addHeader(UPNP_DLNA_CONTENT_FEATURES_HEADER, dlnaContentHeader);
+            headers.addHeader(UPNP_DLNA_CONTENT_FEATURES_HEADER, dlnaContentHeader);
         }
     }
 
@@ -168,7 +168,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 
     std::string dlnaTransferHeader = getDLNATransferHeader(config, mimeType);
     if (!dlnaTransferHeader.empty()) {
-        headers->addHeader(UPNP_DLNA_TRANSFER_MODE_HEADER, dlnaTransferHeader);
+        headers.addHeader(UPNP_DLNA_TRANSFER_MODE_HEADER, dlnaTransferHeader);
     }
 
 #ifdef USING_NPUPNP
@@ -177,7 +177,7 @@ void FileRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     UpnpFileInfo_set_ContentType(info, mimeType.c_str());
 #endif
 
-    headers->writeHeaders(info);
+    headers.writeHeaders(info);
 
     // log_debug("getInfo: Requested {}, ObjectID: {}, Location: {}, MimeType: {}",
     //      filename, object_id.c_str(), path.c_str(), info->content_type);

--- a/src/server.cc
+++ b/src/server.cc
@@ -382,9 +382,9 @@ int Server::handleUpnpRootDeviceEvent(Upnp_EventType eventType, const void* even
     case UPNP_CONTROL_ACTION_REQUEST:
         log_debug("UPNP_CONTROL_ACTION_REQUEST");
         try {
-            auto request = std::make_unique<ActionRequest>(context, static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
+            auto request = ActionRequest(context, static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
             routeActionRequest(request);
-            request->update();
+            request.update();
         } catch (const UpnpException& upnpE) {
             ret = upnpE.getErrorCode();
             UpnpActionRequest_set_ErrCode(static_cast<UpnpActionRequest*>(const_cast<void*>(event)), ret);
@@ -441,26 +441,26 @@ int Server::handleUpnpClientEvent(Upnp_EventType eventType, const void* event)
     return 0;
 }
 
-void Server::routeActionRequest(const std::unique_ptr<ActionRequest>& request) const
+void Server::routeActionRequest(ActionRequest& request)
 {
     log_debug("start");
 
     // make sure the request is for our device
-    if (request->getUDN() != serverUDN) {
+    if (request.getUDN() != serverUDN) {
         // not for us
         throw UpnpException(UPNP_E_BAD_REQUEST, "routeActionRequest: request not for this device");
     }
 
     // we need to match the serviceID to one of our services
-    if (request->getServiceID() == UPNP_DESC_CM_SERVICE_ID) {
+    if (request.getServiceID() == UPNP_DESC_CM_SERVICE_ID) {
         // this call is for the lifetime stats service
         // log_debug("request for connection manager service");
         cmgr->processActionRequest(request);
-    } else if (request->getServiceID() == UPNP_DESC_CDS_SERVICE_ID) {
+    } else if (request.getServiceID() == UPNP_DESC_CDS_SERVICE_ID) {
         // this call is for the toaster control service
         // log_debug("routeActionRequest: request for content directory service");
         cds->processActionRequest(request);
-    } else if (request->getServiceID() == UPNP_DESC_MRREG_SERVICE_ID) {
+    } else if (request.getServiceID() == UPNP_DESC_MRREG_SERVICE_ID) {
         mrreg->processActionRequest(request);
     } else {
         // cp is asking for a nonexistent service, or for a service

--- a/src/server.h
+++ b/src/server.h
@@ -165,7 +165,7 @@ protected:
     /// and ConnectionManagerService), this function looks at the service id
     /// of the request and calls the process_action_request() for the
     /// appropriate service.
-    void routeActionRequest(const std::unique_ptr<ActionRequest>& request) const;
+    void routeActionRequest(ActionRequest& request);
 
     /// \brief Dispatched a SubscriptionRequest between the services.
     /// \param request Incoming SubscriptionRequest.

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -52,11 +52,11 @@ ContentDirectoryService::ContentDirectoryService(const std::shared_ptr<Context>&
     searchableContainers = this->config->getBoolOption(CFG_UPNP_SEARCH_CONTAINER_FLAG);
 }
 
-void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doBrowse(ActionRequest& request)
 {
     log_debug("start");
 
-    auto req = request->getRequest();
+    auto req = request.getRequest();
     auto reqRoot = req->document_element();
 #ifdef DEBUG_UPNP
     for (auto&& child : req_root.children()) {
@@ -76,7 +76,7 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     if (objID.empty())
         throw UpnpException(UPNP_E_NO_SUCH_ID, "empty object id");
 
-    auto&& quirks = request->getQuirks();
+    auto&& quirks = request.getQuirks();
     auto arr = quirks->getSamsungFeatureRoot(objID);
     int objectID = stoiString(objID);
 
@@ -140,22 +140,22 @@ void ContentDirectoryService::doBrowse(const std::unique_ptr<ActionRequest>& req
     std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", 0);
     log_debug("didl {}", didlLiteXml);
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto respRoot = response->document_element();
     respRoot.append_child("Result").append_child(pugi::node_pcdata).set_value(didlLiteXml.c_str());
     respRoot.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(arr.size()).c_str());
     respRoot.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(param.getTotalMatches()).c_str());
     respRoot.append_child("UpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
-    request->setResponse(std::move(response));
+    request.setResponse(std::move(response));
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doSearch(ActionRequest& request)
 {
     log_debug("start");
 
-    auto req = request->getRequest();
+    auto req = request.getRequest();
     auto reqRoot = req->document_element();
 #ifdef DEBUG_UPNP
     for (auto&& child : req_root.children()) {
@@ -171,7 +171,7 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     log_debug("Search received parameters: ContainerID [{}] SearchCriteria [{}] StartingIndex [{}] RequestedCount [{}] RequestedCount [{}]",
         containerID, searchCriteria, startingIndex, requestedCount, requestedCount);
 
-    auto&& quirks = request->getQuirks();
+    auto&& quirks = request.getQuirks();
     pugi::xml_document didlLite;
     if (!quirks->blockXmlDeclaration()) {
         auto decl = didlLite.prepend_child(pugi::node_declaration);
@@ -232,115 +232,115 @@ void ContentDirectoryService::doSearch(const std::unique_ptr<ActionRequest>& req
     std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", 0);
     log_debug("didl {}", didlLiteXml);
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto respRoot = response->document_element();
     respRoot.append_child("Result").append_child(pugi::node_pcdata).set_value(didlLiteXml.c_str());
     respRoot.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(results.size()).c_str());
     respRoot.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(numMatches).c_str());
     respRoot.append_child("UpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
-    request->setResponse(std::move(response));
+    request.setResponse(std::move(response));
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doGetSearchCapabilities(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doGetSearchCapabilities(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("SearchCaps").append_child(pugi::node_pcdata).set_value(SQLDatabase::getSearchCapabilities().c_str());
-    request->setResponse(std::move(response));
+    request.setResponse(std::move(response));
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doGetSortCapabilities(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doGetSortCapabilities(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("SortCaps").append_child(pugi::node_pcdata).set_value(SQLDatabase::getSortCapabilities().c_str());
-    request->setResponse(std::move(response));
+    request.setResponse(std::move(response));
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doGetSystemUpdateID(const std::unique_ptr<ActionRequest>& request) const
+void ContentDirectoryService::doGetSystemUpdateID(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Id").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
-    request->setResponse(std::move(response));
+    request.setResponse(std::move(response));
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doSamsungBookmark(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doSamsungBookmark(ActionRequest& request)
 {
     log_debug("start");
 
-    request->getQuirks()->saveSamsungBookMarkedPosition(request);
+    request.getQuirks()->saveSamsungBookMarkedPosition(request);
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doSamsungFeatureList(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doSamsungFeatureList(ActionRequest& request)
 {
     log_debug("start");
 
-    request->getQuirks()->getSamsungFeatureList(request);
+    request.getQuirks()->getSamsungFeatureList(request);
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doSamsungGetObjectIDfromIndex(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doSamsungGetObjectIDfromIndex(ActionRequest& request)
 {
     log_debug("start");
 
-    request->getQuirks()->getSamsungObjectIDfromIndex(request);
+    request.getQuirks()->getSamsungObjectIDfromIndex(request);
 
     log_debug("end");
 }
 
-void ContentDirectoryService::doSamsungGetIndexfromRID(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::doSamsungGetIndexfromRID(ActionRequest& request)
 {
     log_debug("start");
 
-    request->getQuirks()->getSamsungIndexfromRID(request);
+    request.getQuirks()->getSamsungIndexfromRID(request);
 
     log_debug("end");
 }
 
-void ContentDirectoryService::processActionRequest(const std::unique_ptr<ActionRequest>& request)
+void ContentDirectoryService::processActionRequest(ActionRequest& request)
 {
     log_debug("start");
 
-    if (request->getActionName() == "Browse") {
+    if (request.getActionName() == "Browse") {
         doBrowse(request);
-    } else if (request->getActionName() == "GetSearchCapabilities") {
+    } else if (request.getActionName() == "GetSearchCapabilities") {
         doGetSearchCapabilities(request);
-    } else if (request->getActionName() == "GetSortCapabilities") {
+    } else if (request.getActionName() == "GetSortCapabilities") {
         doGetSortCapabilities(request);
-    } else if (request->getActionName() == "GetSystemUpdateID") {
+    } else if (request.getActionName() == "GetSystemUpdateID") {
         doGetSystemUpdateID(request);
-    } else if (request->getActionName() == "Search") {
+    } else if (request.getActionName() == "Search") {
         doSearch(request);
-    } else if (request->getActionName() == "X_SetBookmark") {
+    } else if (request.getActionName() == "X_SetBookmark") {
         doSamsungBookmark(request);
-    } else if (request->getActionName() == "X_GetFeatureList") {
+    } else if (request.getActionName() == "X_GetFeatureList") {
         doSamsungFeatureList(request);
-    } else if (request->getActionName() == "X_GetObjectIDfromIndex") {
+    } else if (request.getActionName() == "X_GetObjectIDfromIndex") {
         doSamsungGetObjectIDfromIndex(request);
-    } else if (request->getActionName() == "X_GetIndexfromRID") {
+    } else if (request.getActionName() == "X_GetIndexfromRID") {
         doSamsungGetIndexfromRID(request);
     } else {
         // invalid or unsupported action
-        log_warning("Unrecognized action {}", request->getActionName().c_str());
-        request->setErrorCode(UPNP_E_INVALID_ACTION);
+        log_warning("Unrecognized action {}", request.getActionName().c_str());
+        request.setErrorCode(UPNP_E_INVALID_ACTION);
     }
 
     log_debug("ContentDirectoryService::processActionRequest: end");

--- a/src/upnp_cds.h
+++ b/src/upnp_cds.h
@@ -63,7 +63,7 @@ private:
     /// Browse(string ObjectID, string BrowseFlag, string Filter, ui4 StartingIndex,
     /// ui4 RequestedCount, string SortCriteria, string Result, ui4 NumberReturned,
     /// ui4 TotalMatches, ui4 UpdateID)
-    void doBrowse(const std::unique_ptr<ActionRequest>& request);
+    void doBrowse(ActionRequest& request);
 
     /// \brief UPnP standard defined action: Search()
     /// \param request Incoming ActionRequest.
@@ -71,43 +71,43 @@ private:
     /// Search(string ContainerID, string SearchCriteria, string Filter, ui4 StartingIndex,
     /// ui4 RequestedCount, string SortCriteria, string Result, ui4 NumberReturned,
     /// ui4 TotalMatches, ui4 UpdateID)
-    void doSearch(const std::unique_ptr<ActionRequest>& request);
+    void doSearch(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetSearchCapabilities()
     /// \param request Incoming ActionRequest.
     ///
     /// GetSearchCapabilities(string SearchCaps)
-    static void doGetSearchCapabilities(const std::unique_ptr<ActionRequest>& request);
+    static void doGetSearchCapabilities(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetSortCapabilities()
     /// \param request Incoming ActionRequest.
     ///
     /// GetSortCapabilities(string SortCaps)
-    static void doGetSortCapabilities(const std::unique_ptr<ActionRequest>& request);
+    static void doGetSortCapabilities(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetSystemUpdateID()
     /// \param request Incoming ActionRequest.
     ///
     /// GetSystemUpdateID(ui4 Id)
-    void doGetSystemUpdateID(const std::unique_ptr<ActionRequest>& request) const;
+    void doGetSystemUpdateID(ActionRequest& request);
 
     /// \brief Samsung Extension X_SetBookmark
     /// \param request Incoming ActionRequest.
     ///
-    static void doSamsungBookmark(const std::unique_ptr<ActionRequest>& request);
+    static void doSamsungBookmark(ActionRequest& request);
 
     /// \brief Samsung Extension X_GetFeatureListResponse
     /// \param request Incoming ActionRequest.
     ///
-    static void doSamsungFeatureList(const std::unique_ptr<ActionRequest>& request);
+    static void doSamsungFeatureList(ActionRequest& request);
 
     /// \brief Samsung Extension X_GetObjectIDfromIndex
     /// \param request Incoming ActionRequest.
-    static void doSamsungGetObjectIDfromIndex(const std::unique_ptr<ActionRequest>& request);
+    static void doSamsungGetObjectIDfromIndex(ActionRequest& request);
 
     /// \brief Samsung Extension X_GetIndexfromRID
     /// \param request Incoming ActionRequest.
-    static void doSamsungGetIndexfromRID(const std::unique_ptr<ActionRequest>& request);
+    static void doSamsungGetIndexfromRID(ActionRequest& request);
 
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;
@@ -130,7 +130,7 @@ public:
     ///
     /// This function looks at the incoming ActionRequest and passes it on
     /// to the appropriate action for processing.
-    void processActionRequest(const std::unique_ptr<ActionRequest>& request);
+    void processActionRequest(ActionRequest& request);
 
     /// \brief Processes an incoming SubscriptionRequest.
     /// \param request SubscriptionRequest to be processed by the function.

--- a/src/upnp_cm.cc
+++ b/src/upnp_cm.cc
@@ -46,60 +46,60 @@ ConnectionManagerService::ConnectionManagerService(const std::shared_ptr<Context
 {
 }
 
-void ConnectionManagerService::doGetCurrentConnectionIDs(const std::unique_ptr<ActionRequest>& request)
+void ConnectionManagerService::doGetCurrentConnectionIDs(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("ConnectionID").append_child(pugi::node_pcdata).set_value("0");
 
-    request->setResponse(std::move(response));
-    request->setErrorCode(UPNP_E_SUCCESS);
+    request.setResponse(std::move(response));
+    request.setErrorCode(UPNP_E_SUCCESS);
 
     log_debug("end");
 }
 
-void ConnectionManagerService::doGetCurrentConnectionInfo(const std::unique_ptr<ActionRequest>& request)
+void ConnectionManagerService::doGetCurrentConnectionInfo(ActionRequest& request)
 {
     log_debug("start");
 
-    request->setErrorCode(UPNP_E_NOT_EXIST);
+    request.setErrorCode(UPNP_E_NOT_EXIST);
 
     log_debug("doGetCurrentConnectionInfo: end");
 }
 
-void ConnectionManagerService::doGetProtocolInfo(const std::unique_ptr<ActionRequest>& request)
+void ConnectionManagerService::doGetProtocolInfo(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
     auto csv = mimeTypesToCsv(database->getMimeTypes());
     auto root = response->document_element();
 
     root.append_child("Source").append_child(pugi::node_pcdata).set_value(csv.c_str());
     root.append_child("Sink").append_child(pugi::node_pcdata).set_value("");
 
-    request->setResponse(std::move(response));
-    request->setErrorCode(UPNP_E_SUCCESS);
+    request.setResponse(std::move(response));
+    request.setErrorCode(UPNP_E_SUCCESS);
 
     log_debug("end");
 }
 
-void ConnectionManagerService::processActionRequest(const std::unique_ptr<ActionRequest>& request)
+void ConnectionManagerService::processActionRequest(ActionRequest& request)
 {
     log_debug("start");
 
-    if (request->getActionName() == "GetCurrentConnectionIDs") {
+    if (request.getActionName() == "GetCurrentConnectionIDs") {
         doGetCurrentConnectionIDs(request);
-    } else if (request->getActionName() == "GetCurrentConnectionInfo") {
+    } else if (request.getActionName() == "GetCurrentConnectionInfo") {
         doGetCurrentConnectionInfo(request);
-    } else if (request->getActionName() == "GetProtocolInfo") {
+    } else if (request.getActionName() == "GetProtocolInfo") {
         doGetProtocolInfo(request);
     } else {
         // invalid or unsupported action
-        log_debug("unrecognized action {}", request->getActionName().c_str());
-        request->setErrorCode(UPNP_E_INVALID_ACTION);
+        log_debug("unrecognized action {}", request.getActionName().c_str());
+        request.setErrorCode(UPNP_E_INVALID_ACTION);
         //        throw UpnpException(UPNP_E_INVALID_ACTION, "unrecognized action");
     }
 

--- a/src/upnp_cm.h
+++ b/src/upnp_cm.h
@@ -51,7 +51,7 @@ protected:
     /// GetCurrentConnectionIDs(string ConnectionIDs)
     ///
     /// This is currently unsupported (returns empty string)
-    static void doGetCurrentConnectionIDs(const std::unique_ptr<ActionRequest>& request);
+    static void doGetCurrentConnectionIDs(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetCurrentConnectionInfo()
     /// \param request Incoming ActionRequest.
@@ -60,13 +60,13 @@ protected:
     /// string PeerConnectionManager, i4 PeerConnectionID, string Direction, string Status)
     ///
     /// This action is currently unsupported.
-    static void doGetCurrentConnectionInfo(const std::unique_ptr<ActionRequest>& request);
+    static void doGetCurrentConnectionInfo(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetProtocolInfo()
     /// \param request Incoming ActionRequest.
     ///
     /// GetProtocolInfo(string Source, string Sink)
-    void doGetProtocolInfo(const std::unique_ptr<ActionRequest>& request);
+    void doGetProtocolInfo(ActionRequest& request);
 
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;
@@ -86,7 +86,7 @@ public:
     ///
     /// This function looks at the incoming ActionRequest and passes it on
     /// to the appropriate action for processing.
-    void processActionRequest(const std::unique_ptr<ActionRequest>& request);
+    void processActionRequest(ActionRequest& request);
 
     /// \brief Processes an incoming SubscriptionRequest.
     /// \param request Incoming SubscriptionRequest.

--- a/src/upnp_mrreg.cc
+++ b/src/upnp_mrreg.cc
@@ -46,57 +46,57 @@ MRRegistrarService::MRRegistrarService(const std::shared_ptr<Context>& context,
 {
 }
 
-void MRRegistrarService::doIsAuthorized(const std::unique_ptr<ActionRequest>& request)
+void MRRegistrarService::doIsAuthorized(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 
-    request->setResponse(std::move(response));
-    request->setErrorCode(UPNP_E_SUCCESS);
+    request.setResponse(std::move(response));
+    request.setErrorCode(UPNP_E_SUCCESS);
 
     log_debug("end");
 }
 
-void MRRegistrarService::doRegisterDevice(const std::unique_ptr<ActionRequest>& request)
+void MRRegistrarService::doRegisterDevice(ActionRequest& request)
 {
     log_debug("start");
 
-    request->setErrorCode(UPNP_E_NOT_EXIST);
+    request.setErrorCode(UPNP_E_NOT_EXIST);
 
     log_debug("upnpActionGetCurrentConnectionInfo: end");
 }
 
-void MRRegistrarService::doIsValidated(const std::unique_ptr<ActionRequest>& request)
+void MRRegistrarService::doIsValidated(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request->getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
+    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 
-    request->setResponse(std::move(response));
-    request->setErrorCode(UPNP_E_SUCCESS);
+    request.setResponse(std::move(response));
+    request.setErrorCode(UPNP_E_SUCCESS);
 
     log_debug("end");
 }
 
-void MRRegistrarService::processActionRequest(const std::unique_ptr<ActionRequest>& request)
+void MRRegistrarService::processActionRequest(ActionRequest& request)
 {
     log_debug("start");
 
-    if (request->getActionName() == "IsAuthorized") {
+    if (request.getActionName() == "IsAuthorized") {
         doIsAuthorized(request);
-    } else if (request->getActionName() == "RegisterDevice") {
+    } else if (request.getActionName() == "RegisterDevice") {
         doRegisterDevice(request);
-    } else if (request->getActionName() == "IsValidated") {
+    } else if (request.getActionName() == "IsValidated") {
         doIsValidated(request);
     } else {
         // invalid or unsupported action
-        log_debug("unrecognized action {}", request->getActionName());
-        request->setErrorCode(UPNP_E_INVALID_ACTION);
+        log_debug("unrecognized action {}", request.getActionName());
+        request.setErrorCode(UPNP_E_INVALID_ACTION);
         // throw UpnpException(UPNP_E_INVALID_ACTION, "unrecognized action");
     }
 

--- a/src/upnp_mrreg.h
+++ b/src/upnp_mrreg.h
@@ -59,7 +59,7 @@ protected:
     /// IsAuthorized(string DeviceID, i4 Result)
     ///
     /// This is currently unsupported (always returns 1)
-    static void doIsAuthorized(const std::unique_ptr<ActionRequest>& request);
+    static void doIsAuthorized(ActionRequest& request);
 
     /// \brief Media Receiver Registrar service action: RegisterDevice()
     /// \param request Incoming ActionRequest.
@@ -67,13 +67,13 @@ protected:
     /// RegisterDevice(bin.base64 RegistrationReqMsg, bin.base64 RegistrationRespMsg)
     ///
     /// This action is currently unsupported.
-    static void doRegisterDevice(const std::unique_ptr<ActionRequest>& request);
+    static void doRegisterDevice(ActionRequest& request);
 
     /// \brief Media Receiver Registrar service action: IsValidated()
     /// \param request Incoming ActionRequest.
     ///
     /// IsValidated(string DeviceID, i4 Result)
-    static void doIsValidated(const std::unique_ptr<ActionRequest>& request);
+    static void doIsValidated(ActionRequest& request);
 
     std::shared_ptr<Config> config;
 
@@ -91,7 +91,7 @@ public:
     ///
     /// This function looks at the incoming ActionRequest and passes it on
     /// to the appropriate action for processing.
-    static void processActionRequest(const std::unique_ptr<ActionRequest>& request);
+    static void processActionRequest(ActionRequest& request);
 
     /// \brief Processes an incoming SubscriptionRequest.
     /// \param request Incoming SubscriptionRequest.

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -135,7 +135,7 @@ void Clients::refresh(const std::shared_ptr<Config>& config)
     auto clientConfigList = config->getClientConfigListOption(CFG_CLIENTS_LIST);
     for (std::size_t i = 0; i < clientConfigList->size(); i++) {
         auto clientConfig = clientConfigList->get(i);
-        clientInfo.push_back(*clientConfig->getClientInfo());
+        clientInfo.push_back(clientConfig->getClientInfo());
     }
 }
 

--- a/src/util/upnp_quirks.h
+++ b/src/util/upnp_quirks.h
@@ -56,7 +56,7 @@ public:
 
     // Look for subtitle file and returns its URL in CaptionInfo.sec response header.
     // To be more compliant with original Samsung server we should check for getCaptionInfo.sec: 1 request header.
-    void addCaptionInfo(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Headers>& headers) const;
+    void addCaptionInfo(const std::shared_ptr<CdsItem>& item, Headers& headers);
 
     /** \brief Add Samsung specific bookmark information to the request's result.
      *
@@ -73,7 +73,7 @@ public:
      * \return void
      *
      */
-    void saveSamsungBookMarkedPosition(const std::unique_ptr<ActionRequest>& request) const;
+    void saveSamsungBookMarkedPosition(ActionRequest& request);
 
     /** \brief get Samsung Feature List
      *
@@ -81,7 +81,7 @@ public:
      * \return void
      *
      */
-    void getSamsungFeatureList(const std::unique_ptr<ActionRequest>& request) const;
+    void getSamsungFeatureList(ActionRequest& request);
     std::vector<std::shared_ptr<CdsObject>> getSamsungFeatureRoot(const std::string& objId);
 
     /** \brief get Samsung ObjectID from Index
@@ -90,7 +90,7 @@ public:
      * \return void
      *
      */
-    void getSamsungObjectIDfromIndex(const std::unique_ptr<ActionRequest>& request) const;
+    void getSamsungObjectIDfromIndex(ActionRequest& request);
 
     /** \brief get Samsung Index from RID
      *
@@ -98,7 +98,7 @@ public:
      * \return void
      *
      */
-    void getSamsungIndexfromRID(const std::unique_ptr<ActionRequest>& request) const;
+    void getSamsungIndexfromRID(ActionRequest& request);
 
     /** \brief block XML header in response for broken clients
      *


### PR DESCRIPTION
SonarLint reports:

If you use std::unique_ptr<T> const & for a function parameter type, it
means that the function will not be able to alter the ownership of the
pointed-to object by the unique_ptr:

It cannot acquire ownership of the pointed-to object (this would require
a parameter of type std::unique_ptr<T>)
It cannot transfer the object ownership to someone else (this would
require a std::unique_ptr<T> &).
That means the function can only observe the pointed-to object, and in
this case passing a T* (if the unique_ptr can be null) or a T& (if it
cannot) provides the same features, while also allowing the function to
work with objects that are not handled by a unique_ptr (E.G. objects on
the stack, in a vector, or in another kind of smart pointer), thus making
the function more general-purpose.

Signed-off-by: Rosen Penev <rosenp@gmail.com>