### PR TITLE
replace all lock_guard with scoped_lock

### DIFF
--- a/src/config/client_config.h
+++ b/src/config/client_config.h
@@ -63,7 +63,7 @@ protected:
     std::map<std::size_t, std::shared_ptr<ClientConfig>> indexMap;
 
     std::recursive_mutex mutex;
-    using AutoLock = std::lock_guard<std::recursive_mutex>;
+    using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<ClientConfig>> list;
     void _add(const std::shared_ptr<ClientConfig>& client, std::size_t index);

--- a/src/config/directory_tweak.h
+++ b/src/config/directory_tweak.h
@@ -77,7 +77,7 @@ protected:
     std::map<std::size_t, std::shared_ptr<DirectoryTweak>> indexMap;
 
     std::recursive_mutex mutex;
-    using AutoLock = std::lock_guard<std::recursive_mutex>;
+    using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<DirectoryTweak>> list;
     void _add(const std::shared_ptr<DirectoryTweak>& dir, std::size_t index);

--- a/src/config/dynamic_content.h
+++ b/src/config/dynamic_content.h
@@ -64,7 +64,7 @@ protected:
     std::map<std::size_t, std::shared_ptr<DynamicContent>> indexMap;
 
     std::recursive_mutex mutex;
-    using AutoLock = std::lock_guard<std::recursive_mutex>;
+    using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<DynamicContent>> list;
     void _add(const std::shared_ptr<DynamicContent>& cont, std::size_t index);

--- a/src/content/autoscan_inotify.h
+++ b/src/content/autoscan_inotify.h
@@ -77,7 +77,7 @@ private:
     std::unique_ptr<Inotify> inotify;
 
     std::mutex mutex;
-    using AutoLock = std::lock_guard<std::mutex>;
+    using AutoLock = std::scoped_lock<std::mutex>;
 
     std::queue<std::shared_ptr<AutoscanDirectory>> monitorQueue;
     std::queue<std::shared_ptr<AutoscanDirectory>> unmonitorQueue;

--- a/src/content/autoscan_list.h
+++ b/src/content/autoscan_list.h
@@ -87,7 +87,7 @@ protected:
     std::shared_ptr<Database> database;
 
     std::recursive_mutex mutex;
-    using AutoLock = std::lock_guard<std::recursive_mutex>;
+    using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<AutoscanDirectory>> list;
     int _add(const std::shared_ptr<AutoscanDirectory>& dir, std::size_t index);

--- a/src/content/scripting/scripting_runtime.h
+++ b/src/content/scripting/scripting_runtime.h
@@ -54,7 +54,7 @@ public:
     duk_context* createContext(const std::string& name);
     void destroyContext(const std::string& name);
 
-    using AutoLock = std::lock_guard<std::recursive_mutex>;
+    using AutoLock = std::scoped_lock<std::recursive_mutex>;
     std::recursive_mutex& getMutex() { return mutex; }
 };
 

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -209,7 +209,7 @@ protected:
     std::array<unsigned int, DBVERSION> hashies;
 
     std::recursive_mutex sqlMutex;
-    using SqlAutoLock = std::lock_guard<decltype(sqlMutex)>;
+    using SqlAutoLock = std::scoped_lock<decltype(sqlMutex)>;
     std::map<int, std::shared_ptr<CdsContainer>> dynamicContainers;
 
     void upgradeDatabase(unsigned int dbVersion, const std::array<unsigned int, DBVERSION>& hashies, config_option_t upgradeOption, const std::string& updateVersionCommand, const std::string& addResourceColumnCmd);
@@ -297,7 +297,7 @@ private:
 
     std::shared_ptr<SQLEmitter> sqlEmitter;
 
-    using AutoLock = std::lock_guard<std::mutex>;
+    using AutoLock = std::scoped_lock<std::mutex>;
 };
 
 template <typename T>

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -373,7 +373,7 @@ bool SLTask::is_running() const
 void SLTask::sendSignal()
 {
     if (is_running()) { // we check before we lock first, because there is no need to lock then
-        std::lock_guard<decltype(mutex)> lock(mutex);
+        std::scoped_lock<decltype(mutex)> lock(mutex);
         running = false;
         cond.notify_one();
     }

--- a/src/util/thread_runner.h
+++ b/src/util/thread_runner.h
@@ -77,7 +77,7 @@ public:
         thread = 0;
     }
 
-    using AutoLock = std::lock_guard<Mutex>;
+    using AutoLock = std::scoped_lock<Mutex>;
     using AutoLockU = std::unique_lock<Mutex>;
 
     /// \brief the exit status of the thread - needs to be overridden
@@ -110,7 +110,7 @@ public:
         cond.wait(lck, pred);
     }
     template <class Predicate>
-    void wait(std::lock_guard<Mutex>& lck, Predicate pred)
+    void wait(std::scoped_lock<Mutex>& lck, Predicate pred)
     {
         log_debug("ThreadRunner: Waiting for {}", threadName);
         cond.wait(lck, pred);

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -110,7 +110,7 @@ private:
     static std::unique_ptr<pugi::xml_document> downloadDescription(const std::string& location);
 
     std::mutex mutex;
-    using AutoLock = std::lock_guard<std::mutex>;
+    using AutoLock = std::scoped_lock<std::mutex>;
     std::vector<ClientCacheEntry> cache;
 
     std::vector<ClientInfo> clientInfo;

--- a/src/web/session_manager.h
+++ b/src/web/session_manager.h
@@ -99,7 +99,7 @@ protected:
     void containerChangedUI(const std::vector<int>& objectIDs);
 
     std::recursive_mutex rmutex;
-    using AutoLockR = std::lock_guard<decltype(rmutex)>;
+    using AutoLockR = std::scoped_lock<decltype(rmutex)>;
     std::map<std::string, std::string> dict;
 
     /// \brief True if the ui update id hash became to big and
@@ -128,7 +128,7 @@ protected:
     std::shared_ptr<Timer> timer;
 
     std::mutex mutex;
-    using AutoLock = std::lock_guard<decltype(mutex)>;
+    using AutoLock = std::scoped_lock<decltype(mutex)>;
 
     /// \brief This array is holding available sessions.
     std::vector<std::shared_ptr<Session>> sessions;


### PR DESCRIPTION
SonarLint reports the latter to be better:

std::scoped_lock basically provides the same feature as std::lock_guard,
but is more generic: It can lock several mutexes at the same time, with a
deadlock prevention mechanism (see {rule:cpp:S5524}). The equivalent code
to perform simultaneous locking with std::lock_guard is significantly more
complex. Therefore, it is simpler to use std::scoped_lock all the time,
even when locking only one mutex (there will be no performance impact).

Signed-off-by: Rosen Penev <rosenp@gmail.com>