### PR TITLE
append with fmt

### DIFF
--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -771,7 +771,7 @@ void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xm
 
         // URL is path until now
         if (!item->isExternalItem() || (hideOriginalResource && item->isExternalItem())) {
-            url = virtualURL + url;
+            url = fmt::format("{}{}", virtualURL, url);
         }
 
         if (!hideOriginalResource || transcoded || originalResource != res->getResId())


### PR DESCRIPTION
Avoid clang-tidy warning

Signed-off-by: Rosen Penev <rosenp@gmail.com>