### PR TITLE
remove custom destructor

### DIFF
--- a/src/metadata/matroska_handler.cc
+++ b/src/metadata/matroska_handler.cc
@@ -57,14 +57,6 @@ public:
         mediaFile = file.open("rb");
     }
 
-    ~FileIOCallback() override
-    {
-        close();
-    }
-
-    FileIOCallback(const FileIOCallback&) = delete;
-    FileIOCallback& operator=(const FileIOCallback&) = delete;
-
     uint32 read(void* buffer, std::size_t size) override
     {
         assert(mediaFile);


### PR DESCRIPTION
In the one place where this is used, close() is called anyway.

Signed-off-by: Rosen Penev <rosenp@gmail.com>