### PR TITLE
Fix segfaulting on ARM due to (maybe) unintended pointer  

### DIFF
--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -66,7 +66,7 @@ void Web::ConfigLoad::addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<Co
 
 void Web::ConfigLoad::createItem(pugi::xml_node& item, const std::string& name, config_option_t id, config_option_t aid, const std::shared_ptr<ConfigSetup>& cs)
 {
-    allItems[name] = &item;
+    allItems[name] = item;
     item.append_attribute("item") = name.c_str();
     item.append_attribute("id") = fmt::format("{:03d}", id).c_str();
     item.append_attribute("aid") = fmt::format("{:03d}", aid).c_str();
@@ -505,8 +505,9 @@ void Web::ConfigLoad::process()
         auto exItem = allItems.find(entry.item);
         if (exItem != allItems.end()) {
             auto item = exItem->second;
-            item->attribute("source") = "database";
-            item->attribute("status") = entry.status.c_str();
+			setValue(item, entry.value);
+            item.attribute("source") = "database";
+            item.attribute("status") = entry.status.c_str();
         } else {
             auto cs = ConfigDefinition::findConfigSetupByPath(entry.item, true);
             auto acs = ConfigDefinition::findConfigSetupByPath(entry.item, true, cs);

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -505,7 +505,7 @@ void Web::ConfigLoad::process()
         auto exItem = allItems.find(entry.item);
         if (exItem != allItems.end()) {
             auto item = exItem->second;
-			setValue(item, entry.value);
+            setValue(item, entry.value);
             item.attribute("source") = "database";
             item.attribute("status") = entry.status.c_str();
         } else {

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -189,7 +189,7 @@ public:
 class ConfigLoad : public WebRequestHandler {
 protected:
     std::vector<ConfigValue> dbEntries;
-    std::map<std::string, pugi::xml_node*> allItems;
+    std::map<std::string, pugi::xml_node> allItems;
     void createItem(pugi::xml_node& item, const std::string& name, config_option_t id, config_option_t aid, const std::shared_ptr<ConfigSetup>& cs = nullptr);
     template <typename T>
     static void setValue(pugi::xml_node& item, const T& value);


### PR DESCRIPTION
I cross-compiled Gerbera to run on my ARM-powered NAS. However everytime when opening the Config-Section using the web interface the Gerbera process died with a SEGFAULT.
Gdb showed it happens inside Web::ConfigLoad::process() at this routine:

```
//update entries with datebase values
for (auto&& entry : dbEntries) {
        auto exItem = allItems.find(entry.item);
        if (exItem != allItems.end()) {
            auto item = exItem->second;
            setValue(item, entry.value);

```
exItem->second did not point to a valid \<pugi::xml_node\> item structure (just garbage).

For debug reasons I dumped the "allItems" map just before the loop and found out that the map contains distinct values for \<std::string\>, but blockwise a lot of identical \<pugi::xml_node*\> values - all pointing to the locally declared variables "auto item =..." above. But those variables already lost their context at this point and may contain garbage data when entering the lookup database loop.

I fixed the issue (working for me) by changing the pointer type.
Maybe I am mistaken, but I would be happy if someone can look into this issue. 

