### PR TITLE
remove FileIOHandler destroctor

### DIFF
--- a/src/iohandler/file_io_handler.cc
+++ b/src/iohandler/file_io_handler.cc
@@ -38,11 +38,6 @@ FileIOHandler::FileIOHandler(fs::path filename)
 {
 }
 
-FileIOHandler::~FileIOHandler()
-{
-    close();
-}
-
 void FileIOHandler::open(enum UpnpOpenFileMode mode)
 {
     if (mode != UPNP_READ)

--- a/src/iohandler/file_io_handler.h
+++ b/src/iohandler/file_io_handler.h
@@ -48,10 +48,6 @@ protected:
 public:
     /// \brief Sets the filename to work with.
     explicit FileIOHandler(fs::path filename);
-    ~FileIOHandler() override;
-
-    FileIOHandler(const FileIOHandler&) = delete;
-    FileIOHandler& operator=(const FileIOHandler&) = delete;
 
     /// \brief Opens file for reading (writing is not supported)
     void open(enum UpnpOpenFileMode mode) override;


### PR DESCRIPTION
It calls close() which is an empty function. Removing it like this uses
a defaulted destructor.

Signed-off-by: Rosen Penev <rosenp@gmail.com>