### PR TITLE
matroska_handler: default init activeFlag

### DIFF
--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -47,7 +47,7 @@ public:
     std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, int resNum) override;
 
 private:
-    int activeFlag;
+    int activeFlag {};
 
     void parseMKV(const std::shared_ptr<CdsItem>& item, std::unique_ptr<MemIOHandler>* pIoHandler);
     void parseLevel1Element(const std::shared_ptr<CdsItem>& item, IOCallback& ebmlFile, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlElement* elL1, std::unique_ptr<MemIOHandler>* pIoHandler);


### PR DESCRIPTION
Fixes clang-analyzer warning.

Signed-off-by: Rosen Penev <rosenp@gmail.com>