### PR TITLE
copy shared pointer instead of passing reference

### DIFF
--- a/src/content/autoscan_list.cc
+++ b/src/content/autoscan_list.cc
@@ -155,7 +155,7 @@ std::shared_ptr<AutoscanList> AutoscanList::removeIfSubdir(const fs::path& paren
     auto rmIdList = std::make_shared<AutoscanList>(database);
 
     for (auto it = list.begin(); it != list.end(); /*++it*/) {
-        auto& dir = *it;
+        auto dir = *it;
 
         if (startswith(dir->getLocation().string(), parent.string())) {
             if (dir->persistent() && !persistent) {


### PR DESCRIPTION
SonarLint reports that this should be const. However adding const,
using auto&&, or removing and replacing with *it everywhere results in a
crash. I'm guessing there's some null reference issue going on. Pass by
copy to avoid any warnings.

No size difference.

Signed-off-by: Rosen Penev <rosenp@gmail.com>