### PR TITLE
use operator < instead of startswith

### DIFF
--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -592,7 +592,7 @@ std::shared_ptr<AutoscanInotify::WatchAutoscan> AutoscanInotify::getAppropriateA
             auto watchAs = std::static_pointer_cast<WatchAutoscan>(watch);
             if (watchAs->getNonexistingPathArray().empty()) {
                 fs::path testLocation = watchAs->getAutoscanDirectory()->getLocation();
-                if (startswith(path.string(), testLocation.string())) {
+                if (path < testLocation) {
                     if (!pathBestMatch.empty()) {
                         if (pathBestMatch.string().length() < testLocation.string().length()) {
                             pathBestMatch = testLocation;

--- a/src/content/autoscan_list.cc
+++ b/src/content/autoscan_list.cc
@@ -157,7 +157,7 @@ std::shared_ptr<AutoscanList> AutoscanList::removeIfSubdir(const fs::path& paren
     for (auto it = list.begin(); it != list.end(); /*++it*/) {
         auto dir = *it;
 
-        if (startswith(dir->getLocation().string(), parent.string())) {
+        if (dir->getLocation() < parent) {
             if (dir->persistent() && !persistent) {
                 ++it;
                 continue;

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -800,7 +800,7 @@ void ContentManager::addRecursive(std::shared_ptr<AutoscanDirectory>& adir, cons
         for (std::size_t i = 0; i < autoscan_inotify->size(); i++) {
             log_debug("AutoDir {}", i);
             auto dir = autoscan_inotify->get(i);
-            if (dir && startswith(dir->getLocation().string(), subDir.path().string()) && fs::is_directory(dir->getLocation())) {
+            if (dir && (dir->getLocation() < subDir.path()) && fs::is_directory(dir->getLocation())) {
                 adir = std::move(dir);
             }
         }
@@ -810,7 +810,7 @@ void ContentManager::addRecursive(std::shared_ptr<AutoscanDirectory>& adir, cons
         for (std::size_t i = 0; i < autoscan_timed->size(); i++) {
             log_debug("Timed AutoscanDir {}", i);
             auto dir = autoscan_timed->get(i);
-            if (dir && startswith(dir->getLocation().string(), subDir.path().string()) && fs::is_directory(dir->getLocation())) {
+            if (dir && (dir->getLocation() < subDir.path()) && fs::is_directory(dir->getLocation())) {
                 adir = std::move(dir);
             }
         }
@@ -1456,7 +1456,7 @@ void ContentManager::invalidateAddTask(const std::shared_ptr<GenericTask>& t, co
     if (t->getType() == AddFile) {
         auto addTask = std::static_pointer_cast<CMAddFileTask>(t);
         log_debug("comparing, task path: {}, remove path: {}", addTask->getPath().c_str(), path.c_str());
-        if (startswith(addTask->getPath().string(), path.string())) {
+        if (addTask->getPath() < path) {
             log_debug("Invalidating task with path {}", addTask->getPath().c_str());
             addTask->invalidate();
         }

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -111,7 +111,7 @@ void Web::Autoscan::process()
 
         // --- sorting autoscans
 
-        std::sort(autoscanList.begin(), autoscanList.end(), [](auto&& a1, auto&& a2) { return a1->getLocation().compare(a2->getLocation()) < 0; });
+        std::sort(autoscanList.begin(), autoscanList.end(), [](auto&& a1, auto&& a2) { return a1->getLocation() < a2->getLocation(); });
 
         // ---
 


### PR DESCRIPTION
Avoids unnecessary conversions from fs::path, to std::string, to
std::string_view.

Signed-off-by: Rosen Penev <rosenp@gmail.com>