### PR TITLE
add comment about non const reference

### DIFF
--- a/src/content/autoscan_list.cc
+++ b/src/content/autoscan_list.cc
@@ -155,6 +155,7 @@ std::shared_ptr<AutoscanList> AutoscanList::removeIfSubdir(const fs::path& paren
     auto rmIdList = std::make_shared<AutoscanList>(database);
 
     for (auto it = list.begin(); it != list.end(); /*++it*/) {
+        // the following must be non const. Otherwise, crash happens when two entries are added.
         auto& dir = *it;
 
         if (startswith(dir->getLocation().string(), parent.string())) {


### PR DESCRIPTION
SonarLint reports that this should be const. However adding const,
using auto&&, or removing and replacing with *it everywhere results in a
crash. I can't really figure out why so add a comment that it should not
be changed.

Signed-off-by: Rosen Penev <rosenp@gmail.com>