### PR TITLE
remove pointless move

### DIFF
--- a/src/config/config_definition.cc
+++ b/src/config/config_definition.cc
@@ -852,7 +852,7 @@ const std::vector<std::shared_ptr<ConfigSetup>> ConfigDefinition::complexOptions
     std::make_shared<ConfigDictionarySetup>(CFG_IMPORT_LIBOPTS_FFMPEG_METADATA_TAGS_LIST,
         "/import/library-options/ffmpeg/metadata", "config-import.html#ffmpeg",
         ATTR_IMPORT_LIBOPTS_AUXDATA_DATA, ATTR_IMPORT_LIBOPTS_AUXDATA_TAG, ATTR_IMPORT_LIBOPTS_AUXDATA_KEY,
-        false, true, false, std::move(ffmpeg_specialPropertyMap)),
+        false, true, false, ffmpeg_specialPropertyMap),
     std::make_shared<ConfigStringSetup>(CFG_IMPORT_LIBOPTS_FFMPEG_CHARSET,
         "/import/library-options/ffmpeg/attribute::charset", "config-import.html#charset",
         ""),

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -104,7 +104,7 @@ void Web::Autoscan::process()
                 interval,
                 hidden);
             autoscan->setObjectID(objectID);
-            content->setAutoscanDirectory(std::move(autoscan));
+            content->setAutoscanDirectory(autoscan);
         }
     } else if (action == "list") {
         auto autoscanList = content->getAutoscanDirectories();


### PR DESCRIPTION
const ref parameter. No move happens.

Signed-off-by: Rosen Penev <rosenp@gmail.com>