### PR TITLE
grb_fs: run through clang-tidy

### DIFF
--- a/src/util/grb_fs.cc
+++ b/src/util/grb_fs.cc
@@ -63,7 +63,7 @@ bool isRegularFile(const fs::directory_entry& dirEnt, std::error_code& ec) noexc
 #endif
 }
 
-off_t getFileSize(const fs::directory_entry& dirEnt)
+std::uintmax_t getFileSize(const fs::directory_entry& dirEnt)
 {
     // unfortunately fs::file_size() is broken with old libstdc++ on 32bit systems (see #737)
 #if defined(__GLIBCXX__) && (__GLIBCXX__ <= 20190406)
@@ -220,7 +220,7 @@ bool isTheora(const fs::path& oggFilename)
         return false;
     }
 
-    if (std::fseek(f, 28, SEEK_SET) != 0) {
+    if (fseeko(f, 28, SEEK_SET) != 0) {
         throw_std_runtime_error("Incomplete file {}", oggFilename.c_str());
     }
 

--- a/src/util/grb_fs.h
+++ b/src/util/grb_fs.h
@@ -20,7 +20,7 @@ private:
     std::FILE* fd {};
 
 public:
-    GrbFile(fs::path path);
+    explicit GrbFile(fs::path path);
     ~GrbFile();
 
     std::FILE* open(const char* mode, bool fail = true);
@@ -40,7 +40,7 @@ bool isRegularFile(const fs::path& path, std::error_code& ec) noexcept;
 bool isRegularFile(const fs::directory_entry& dirEnt, std::error_code& ec) noexcept;
 
 /// \brief Returns file size of give file, if it does not exist it will throw an exception
-off_t getFileSize(const fs::directory_entry& dirEnt);
+std::uintmax_t getFileSize(const fs::directory_entry& dirEnt);
 
 /// \brief Checks if the given binary is executable by our process
 /// \param path absolute path of the binary


### PR DESCRIPTION
used std::move

Change return type to uintmax_t as that is the type returned by
file_size().

Switch to fseeko to avoid potential 32-bit problems.

Signed-off-by: Rosen Penev <rosenp@gmail.com>