### PR TITLE
remove unique_ptr from matroska thing

### DIFF
--- a/src/iohandler/mem_io_handler.h
+++ b/src/iohandler/mem_io_handler.h
@@ -50,10 +50,11 @@ public:
     /// \param buffer all operations will be done on this buffer.
     MemIOHandler(const void* buffer, int length);
     explicit MemIOHandler(const std::string& str);
+    MemIOHandler() = default;
     ~MemIOHandler() override;
 
-    MemIOHandler(const MemIOHandler&) = delete;
-    MemIOHandler& operator=(const MemIOHandler&) = delete;
+    MemIOHandler(MemIOHandler&&) = default;
+    MemIOHandler& operator=(MemIOHandler&&) = default;
 
     ///
     void open(enum UpnpOpenFileMode mode) override;

--- a/src/metadata/matroska_handler.h
+++ b/src/metadata/matroska_handler.h
@@ -49,11 +49,11 @@ public:
 private:
     int activeFlag {};
 
-    void parseMKV(const std::shared_ptr<CdsItem>& item, std::unique_ptr<MemIOHandler>* pIoHandler);
-    void parseLevel1Element(const std::shared_ptr<CdsItem>& item, IOCallback& ebmlFile, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlElement* elL1, std::unique_ptr<MemIOHandler>* pIoHandler);
-    void parseHead(const std::shared_ptr<CdsItem>& item, IOCallback& ebmlFile, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlMaster* info, std::unique_ptr<MemIOHandler>* pIoHandler);
+    void parseMKV(const std::shared_ptr<CdsItem>& item, MemIOHandler* pIoHandler);
+    void parseLevel1Element(const std::shared_ptr<CdsItem>& item, IOCallback& ebmlFile, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlElement* elL1, MemIOHandler* pIoHandler);
+    void parseHead(const std::shared_ptr<CdsItem>& item, IOCallback& ebmlFile, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlMaster* info, MemIOHandler* pIoHandler);
     void parseInfo(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlMaster* info);
-    void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlMaster* attachments, std::unique_ptr<MemIOHandler>* pIoHandler);
+    void parseAttachments(const std::shared_ptr<CdsItem>& item, LIBEBML_NAMESPACE::EbmlStream& ebmlStream, LIBEBML_NAMESPACE::EbmlMaster* attachments, MemIOHandler* pIoHandler);
     std::string getContentTypeFromByteVector(const LIBMATROSKA_NAMESPACE::KaxFileData& data) const;
     static void addArtworkResource(const std::shared_ptr<CdsItem>& item, const std::string& artMimetype);
 };


### PR DESCRIPTION
The class can be passed with a normal pointer instead of using a double
pointer.

Signed-off-by: Rosen Penev <rosenp@gmail.com>