### PR TITLE
matroska_handler: fix wrong field type

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -201,7 +201,7 @@ void MatroskaHandler::parseInfo(const std::shared_ptr<CdsItem>& item, EbmlStream
             auto fDate = fmt::format("{:%Y-%m-%d}", fmt::gmtime(dateEl->GetEpochDate()));
             if (!fDate.empty()) {
                 log_debug("KaxDateUTC = {}", fDate);
-                item->addMetaData(M_DATE, sc->convert(fDate));
+                item->addMetaData(M_CREATION_DATE, sc->convert(fDate));
             }
         }
     }


### PR DESCRIPTION
The ffmpeg handler reads the exact same matroska section but writes it
to M_CREATION_DATE. Match it here.

Signed-off-by: Rosen Penev <rosenp@gmail.com>