### PR TITLE
remove IOHandlerBufferHelper destructor

### DIFF
--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -55,12 +55,6 @@ void IOHandlerBufferHelper::open(enum UpnpOpenFileMode mode)
     isOpen = true;
 }
 
-IOHandlerBufferHelper::~IOHandlerBufferHelper() noexcept
-{
-    if (isOpen)
-        close();
-}
-
 std::size_t IOHandlerBufferHelper::read(char* buf, std::size_t length)
 {
     // check read on closed BufferedIOHandler

--- a/src/iohandler/io_handler_buffer_helper.h
+++ b/src/iohandler/io_handler_buffer_helper.h
@@ -52,10 +52,6 @@ public:
     /// before the first read at the very beginning or after a seek returns;
     /// 0 disables the delay
     IOHandlerBufferHelper(std::shared_ptr<Config> config, std::size_t bufSize, std::size_t initialFillSize);
-    ~IOHandlerBufferHelper() noexcept override;
-
-    IOHandlerBufferHelper(const IOHandlerBufferHelper&) = delete;
-    IOHandlerBufferHelper& operator=(const IOHandlerBufferHelper&) = delete;
 
     // inherited from IOHandler
     void open(enum UpnpOpenFileMode mode) override;


### PR DESCRIPTION
All derived classes call close() already.

Signed-off-by: Rosen Penev <rosenp@gmail.com>