### PR TITLE
remove unique_ptr from ClientInfo.

### DIFF
--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -31,29 +31,22 @@
 #include "util/upnp_clients.h"
 #include "util/upnp_quirks.h"
 
-ClientConfig::ClientConfig()
-    : clientInfo(std::make_unique<ClientInfo>())
-{
-}
-
 ClientConfig::ClientConfig(int flags, std::string_view ip, std::string_view userAgent)
 {
-    auto cInfo = ClientInfo();
-    cInfo.type = ClientType::Unknown;
+    clientInfo.type = ClientType::Unknown;
     if (!ip.empty()) {
-        cInfo.matchType = ClientMatchType::IP;
-        cInfo.match = ip;
+        clientInfo.matchType = ClientMatchType::IP;
+        clientInfo.match = ip;
     } else if (!userAgent.empty()) {
-        cInfo.matchType = ClientMatchType::UserAgent;
-        cInfo.match = userAgent;
+        clientInfo.matchType = ClientMatchType::UserAgent;
+        clientInfo.match = userAgent;
     } else {
-        cInfo.matchType = ClientMatchType::None;
+        clientInfo.matchType = ClientMatchType::None;
     }
-    cInfo.flags = flags;
+    clientInfo.flags = flags;
     auto sIP = ip.empty() ? "" : fmt::format(" IP {}", ip);
     auto sUA = userAgent.empty() ? "" : fmt::format(" UserAgent {}", userAgent);
-    cInfo.name = fmt::format("Manual Setup for{}{}", sIP, sUA);
-    clientInfo = std::make_unique<ClientInfo>(std::move(cInfo));
+    clientInfo.name = fmt::format("Manual Setup for{}{}", sIP, sUA);
 }
 
 void ClientConfigList::add(const std::shared_ptr<ClientConfig>& client, std::size_t index)

--- a/src/config/client_config.h
+++ b/src/config/client_config.h
@@ -72,7 +72,7 @@ protected:
 /// \brief Provides information about one manual client.
 class ClientConfig {
 public:
-    ClientConfig();
+    ClientConfig() = default;
 
     /// \brief Creates a new ClientConfig object.
     /// \param flags quirks flags
@@ -80,23 +80,23 @@ public:
     /// \param userAgent user agent
     ClientConfig(int flags, std::string_view ip, std::string_view userAgent);
 
-    const std::unique_ptr<ClientInfo>& getClientInfo() const { return clientInfo; }
+    const ClientInfo& getClientInfo() const { return clientInfo; }
 
-    int getFlags() const { return clientInfo->flags; }
-    void setFlags(int flags) { this->clientInfo->flags = flags; }
+    int getFlags() const { return clientInfo.flags; }
+    void setFlags(int flags) { this->clientInfo.flags = flags; }
 
-    std::string getIp() const { return (this->clientInfo->matchType == ClientMatchType::IP) ? this->clientInfo->match : ""; }
+    std::string getIp() const { return (this->clientInfo.matchType == ClientMatchType::IP) ? this->clientInfo.match : ""; }
     void setIp(std::string_view ip)
     {
-        this->clientInfo->matchType = ClientMatchType::IP;
-        this->clientInfo->match = ip;
+        this->clientInfo.matchType = ClientMatchType::IP;
+        this->clientInfo.match = ip;
     }
 
-    std::string getUserAgent() const { return (this->clientInfo->matchType == ClientMatchType::UserAgent) ? this->clientInfo->match : ""; }
+    std::string getUserAgent() const { return (this->clientInfo.matchType == ClientMatchType::UserAgent) ? this->clientInfo.match : ""; }
     void setUserAgent(std::string_view userAgent)
     {
-        this->clientInfo->matchType = ClientMatchType::UserAgent;
-        this->clientInfo->match = userAgent;
+        this->clientInfo.matchType = ClientMatchType::UserAgent;
+        this->clientInfo.match = userAgent;
     }
 
     /* helpers for clientType stuff */
@@ -113,7 +113,7 @@ public:
 
 protected:
     bool isOrig {};
-    std::unique_ptr<ClientInfo> clientInfo;
+    ClientInfo clientInfo {};
 };
 
 #endif

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -135,7 +135,7 @@ void Clients::refresh(const std::shared_ptr<Config>& config)
     auto clientConfigList = config->getClientConfigListOption(CFG_CLIENTS_LIST);
     for (std::size_t i = 0; i < clientConfigList->size(); i++) {
         auto clientConfig = clientConfigList->get(i);
-        clientInfo.push_back(*clientConfig->getClientInfo());
+        clientInfo.push_back(clientConfig->getClientInfo());
     }
 }
 


### PR DESCRIPTION
Allows simplifying the code.

Signed-off-by: Rosen Penev <rosenp@gmail.com>