### PR TITLE
use lambda and fs::path

### DIFF
--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -44,17 +44,17 @@ void Web::Autoscan::process()
         throw_std_runtime_error("web:autoscan called with illegal action");
 
     bool fromFs = boolParam("from_fs");
-    std::string path;
     std::string objID = param("object_id");
-    if (fromFs) {
-        if (objID == "0")
-            path = FS_ROOT_DIRECTORY;
-        else
-            path = hexDecodeString(objID);
-    }
+    auto path = [fromFs, &objID]() -> fs::path {
+        if (fromFs) {
+            if (objID == "0")
+                return FS_ROOT_DIRECTORY;
+            return hexDecodeString(objID);
+        }
+        return {};
+    }();
 
     auto root = xmlDoc->document_element();
-
     if (action == "as_edit_load") {
         auto autoscan = root.append_child("autoscan");
         if (fromFs) {


### PR DESCRIPTION
The former allows to avoid reassigning a value. The latter gets rid of
various conversions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>