### PR TITLE
convert string to fs::path

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -504,7 +504,7 @@ int main(int argc, char** argv, char** envp)
         }
 
         if (opts.count("add-file") > 0) {
-            auto files = opts["add-file"].as<std::vector<std::string>>();
+            auto files = opts["add-file"].as<std::vector<fs::path>>();
             for (auto&& f : files) {
                 try {
                     std::error_code ec;
@@ -519,7 +519,7 @@ int main(int argc, char** argv, char** envp)
                         asSetting.mergeOptions(configManager, f);
                         server->getContent()->addFile(dirEnt, asSetting, true);
                     } else {
-                        log_error("Failed to read {}: {}", f, ec.message());
+                        log_error("Failed to read {}: {}", f.c_str(), ec.message());
                     }
                 } catch (const std::runtime_error& e) {
                     log_error("{}", e.what());


### PR DESCRIPTION
It's used in filesystem context.

Signed-off-by: Rosen Penev <rosenp@gmail.com>