### PR TITLE
Validate bound port

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -510,6 +510,9 @@ int main(int argc, char** argv, char** envp)
             } else if (ue.getErrorCode() == UPNP_E_SOCKET_ERROR) {
                 log_error("LibUPnP Socket error");
                 log_error("Please check if your network interface was configured for multicast!");
+            } else if (ue.getErrorCode() == UPNP_E_SUCCESS) {
+                /* This means we died, not libupnp explicitly, likely because they gave us the wrong port */
+                log_error(ue.what());
             } else {
 #ifdef UPNP_HAVE_TOOLS
                 log_error("Failed to start LibUPnP: {} error code: {}", UpnpGetErrorMessage(ue.getErrorCode()), ue.getErrorCode());

--- a/src/server.cc
+++ b/src/server.cc
@@ -120,14 +120,19 @@ void Server::run()
         throw_std_runtime_error("Invalid web server root directory {}", webRoot);
     }
 
-    auto ret = startupInterface(iface, in_port_t(config->getIntOption(CFG_SERVER_PORT)));
+    auto configPort = config->getIntOption(CFG_SERVER_PORT);
+    auto ret = startupInterface(iface, configPort);
     if (ret != UPNP_E_SUCCESS) {
-        throw UpnpException(ret, fmt::format("run: UpnpInit failed {} {}", iface, port));
+        throw UpnpException(ret, fmt::format("UpnpInit failed {} {}", iface, port));
+    }
+
+    if (configPort > 0 && port != configPort) {
+        throw UpnpException(ret, fmt::format("LibUPnP failed to bind to request port! Bound to {}, requested: {}", port, configPort));
     }
 
     ret = UpnpSetWebServerRootDir(webRoot.c_str());
     if (ret != UPNP_E_SUCCESS) {
-        throw UpnpException(ret, fmt::format("run: UpnpSetWebServerRootDir failed {}", webRoot));
+        throw UpnpException(ret, fmt::format("UpnpSetWebServerRootDir failed {}", webRoot));
     }
 
     log_debug("webroot: {}", webRoot);


### PR DESCRIPTION
LibUPnP will give us another port instead of the one we requested if it
cannot bind. If port has been explictly set this is undesirable
behaviour.

Check the bound port and fail to start in this case, to make it obvious
to the user that there is something awry.
