### PR TITLE
add missing ixmlDocument_free call

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -113,6 +113,7 @@ void ActionRequest::update()
             UpnpActionRequest_set_ActionResult(upnp_request, result);
             UpnpActionRequest_set_ErrCode(upnp_request, errCode);
         }
+        ixmlDocument_free(result);
 #endif
     } else {
         // ok, here there can be two cases


### PR DESCRIPTION
Address Sanitizer reports a memory leak without it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>