### PR TITLE
remove sys/socket include

### DIFF
--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -36,7 +36,6 @@
 #include <numeric>
 #include <queue>
 #include <sstream>
-#include <sys/socket.h>
 
 #ifdef __HAIKU__
 #define _DEFAULT_SOURCE


### PR DESCRIPTION
CLion reports it as unneeded.

Signed-off-by: Rosen Penev <rosenp@gmail.com>