### PR TITLE
ThreadRunner: use std::thread

### DIFF
--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -102,7 +102,7 @@ void ContentManager::run()
             inst->threadProc();
             return nullptr;
         },
-        this, config);
+        this);
 
     // wait for ContentTaskThread to become ready
     threadRunner->waitForReady();

--- a/src/content/onlineservice/task_processor.cc
+++ b/src/content/onlineservice/task_processor.cc
@@ -43,7 +43,7 @@ void TaskProcessor::run()
             inst->threadProc();
             return nullptr;
         },
-        this, config);
+        this);
 
     // wait for thread to become ready
     threadRunner->waitForReady();

--- a/src/content/update_manager.cc
+++ b/src/content/update_manager.cc
@@ -59,7 +59,7 @@ void UpdateManager::run()
             inst->threadProc();
             return nullptr;
         },
-        this, config);
+        this);
     // wait for thread to become ready
     threadRunner->waitForReady();
 }

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -77,7 +77,7 @@ void Sqlite3Database::init()
         "SQLiteThread", [](void* arg) -> void* {
             auto inst = static_cast<Sqlite3Database*>(arg);
             inst->threadProc();
-            return nullptr; }, this, config);
+            return nullptr; }, this);
 
     if (!threadRunner->isAlive()) {
         throw DatabaseException("", fmt::format("Could not start sqlite thread: {}", std::strerror(errno)));

--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -179,7 +179,7 @@ void IOHandlerBufferHelper::startBufferThread()
             inst->threadProc();
             return nullptr;
         },
-        this, config);
+        this);
 }
 
 void IOHandlerBufferHelper::stopBufferThread()

--- a/src/util/timer.cc
+++ b/src/util/timer.cc
@@ -45,7 +45,7 @@ void Timer::run()
             inst->threadProc();
             return nullptr;
         },
-        this, config);
+        this);
 
     // wait for TimerThread to become ready
     threadRunner->waitForReady();


### PR DESCRIPTION
More work towards tidying up the statics.

With this patch I can run load testing tool successfully against a transcoded image resource path without it crashing in various places. 