### PR TITLE
exiv2: silence messages without debug

### DIFF
--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -39,6 +39,13 @@
 #include "util/string_converter.h"
 #include "util/tools.h"
 
+Exiv2Handler::Exiv2Handler(const std::shared_ptr<Context>& context)
+    : MetadataHandler(context)
+{
+    // silence exiv2 messages without debug
+    Exiv2::LogMsg::setHandler([](auto, auto s) { log_debug("Exiv2: {}", s); });
+}
+
 void Exiv2Handler::fillMetadata(const std::shared_ptr<CdsObject>& item)
 {
     try {

--- a/src/metadata/exiv2_handler.h
+++ b/src/metadata/exiv2_handler.h
@@ -39,10 +39,7 @@
 /// \brief This class is responsible for reading exif header metadata
 class Exiv2Handler : public MetadataHandler {
 public:
-    explicit Exiv2Handler(const std::shared_ptr<Context>& context)
-        : MetadataHandler(context)
-    {
-    }
+    explicit Exiv2Handler(const std::shared_ptr<Context>& context);
     void fillMetadata(const std::shared_ptr<CdsObject>& item) override;
     std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& item, int resNum) override;
 };


### PR DESCRIPTION
Replaces the log handler with one that uses log_debug.

Also moved constructor out of line as it should be.

Signed-off-by: Rosen Penev <rosenp@gmail.com>