### PR TITLE
pass shared_ptr constructors by reference

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -34,7 +34,7 @@
 #include "upnp_xml.h"
 #include "util/upnp_quirks.h"
 
-ActionRequest::ActionRequest(std::shared_ptr<Context> context, UpnpActionRequest* upnpRequest)
+ActionRequest::ActionRequest(const std::shared_ptr<Context>& context, UpnpActionRequest* upnpRequest)
     : upnp_request(upnpRequest)
     , actionName(UpnpActionRequest_get_ActionName_cstr(upnpRequest))
     , UDN(UpnpActionRequest_get_DevUDN_cstr(upnpRequest))
@@ -42,7 +42,7 @@ ActionRequest::ActionRequest(std::shared_ptr<Context> context, UpnpActionRequest
 {
     auto ctrlPtIPAddr = UpnpActionRequest_get_CtrlPtIPAddr(upnpRequest);
     std::string userAgent = UpnpActionRequest_get_Os_cstr(upnpRequest);
-    quirks = std::make_unique<Quirks>(std::move(context), ctrlPtIPAddr, userAgent);
+    quirks = std::make_unique<Quirks>(context, ctrlPtIPAddr, userAgent);
 }
 
 std::string ActionRequest::getActionName() const

--- a/src/action_request.h
+++ b/src/action_request.h
@@ -83,7 +83,7 @@ protected:
 public:
     /// \brief The Constructor takes the values from the upnp_request and fills in internal variables.
     /// \param *upnp_request Pointer to the Upnp_Action_Request structure.
-    explicit ActionRequest(std::shared_ptr<Context> context, UpnpActionRequest* upnpRequest);
+    explicit ActionRequest(const std::shared_ptr<Context>& context, UpnpActionRequest* upnpRequest);
 
     /// \brief Returns the name of the action.
     std::string getActionName() const;

--- a/src/cds_resource.cc
+++ b/src/cds_resource.cc
@@ -55,9 +55,9 @@ CdsResource::CdsResource(int handlerType,
 {
 }
 
-void CdsResource::addAttribute(resource_attributes_t res, std::string value)
+void CdsResource::addAttribute(resource_attributes_t res, const std::string& value)
 {
-    attributes[MetadataHandler::getResAttrName(res)] = std::move(value);
+    attributes[MetadataHandler::getResAttrName(res)] = value;
 }
 
 void CdsResource::mergeAttributes(const std::map<std::string, std::string>& additional)

--- a/src/cds_resource.h
+++ b/src/cds_resource.h
@@ -76,7 +76,7 @@ public:
     ///
     /// \param name attribute name
     /// \param value attribute value
-    void addAttribute(resource_attributes_t res, std::string value);
+    void addAttribute(resource_attributes_t res, const std::string& value);
 
     /// \brief Merge existing attributes with new ones
     void mergeAttributes(const std::map<std::string, std::string>& additional);

--- a/src/config/config.h
+++ b/src/config/config.h
@@ -342,7 +342,7 @@ enum config_option_t {
 class Config {
 public:
     virtual ~Config() = default;
-    virtual void updateConfigFromDatabase(std::shared_ptr<Database> database) = 0;
+    virtual void updateConfigFromDatabase(const std::shared_ptr<Database>& database) = 0;
     virtual std::string getOrigValue(const std::string& item) const = 0;
     virtual void setOrigValue(const std::string& item, const std::string& value) = 0;
     virtual void setOrigValue(const std::string& item, bool value) = 0;
@@ -355,7 +355,7 @@ public:
     /// \brief add a config option
     /// \param option option type to add.
     /// \param option option to add.
-    virtual void addOption(config_option_t option, std::shared_ptr<ConfigOption> optionValue) = 0;
+    virtual void addOption(config_option_t option, const std::shared_ptr<ConfigOption>& optionValue) = 0;
 
     /// \brief returns a config option of type std::string
     /// \param option option to retrieve.

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -97,7 +97,7 @@ std::shared_ptr<ConfigOption> ConfigManager::setOption(const pugi::xml_node& roo
     return co->getValue();
 }
 
-void ConfigManager::addOption(config_option_t option, std::shared_ptr<ConfigOption> optionValue)
+void ConfigManager::addOption(config_option_t option, const std::shared_ptr<ConfigOption>& optionValue)
 {
     options.at(option) = optionValue;
 }
@@ -460,7 +460,7 @@ void ConfigManager::load(const fs::path& userHome)
     xmlDoc = nullptr;
 }
 
-void ConfigManager::updateConfigFromDatabase(std::shared_ptr<Database> database)
+void ConfigManager::updateConfigFromDatabase(const std::shared_ptr<Database>& database)
 {
     auto values = database->getConfigValues();
     auto self = getSelf();

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -67,12 +67,12 @@ public:
     fs::path getConfigFilename() const override { return filename; }
 
     void load(const fs::path& userHome);
-    void updateConfigFromDatabase(std::shared_ptr<Database> database) override;
+    void updateConfigFromDatabase(const std::shared_ptr<Database>& database) override;
 
     /// \brief add a config option
     /// \param option option type to add.
     /// \param option option to add.
-    void addOption(config_option_t option, std::shared_ptr<ConfigOption> optionValue) override;
+    void addOption(config_option_t option, const std::shared_ptr<ConfigOption>& optionValue) override;
 
     /// \brief returns a config option of type std::string
     /// \param option option to retrieve.

--- a/src/config/config_options.h
+++ b/src/config/config_options.h
@@ -200,8 +200,8 @@ private:
 
 class AutoscanListOption : public ConfigOption {
 public:
-    explicit AutoscanListOption(std::shared_ptr<AutoscanList> option)
-        : option(std::move(option))
+    explicit AutoscanListOption(const std::shared_ptr<AutoscanList>& option)
+        : option(option)
     {
     }
 
@@ -213,7 +213,7 @@ private:
 
 class ClientConfigListOption : public ConfigOption {
 public:
-    explicit ClientConfigListOption(std::shared_ptr<ClientConfigList> option)
+    explicit ClientConfigListOption(const std::shared_ptr<ClientConfigList>& option)
         : option(std::move(option))
     {
     }
@@ -225,8 +225,8 @@ private:
 
 class DirectoryTweakOption : public ConfigOption {
 public:
-    explicit DirectoryTweakOption(std::shared_ptr<DirectoryConfigList> option)
-        : option(std::move(option))
+    explicit DirectoryTweakOption(const std::shared_ptr<DirectoryConfigList>& option)
+        : option(option)
     {
     }
     std::shared_ptr<DirectoryConfigList> getDirectoryTweakOption() const override { return option; }
@@ -237,8 +237,8 @@ protected:
 
 class TranscodingProfileListOption : public ConfigOption {
 public:
-    explicit TranscodingProfileListOption(std::shared_ptr<TranscodingProfileList> option)
-        : option(std::move(option))
+    explicit TranscodingProfileListOption(const std::shared_ptr<TranscodingProfileList>& option)
+        : option(option)
     {
     }
 
@@ -258,8 +258,8 @@ protected:
 
 class DynamicContentListOption : public ConfigOption {
 public:
-    explicit DynamicContentListOption(std::shared_ptr<DynamicContentList> option)
-        : option(std::move(option))
+    explicit DynamicContentListOption(const std::shared_ptr<DynamicContentList>& option)
+        : option(option)
     {
     }
 

--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -39,10 +39,10 @@
 
 #define INOTIFY_MAX_USER_WATCHES_FILE "/proc/sys/fs/inotify/max_user_watches"
 
-AutoscanInotify::AutoscanInotify(std::shared_ptr<ContentManager> content)
+AutoscanInotify::AutoscanInotify(const std::shared_ptr<ContentManager>& content)
     : config(content->getContext()->getConfig())
     , database(content->getContext()->getDatabase())
-    , content(std::move(content))
+    , content(content)
 {
     std::error_code ec;
     if (isRegularFile(INOTIFY_MAX_USER_WATCHES_FILE, ec)) {

--- a/src/content/autoscan_inotify.h
+++ b/src/content/autoscan_inotify.h
@@ -51,7 +51,7 @@ class ContentManager;
 
 class AutoscanInotify {
 public:
-    explicit AutoscanInotify(std::shared_ptr<ContentManager> content);
+    explicit AutoscanInotify(const std::shared_ptr<ContentManager>& content);
     ~AutoscanInotify();
 
     AutoscanInotify(const AutoscanInotify&) = delete;
@@ -104,9 +104,9 @@ private:
 
     class WatchAutoscan : public Watch {
     public:
-        WatchAutoscan(bool startPoint, std::shared_ptr<AutoscanDirectory> adir)
+        WatchAutoscan(bool startPoint, const std::shared_ptr<AutoscanDirectory>& adir)
             : Watch(WatchType::Autoscan)
-            , adir(std::move(adir))
+            , adir(adir)
             , startPoint(startPoint)
         {
         }
@@ -154,7 +154,7 @@ private:
         void setParentWd(int parentWd) { this->parentWd = parentWd; }
 
         const std::unique_ptr<std::vector<std::shared_ptr<Watch>>>& getWdWatches() const { return wdWatches; }
-        void addWatch(std::shared_ptr<Watch> w) { wdWatches->push_back(move(w)); }
+        void addWatch(const std::shared_ptr<Watch>& w) { wdWatches->push_back(w); }
 
     private:
         std::unique_ptr<std::vector<std::shared_ptr<Watch>>> wdWatches { std::make_unique<std::vector<std::shared_ptr<Watch>>>() };

--- a/src/content/autoscan_list.cc
+++ b/src/content/autoscan_list.cc
@@ -27,6 +27,11 @@
 #include "autoscan.h"
 #include "database/database.h"
 
+AutoscanList::AutoscanList(std::shared_ptr<Database> database)
+    : database(std::move(database))
+{
+}
+
 void AutoscanList::updateLMinDB()
 {
     AutoLock lock(mutex);

--- a/src/content/autoscan_list.h
+++ b/src/content/autoscan_list.h
@@ -34,10 +34,7 @@ class AutoscanDirectory;
 
 class AutoscanList {
 public:
-    explicit AutoscanList(std::shared_ptr<Database> database)
-        : database(std::move(database))
-    {
-    }
+    explicit AutoscanList(std::shared_ptr<Database> database);
 
     /// \brief Adds a new AutoscanDirectory to the list.
     ///

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -220,10 +220,10 @@ void ContentManager::run()
     }
 }
 
-void ContentManager::registerExecutor(std::shared_ptr<Executor> exec)
+void ContentManager::registerExecutor(const std::shared_ptr<Executor>& exec)
 {
     auto lock = threadRunner->lockGuard("registerExecutor");
-    process_list.push_back(std::move(exec));
+    process_list.push_back(exec);
 }
 
 void ContentManager::unregisterExecutor(const std::shared_ptr<Executor>& exec)
@@ -242,7 +242,7 @@ void ContentManager::unregisterExecutor(const std::shared_ptr<Executor>& exec)
     process_list.erase(std::remove(process_list.begin(), process_list.end(), exec), process_list.end());
 }
 
-void ContentManager::timerNotify(std::shared_ptr<Timer::Parameter> parameter)
+void ContentManager::timerNotify(const std::shared_ptr<Timer::Parameter>& parameter)
 {
     if (!parameter)
         return;
@@ -908,7 +908,7 @@ void ContentManager::finishScan(const std::shared_ptr<AutoscanDirectory>& adir, 
 }
 
 template <typename T>
-void ContentManager::updateCdsObject(std::shared_ptr<T>& item, const std::map<std::string, std::string>& parameters)
+void ContentManager::updateCdsObject(const std::shared_ptr<T>& item, const std::map<std::string, std::string>& parameters)
 {
     std::string title = getValueOrDefault(parameters, "title");
     std::string upnpClass = getValueOrDefault(parameters, "class");
@@ -922,7 +922,7 @@ void ContentManager::updateCdsObject(std::shared_ptr<T>& item, const std::map<st
 }
 
 template <>
-void ContentManager::updateCdsObject(std::shared_ptr<CdsContainer>& item, const std::map<std::string, std::string>& parameters)
+void ContentManager::updateCdsObject(const std::shared_ptr<CdsContainer>& item, const std::map<std::string, std::string>& parameters)
 {
     std::string title = getValueOrDefault(parameters, "title");
     std::string upnpClass = getValueOrDefault(parameters, "class");
@@ -951,7 +951,7 @@ void ContentManager::updateCdsObject(std::shared_ptr<CdsContainer>& item, const 
 }
 
 template <>
-void ContentManager::updateCdsObject(std::shared_ptr<CdsItem>& item, const std::map<std::string, std::string>& parameters)
+void ContentManager::updateCdsObject(const std::shared_ptr<CdsItem>& item, const std::map<std::string, std::string>& parameters)
 {
     std::string title = getValueOrDefault(parameters, "title");
     std::string upnpClass = getValueOrDefault(parameters, "class");

--- a/src/content/content_manager.h
+++ b/src/content/content_manager.h
@@ -145,7 +145,7 @@ public:
     void run();
     void shutdown();
 
-    void timerNotify(std::shared_ptr<Timer::Parameter> parameter) override;
+    void timerNotify(const std::shared_ptr<Timer::Parameter>& parameter) override;
 
     /// \brief Returns the task that is currently being executed.
     std::shared_ptr<GenericTask> getCurrentTask() const;
@@ -272,7 +272,7 @@ public:
     /// when we shutdown the server.
     ///
     /// \param exec the Executor object of the process
-    void registerExecutor(std::shared_ptr<Executor> exec);
+    void registerExecutor(const std::shared_ptr<Executor>& exec);
 
     /// \brief unregister process
     ///
@@ -343,7 +343,7 @@ protected:
     void assignFanArt(const std::shared_ptr<CdsContainer>& containerList, const std::shared_ptr<CdsObject>& origObj, int count) const;
 
     template <typename T>
-    void updateCdsObject(std::shared_ptr<T>& item, const std::map<std::string, std::string>& parameters);
+    void updateCdsObject(const std::shared_ptr<T>& item, const std::map<std::string, std::string>& parameters);
 
     std::shared_ptr<Layout> layout;
 

--- a/src/content/layout/builtin_layout.cc
+++ b/src/content/layout/builtin_layout.cc
@@ -47,8 +47,8 @@
 
 #endif // ONLINE_SERVICES
 
-BuiltinLayout::BuiltinLayout(std::shared_ptr<ContentManager> content)
-    : Layout(std::move(content))
+BuiltinLayout::BuiltinLayout(const std::shared_ptr<ContentManager>& content)
+    : Layout(content)
     , config(this->content->getContext()->getConfig())
     , genreMap(this->config->getDictionaryOption(CFG_IMPORT_SCRIPTING_IMPORT_GENRE_MAP))
 {

--- a/src/content/layout/builtin_layout.h
+++ b/src/content/layout/builtin_layout.h
@@ -43,7 +43,7 @@ class CdsObject;
 
 class BuiltinLayout : public Layout {
 public:
-    explicit BuiltinLayout(std::shared_ptr<ContentManager> content);
+    explicit BuiltinLayout(const std::shared_ptr<ContentManager>& content);
 
     void processCdsObject(const std::shared_ptr<CdsObject>& obj, const fs::path& rootpath, const std::string& mimetype, const std::string& contentType) override;
 

--- a/src/content/layout/layout.h
+++ b/src/content/layout/layout.h
@@ -41,8 +41,8 @@ class ContentManager;
 
 class Layout {
 public:
-    explicit Layout(std::shared_ptr<ContentManager> content)
-        : content(std::move(content))
+    explicit Layout(const std::shared_ptr<ContentManager>& content)
+        : content(content)
     {
     }
 

--- a/src/content/onlineservice/atrailers_service.cc
+++ b/src/content/onlineservice/atrailers_service.cc
@@ -37,8 +37,8 @@
 #define ATRAILERS_SERVICE_URL_640 "https://trailers.apple.com/trailers/home/xml/current.xml"
 #define ATRAILERS_SERVICE_URL_720P "https://trailers.apple.com/trailers/home/xml/current_720p.xml"
 
-ATrailersService::ATrailersService(std::shared_ptr<ContentManager> content)
-    : CurlOnlineService(std::move(content), ATRAILERS_SERVICE)
+ATrailersService::ATrailersService(const std::shared_ptr<ContentManager>& content)
+    : CurlOnlineService(content, ATRAILERS_SERVICE)
 {
     if (config->getOption(CFG_ONLINE_CONTENT_ATRAILERS_RESOLUTION) == "640")
         service_url = ATRAILERS_SERVICE_URL_640;

--- a/src/content/onlineservice/atrailers_service.h
+++ b/src/content/onlineservice/atrailers_service.h
@@ -44,7 +44,7 @@ class ContentManager;
 /// handles adding/refreshing content in the database.
 class ATrailersService : public CurlOnlineService {
 public:
-    explicit ATrailersService(std::shared_ptr<ContentManager> content);
+    explicit ATrailersService(const std::shared_ptr<ContentManager>& content);
 
     /// \brief Get the type of the service (i.e. Weborama, Shoutcast, etc.)
     service_type_t getServiceType() const override;

--- a/src/content/onlineservice/curl_online_service.cc
+++ b/src/content/onlineservice/curl_online_service.cc
@@ -38,8 +38,8 @@ CurlContentHandler::CurlContentHandler(const std::shared_ptr<Context>& context)
 {
 }
 
-CurlOnlineService::CurlOnlineService(std::shared_ptr<ContentManager> content, std::string serviceName)
-    : OnlineService(std::move(content))
+CurlOnlineService::CurlOnlineService(const std::shared_ptr<ContentManager>& content, std::string serviceName)
+    : OnlineService(content)
     , curl_handle(curl_easy_init())
     , serviceName(std::move(serviceName))
 {

--- a/src/content/onlineservice/curl_online_service.h
+++ b/src/content/onlineservice/curl_online_service.h
@@ -71,7 +71,7 @@ protected:
 /// handles adding/refreshing content in the database.
 class CurlOnlineService : public OnlineService {
 public:
-    explicit CurlOnlineService(std::shared_ptr<ContentManager> content, std::string serviceName);
+    explicit CurlOnlineService(const std::shared_ptr<ContentManager>& content, std::string serviceName);
     ~CurlOnlineService() override;
 
     CurlOnlineService(const CurlOnlineService&) = delete;

--- a/src/content/onlineservice/online_service.cc
+++ b/src/content/onlineservice/online_service.cc
@@ -62,10 +62,10 @@ std::shared_ptr<OnlineService> OnlineServiceList::getService(service_type_t serv
     return service_list.at(service);
 }
 
-OnlineService::OnlineService(std::shared_ptr<ContentManager> content)
+OnlineService::OnlineService(const std::shared_ptr<ContentManager>& content)
     : config(content->getContext()->getConfig())
     , database(content->getContext()->getDatabase())
-    , content(std::move(content))
+    , content(content)
 {
 }
 

--- a/src/content/onlineservice/online_service.h
+++ b/src/content/onlineservice/online_service.h
@@ -62,7 +62,7 @@ enum service_type_t {
 /// handles adding/refreshing content in the database.
 class OnlineService {
 public:
-    explicit OnlineService(std::shared_ptr<ContentManager> content);
+    explicit OnlineService(const std::shared_ptr<ContentManager>& content);
     virtual ~OnlineService() = default;
 
     /// \brief Retrieves user specified content from the service and adds

--- a/src/content/scripting/import_script.cc
+++ b/src/content/scripting/import_script.cc
@@ -36,9 +36,9 @@
 #include "content/content_manager.h"
 #include "js_functions.h"
 
-ImportScript::ImportScript(std::shared_ptr<ContentManager> content,
+ImportScript::ImportScript(const std::shared_ptr<ContentManager>& content,
     const std::shared_ptr<ScriptingRuntime>& runtime)
-    : Script(std::move(content), runtime, "import")
+    : Script(content, runtime, "import")
 {
     std::string scriptPath = config->getOption(CFG_IMPORT_SCRIPTING_IMPORT_SCRIPT);
 

--- a/src/content/scripting/import_script.h
+++ b/src/content/scripting/import_script.h
@@ -43,7 +43,7 @@ class ScriptingRuntime;
 
 class ImportScript : public Script {
 public:
-    ImportScript(std::shared_ptr<ContentManager> content,
+    ImportScript(const std::shared_ptr<ContentManager>& content,
         const std::shared_ptr<ScriptingRuntime>& runtime);
 
     void processCdsObject(const std::shared_ptr<CdsObject>& obj, const std::string& scriptpath);

--- a/src/content/scripting/playlist_parser_script.cc
+++ b/src/content/scripting/playlist_parser_script.cc
@@ -110,9 +110,9 @@ jsGetCdsObject(duk_context* ctx)
 
 } // extern "C"
 
-PlaylistParserScript::PlaylistParserScript(std::shared_ptr<ContentManager> content,
+PlaylistParserScript::PlaylistParserScript(const std::shared_ptr<ContentManager>& content,
     const std::shared_ptr<ScriptingRuntime>& runtime)
-    : Script(std::move(content), runtime, "playlist")
+    : Script(content, runtime, "playlist")
 {
     ScriptingRuntime::AutoLock lock(runtime->getMutex());
     defineFunction("readln", jsReadln, 0);
@@ -141,7 +141,7 @@ std::string PlaylistParserScript::readln()
     }
 }
 
-void PlaylistParserScript::processPlaylistObject(const std::shared_ptr<CdsObject>& obj, std::shared_ptr<GenericTask> task, const std::string& scriptpath)
+void PlaylistParserScript::processPlaylistObject(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<GenericTask>& task, const std::string& scriptpath)
 {
     if ((currentObjectID != INVALID_OBJECT_ID) || currentHandle || currentLine) {
         throw_std_runtime_error("recursion not allowed");
@@ -153,7 +153,7 @@ void PlaylistParserScript::processPlaylistObject(const std::shared_ptr<CdsObject
     GrbFile file(obj->getLocation());
     currentHandle = file.open("r");
 
-    currentTask = std::move(task);
+    currentTask = task;
     currentObjectID = obj->getID();
     currentLine = new char[ONE_TEXTLINE_BYTES];
     currentLine[0] = '\0';

--- a/src/content/scripting/playlist_parser_script.h
+++ b/src/content/scripting/playlist_parser_script.h
@@ -44,11 +44,11 @@ class GenericTask;
 
 class PlaylistParserScript : public Script {
 public:
-    PlaylistParserScript(std::shared_ptr<ContentManager> content,
+    PlaylistParserScript(const std::shared_ptr<ContentManager>& content,
         const std::shared_ptr<ScriptingRuntime>& runtime);
 
     std::string readln();
-    void processPlaylistObject(const std::shared_ptr<CdsObject>& obj, std::shared_ptr<GenericTask> task, const std::string& scriptpath);
+    void processPlaylistObject(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<GenericTask>& task, const std::string& scriptpath);
     script_class_t whoami() override;
 
 private:

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -163,11 +163,11 @@ void Script::setIntProperty(const std::string& name, int value)
 
 /* **************** */
 
-Script::Script(std::shared_ptr<ContentManager> content,
+Script::Script(const std::shared_ptr<ContentManager>& content,
     const std::shared_ptr<ScriptingRuntime>& runtime, const std::string& name)
     : config(content->getContext()->getConfig())
     , database(content->getContext()->getDatabase())
-    , content(std::move(content))
+    , content(content)
     , runtime(runtime)
     , name(name)
 {

--- a/src/content/scripting/script.h
+++ b/src/content/scripting/script.h
@@ -96,7 +96,7 @@ public:
     std::shared_ptr<ContentManager> getContent() const { return content; }
 
 protected:
-    Script(std::shared_ptr<ContentManager> content,
+    Script(const std::shared_ptr<ContentManager>& content,
         const std::shared_ptr<ScriptingRuntime>& runtime, const std::string& name);
 
     void execute();

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -69,9 +69,9 @@ protected:
     int totalMatches {};
 
 public:
-    BrowseParam(std::shared_ptr<CdsObject> object, unsigned int flags)
+    BrowseParam(const std::shared_ptr<CdsObject>& object, unsigned int flags)
         : flags(flags)
-        , object(std::move(object))
+        , object(object)
     {
     }
 
@@ -259,7 +259,7 @@ public:
 
     /* autoscan methods */
     virtual std::shared_ptr<AutoscanList> getAutoscanList(ScanMode scanode) = 0;
-    virtual void updateAutoscanList(ScanMode scanmode, std::shared_ptr<AutoscanList> list) = 0;
+    virtual void updateAutoscanList(ScanMode scanmode, const std::shared_ptr<AutoscanList>& list) = 0;
 
     /* config methods */
     virtual std::vector<ConfigValue> getConfigValues() = 0;
@@ -272,9 +272,9 @@ public:
     /// \return nullptr if the given id is no autoscan start point,
     /// or the matching AutoscanDirectory
     virtual std::shared_ptr<AutoscanDirectory> getAutoscanDirectory(int objectID) = 0;
-    virtual void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) = 0;
-    virtual void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) = 0;
-    virtual void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) = 0;
+    virtual void addAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) = 0;
+    virtual void updateAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) = 0;
+    virtual void removeAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) = 0;
     virtual void checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir) = 0;
 
     virtual std::vector<int> getPathIDs(int objectID) = 0;

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -47,8 +47,8 @@
 #define MYSQL_UPDATE_VERSION "UPDATE `mt_internal_setting` SET `value`='{}' WHERE `key`='db_version' AND `value`='{}'"
 #define MYSQL_ADD_RESOURCE_ATTR "ALTER TABLE `grb_cds_resource` ADD COLUMN `{}` varchar(255) default NULL"
 
-MySQLDatabase::MySQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime)
-    : SQLDatabase(std::move(config), std::move(mime))
+MySQLDatabase::MySQLDatabase(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime)
+    : SQLDatabase(config, mime)
 {
     table_quote_begin = '`';
     table_quote_end = '`';
@@ -216,6 +216,12 @@ std::string MySQLDatabase::getError(MYSQL* db)
     return res;
 }
 
+MySQLDatabaseWithTransactions::MySQLDatabaseWithTransactions(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime)
+    : SqlWithTransactions(config)
+    , MySQLDatabase(config, mime)
+{
+}
+
 void MySQLDatabaseWithTransactions::beginTransaction(std::string_view tName)
 {
     log_debug("START TRANSACTION {} {}", tName, inTransaction);
@@ -344,6 +350,11 @@ void MySQLDatabase::_exec(const std::string& query)
 }
 
 /* MysqlResult */
+
+MysqlResult::MysqlResult(MYSQL_RES* mysql_res)
+    : mysql_res(mysql_res)
+{
+}
 
 MysqlResult::~MysqlResult()
 {

--- a/src/database/mysql/mysql_database.h
+++ b/src/database/mysql/mysql_database.h
@@ -43,7 +43,7 @@
 /// \brief The Database class for using MySQL
 class MySQLDatabase : public SQLDatabase, public std::enable_shared_from_this<SQLDatabase> {
 public:
-    explicit MySQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime);
+    explicit MySQLDatabase(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime);
     ~MySQLDatabase() override;
 
     MySQLDatabase(const MySQLDatabase&) = delete;
@@ -81,11 +81,8 @@ private:
 /// \brief The Database class for using MySQL with transactions
 class MySQLDatabaseWithTransactions : public SqlWithTransactions, public MySQLDatabase {
 public:
-    MySQLDatabaseWithTransactions(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime)
-        : SqlWithTransactions(config)
-        , MySQLDatabase(std::move(config), std::move(mime))
-    {
-    }
+    MySQLDatabaseWithTransactions(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime);
+
     void beginTransaction(std::string_view tName) override;
     void rollback(std::string_view tName) override;
     void commit(std::string_view tName) override;
@@ -95,10 +92,7 @@ public:
 
 class MysqlResult : public SQLResult {
 public:
-    explicit MysqlResult(MYSQL_RES* mysql_res)
-        : mysql_res(mysql_res)
-    {
-    }
+    explicit MysqlResult(MYSQL_RES* mysql_res);
     ~MysqlResult() override;
 
     MysqlResult(const MysqlResult&) = delete;

--- a/src/database/search_handler.h
+++ b/src/database/search_handler.h
@@ -86,10 +86,7 @@ protected:
 
 class SearchLexer {
 public:
-    explicit SearchLexer(std::string input)
-        : input(std::move(input))
-    {
-    }
+    explicit SearchLexer(std::string input);
 
     std::unique_ptr<SearchToken> nextToken();
 
@@ -128,11 +125,7 @@ protected:
 
 class ASTAsterisk : public ASTNode {
 public:
-    ASTAsterisk(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTAsterisk(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
 
 protected:
@@ -141,11 +134,7 @@ protected:
 
 class ASTProperty : public ASTNode {
 public:
-    ASTProperty(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTProperty(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
 
 protected:
@@ -154,11 +143,7 @@ protected:
 
 class ASTBoolean : public ASTNode {
 public:
-    ASTBoolean(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTBoolean(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
 
 protected:
@@ -167,11 +152,7 @@ protected:
 
 class ASTParenthesis : public ASTNode {
 public:
-    ASTParenthesis(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTNode> node)
-        : ASTNode(sqlEmitter)
-        , bracketedNode(std::move(node))
-    {
-    }
+    ASTParenthesis(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTNode> node);
     std::string emit() const override;
 
 protected:
@@ -180,11 +161,7 @@ protected:
 
 class ASTDQuote : public ASTNode {
 public:
-    ASTDQuote(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTDQuote(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
 
 protected:
@@ -193,11 +170,7 @@ protected:
 
 class ASTEscapedString : public ASTNode {
 public:
-    ASTEscapedString(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTEscapedString(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
 
 protected:
@@ -207,13 +180,7 @@ protected:
 class ASTQuotedString : public ASTNode {
 public:
     ASTQuotedString(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTDQuote> openQuote,
-        std::shared_ptr<ASTEscapedString> escapedString, std::shared_ptr<ASTDQuote> closeQuote)
-        : ASTNode(sqlEmitter)
-        , openQuote(std::move(openQuote))
-        , escapedString(std::move(escapedString))
-        , closeQuote(std::move(closeQuote))
-    {
-    }
+        std::shared_ptr<ASTEscapedString> escapedString, std::shared_ptr<ASTDQuote> closeQuote);
     std::string emit() const override;
 
 protected:
@@ -225,11 +192,7 @@ protected:
 /// \brief Represents a comparison operator such as =, >=, <
 class ASTCompareOperator : public ASTNode {
 public:
-    ASTCompareOperator(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTCompareOperator(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
     std::string emit(const std::string& property, const std::string& value) const;
     std::string getValue() const { return value; }
@@ -242,13 +205,7 @@ protected:
 class ASTCompareExpression : public ASTNode {
 public:
     ASTCompareExpression(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTProperty> lhs,
-        std::shared_ptr<ASTCompareOperator> operatr, std::shared_ptr<ASTQuotedString> rhs)
-        : ASTNode(sqlEmitter)
-        , lhs(std::move(lhs))
-        , operatr(std::move(operatr))
-        , rhs(std::move(rhs))
-    {
-    }
+        std::shared_ptr<ASTCompareOperator> operatr, std::shared_ptr<ASTQuotedString> rhs);
     std::string emit() const override;
 
 protected:
@@ -260,11 +217,7 @@ protected:
 /// \brief Represents an operator defined by a string such as contains, derivedFrom
 class ASTStringOperator : public ASTNode {
 public:
-    ASTStringOperator(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTStringOperator(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
     std::string emit(const std::string& property, const std::string& value) const;
     std::string getValue() const { return value; }
@@ -277,13 +230,7 @@ protected:
 class ASTStringExpression : public ASTNode {
 public:
     ASTStringExpression(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTProperty> lhs,
-        std::shared_ptr<ASTStringOperator> operatr, std::shared_ptr<ASTQuotedString> rhs)
-        : ASTNode(sqlEmitter)
-        , lhs(std::move(lhs))
-        , operatr(std::move(operatr))
-        , rhs(std::move(rhs))
-    {
-    }
+        std::shared_ptr<ASTStringOperator> operatr, std::shared_ptr<ASTQuotedString> rhs);
     std::string emit() const override;
 
 protected:
@@ -294,11 +241,7 @@ protected:
 
 class ASTExistsOperator : public ASTNode {
 public:
-    ASTExistsOperator(const SQLEmitter& sqlEmitter, std::string value)
-        : ASTNode(sqlEmitter)
-        , value(std::move(value))
-    {
-    }
+    ASTExistsOperator(const SQLEmitter& sqlEmitter, std::string value);
     std::string emit() const override;
     std::string emit(const std::string& property, const std::string& value) const;
 
@@ -310,13 +253,7 @@ protected:
 class ASTExistsExpression : public ASTNode {
 public:
     ASTExistsExpression(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTProperty> lhs,
-        std::shared_ptr<ASTExistsOperator> operatr, std::shared_ptr<ASTBoolean> rhs)
-        : ASTNode(sqlEmitter)
-        , lhs(std::move(lhs))
-        , operatr(std::move(operatr))
-        , rhs(std::move(rhs))
-    {
-    }
+        std::shared_ptr<ASTExistsOperator> operatr, std::shared_ptr<ASTBoolean> rhs);
     std::string emit() const override;
 
 protected:
@@ -327,13 +264,7 @@ protected:
 
 class ASTAndOperator : public ASTNode {
 public:
-    ASTAndOperator(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTNode> lhs,
-        std::shared_ptr<ASTNode> rhs)
-        : ASTNode(sqlEmitter)
-        , lhs(std::move(lhs))
-        , rhs(std::move(rhs))
-    {
-    }
+    ASTAndOperator(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTNode> lhs, std::shared_ptr<ASTNode> rhs);
     std::string emit() const override;
 
 protected:
@@ -343,13 +274,7 @@ protected:
 
 class ASTOrOperator : public ASTNode {
 public:
-    ASTOrOperator(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTNode> lhs,
-        std::shared_ptr<ASTNode> rhs)
-        : ASTNode(sqlEmitter)
-        , lhs(std::move(lhs))
-        , rhs(std::move(rhs))
-    {
-    }
+    ASTOrOperator(const SQLEmitter& sqlEmitter, std::shared_ptr<ASTNode> lhs, std::shared_ptr<ASTNode> rhs);
     std::string emit() const override;
 
 protected:
@@ -389,12 +314,7 @@ public:
 
 class DefaultSQLEmitter : public SQLEmitter {
 public:
-    DefaultSQLEmitter(std::shared_ptr<ColumnMapper> colMapper, std::shared_ptr<ColumnMapper> metaMapper, std::shared_ptr<ColumnMapper> resMapper)
-        : colMapper(std::move(colMapper))
-        , metaMapper(std::move(metaMapper))
-        , resMapper(std::move(resMapper))
-    {
-    }
+    DefaultSQLEmitter(std::shared_ptr<ColumnMapper> colMapper, std::shared_ptr<ColumnMapper> metaMapper, std::shared_ptr<ColumnMapper> resMapper);
 
     std::string emitSQL(const ASTNode* node) const override;
     std::string emit(const ASTAsterisk* node) const override { return {}; }
@@ -419,11 +339,7 @@ private:
 
 class SearchParser {
 public:
-    SearchParser(const SQLEmitter& sqlEmitter, const std::string& searchCriteria)
-        : lexer(std::make_unique<SearchLexer>(searchCriteria))
-        , sqlEmitter(sqlEmitter)
-    {
-    }
+    SearchParser(const SQLEmitter& sqlEmitter, const std::string& searchCriteria);
     std::shared_ptr<ASTNode> parse();
 
 protected:
@@ -515,12 +431,7 @@ private:
 
 class SortParser {
 public:
-    SortParser(std::shared_ptr<ColumnMapper> colMapper, std::shared_ptr<ColumnMapper> metaMapper, std::string sortCriteria)
-        : colMapper(std::move(colMapper))
-        , metaMapper(std::move(metaMapper))
-        , sortCrit(std::move(sortCriteria))
-    {
-    }
+    SortParser(std::shared_ptr<ColumnMapper> colMapper, std::shared_ptr<ColumnMapper> metaMapper, std::string sortCriteria);
     std::string parse(std::string& addColumns, std::string& addJoin);
 
 private:

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -310,8 +310,8 @@ static std::shared_ptr<EnumColumnMapper<AutoscanCol>> asColumnMapper;
 static std::shared_ptr<EnumColumnMapper<AutoscanColumn>> autoscanColumnMapper;
 static std::shared_ptr<EnumColumnMapper<int>> resourceColumnMapper;
 
-SQLDatabase::SQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime)
-    : Database(std::move(config))
+SQLDatabase::SQLDatabase(const std::shared_ptr<Config>& config, std::shared_ptr<Mime> mime)
+    : Database(config)
     , mime(std::move(mime))
 {
 }
@@ -2022,7 +2022,7 @@ void SQLDatabase::updateConfigValue(const std::string& key, const std::string& i
     }
 }
 
-void SQLDatabase::updateAutoscanList(ScanMode scanmode, std::shared_ptr<AutoscanList> list)
+void SQLDatabase::updateAutoscanList(ScanMode scanmode, const std::shared_ptr<AutoscanList>& list)
 {
     log_debug("setting persistent autoscans untouched - scanmode: {};", AutoscanDirectory::mapScanmode(scanmode));
 
@@ -2148,7 +2148,7 @@ std::shared_ptr<AutoscanDirectory> SQLDatabase::_fillAutoscanDirectory(const std
     return dir;
 }
 
-void SQLDatabase::addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir)
+void SQLDatabase::addAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir)
 {
     if (!adir)
         throw_std_runtime_error("addAutoscanDirectory called with adir==nullptr");
@@ -2189,7 +2189,7 @@ void SQLDatabase::addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir)
     adir->setDatabaseID(insert(AUTOSCAN_TABLE, fields, values, true));
 }
 
-void SQLDatabase::updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir)
+void SQLDatabase::updateAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir)
 {
     if (!adir)
         throw_std_runtime_error("updateAutoscanDirectory called with adir==nullptr");
@@ -2222,7 +2222,7 @@ void SQLDatabase::updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adi
     updateRow(AUTOSCAN_TABLE, fields, "id", adir->getDatabaseID());
 }
 
-void SQLDatabase::removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir)
+void SQLDatabase::removeAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir)
 {
     _removeAutoscanDirectory(adir->getDatabaseID());
 }

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -150,12 +150,12 @@ public:
     void storeInternalSetting(const std::string& key, const std::string& value) override = 0;
 
     std::shared_ptr<AutoscanList> getAutoscanList(ScanMode scanmode) override;
-    void updateAutoscanList(ScanMode scanmode, std::shared_ptr<AutoscanList> list) override;
+    void updateAutoscanList(ScanMode scanmode, const std::shared_ptr<AutoscanList>& list) override;
 
     std::shared_ptr<AutoscanDirectory> getAutoscanDirectory(int objectID) override;
-    void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
-    void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
-    void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override;
+    void addAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) override;
+    void updateAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) override;
+    void removeAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) override;
     void checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir) override;
 
     /* config methods */
@@ -185,7 +185,7 @@ public:
     void deleteRows(std::string_view tableName, std::string_view where_key, const std::vector<int>& where_values);
 
 protected:
-    explicit SQLDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime);
+    explicit SQLDatabase(const std::shared_ptr<Config>& config, std::shared_ptr<Mime> mime);
     void init() override;
 
     /// \brief migrate metadata from mt_cds_objects to mt_metadata before removing the column (DBVERSION 12)

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -93,11 +93,7 @@ protected:
 class SLInitTask : public SLTask {
 public:
     /// \brief Constructor for the sqlite3 init task
-    explicit SLInitTask(std::shared_ptr<Config> config, unsigned int hashie)
-        : config(std::move(config))
-        , hashie(hashie)
-    {
-    }
+    explicit SLInitTask(std::shared_ptr<Config> config, unsigned int hashie);
     void run(sqlite3*& db, Sqlite3Database* sl) override;
 
     std::string_view taskType() const override { return "InitTask"; }
@@ -112,10 +108,7 @@ class SLSelectTask : public SLTask {
 public:
     /// \brief Constructor for the sqlite3 select task
     /// \param query The SQL query string
-    explicit SLSelectTask(const std::string& query)
-        : query(query.c_str())
-    {
-    }
+    explicit SLSelectTask(const std::string& query);
     void run(sqlite3*& db, Sqlite3Database* sl) override;
     [[nodiscard]] std::shared_ptr<SQLResult> getResult() const { return std::static_pointer_cast<SQLResult>(pres); }
 
@@ -164,8 +157,8 @@ protected:
 /// \brief The Database class for using SQLite3
 class Sqlite3Database : public Timer::Subscriber, public SQLDatabase, public std::enable_shared_from_this<SQLDatabase> {
 public:
-    void timerNotify(std::shared_ptr<Timer::Parameter> param) override;
-    Sqlite3Database(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime, std::shared_ptr<Timer> timer);
+    void timerNotify(const std::shared_ptr<Timer::Parameter>& param) override;
+    Sqlite3Database(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime, std::shared_ptr<Timer> timer);
 
 protected:
     void _exec(const std::string& query) override;
@@ -217,11 +210,8 @@ private:
 /// \brief The Database class for using SQLite3 with transactions
 class Sqlite3DatabaseWithTransactions : public SqlWithTransactions, public Sqlite3Database {
 public:
-    Sqlite3DatabaseWithTransactions(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime, std::shared_ptr<Timer> timer)
-        : SqlWithTransactions(config)
-        , Sqlite3Database(std::move(config), std::move(mime), std::move(timer))
-    {
-    }
+    Sqlite3DatabaseWithTransactions(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime, const std::shared_ptr<Timer>& timer);
+
     void beginTransaction(std::string_view tName) override;
     void rollback(std::string_view tName) override;
     void commit(std::string_view tName) override;

--- a/src/device_description_handler.cc
+++ b/src/device_description_handler.cc
@@ -27,8 +27,8 @@
 
 #include "iohandler/mem_io_handler.h"
 
-DeviceDescriptionHandler::DeviceDescriptionHandler(std::shared_ptr<ContentManager> content, const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder)
-    : RequestHandler(std::move(content))
+DeviceDescriptionHandler::DeviceDescriptionHandler(const std::shared_ptr<ContentManager>& content, const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder)
+    : RequestHandler(content)
     , xmlBuilder(xmlBuilder)
 {
     auto desc = xmlBuilder->renderDeviceDescription();

--- a/src/device_description_handler.h
+++ b/src/device_description_handler.h
@@ -30,7 +30,7 @@
 
 class DeviceDescriptionHandler : public RequestHandler {
 public:
-    explicit DeviceDescriptionHandler(std::shared_ptr<ContentManager> content, const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder);
+    explicit DeviceDescriptionHandler(const std::shared_ptr<ContentManager>& content, const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder);
 
     void getInfo(const char* filename, UpnpFileInfo* info) override;
     std::unique_ptr<IOHandler> open(const char* filename, enum UpnpOpenFileMode mode) override;

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -45,8 +45,8 @@
 #include "util/upnp_quirks.h"
 #include "web/session_manager.h"
 
-FileRequestHandler::FileRequestHandler(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
-    : RequestHandler(std::move(content))
+FileRequestHandler::FileRequestHandler(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
+    : RequestHandler(content)
     , xmlBuilder(std::move(xmlBuilder))
 {
 }

--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -40,7 +40,7 @@
 class FileRequestHandler : public RequestHandler {
 
 public:
-    explicit FileRequestHandler(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
+    explicit FileRequestHandler(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
 
     void getInfo(const char* filename, UpnpFileInfo* info) override;
     std::unique_ptr<IOHandler> open(const char* filename, enum UpnpOpenFileMode mode) override;

--- a/src/iohandler/buffered_io_handler.cc
+++ b/src/iohandler/buffered_io_handler.cc
@@ -35,8 +35,8 @@
 
 class Config;
 
-BufferedIOHandler::BufferedIOHandler(std::shared_ptr<Config> config, std::unique_ptr<IOHandler> underlyingHandler, std::size_t bufSize, std::size_t maxChunkSize, std::size_t initialFillSize)
-    : IOHandlerBufferHelper(std::move(config), bufSize, initialFillSize)
+BufferedIOHandler::BufferedIOHandler(const std::shared_ptr<Config>& config, std::unique_ptr<IOHandler> underlyingHandler, std::size_t bufSize, std::size_t maxChunkSize, std::size_t initialFillSize)
+    : IOHandlerBufferHelper(config, bufSize, initialFillSize)
 {
     if (!underlyingHandler)
         throw_std_runtime_error("underlyingHandler must not be nullptr");

--- a/src/iohandler/buffered_io_handler.h
+++ b/src/iohandler/buffered_io_handler.h
@@ -50,7 +50,7 @@ public:
     /// \param initialFillSize the number of bytes which have to be in the buffer
     /// before the first read at the very beginning or after a seek returns;
     /// 0 disables the delay
-    BufferedIOHandler(std::shared_ptr<Config> config, std::unique_ptr<IOHandler> underlyingHandler, std::size_t bufSize, std::size_t maxChunkSize, std::size_t initialFillSize);
+    BufferedIOHandler(const std::shared_ptr<Config>& config, std::unique_ptr<IOHandler> underlyingHandler, std::size_t bufSize, std::size_t maxChunkSize, std::size_t initialFillSize);
 
     void open(enum UpnpOpenFileMode mode) override;
     void close() override;

--- a/src/iohandler/curl_io_handler.cc
+++ b/src/iohandler/curl_io_handler.cc
@@ -35,8 +35,8 @@
 #include "config/config_manager.h"
 #include "util/tools.h"
 
-CurlIOHandler::CurlIOHandler(std::shared_ptr<Config> config, const std::string& url, CURL* curlHandle, std::size_t bufSize, std::size_t initialFillSize)
-    : IOHandlerBufferHelper(std::move(config), bufSize, initialFillSize)
+CurlIOHandler::CurlIOHandler(const std::shared_ptr<Config>& config, const std::string& url, CURL* curlHandle, std::size_t bufSize, std::size_t initialFillSize)
+    : IOHandlerBufferHelper(config, bufSize, initialFillSize)
 {
     if (url.empty())
         throw_std_runtime_error("URL has not been set correctly");

--- a/src/iohandler/curl_io_handler.h
+++ b/src/iohandler/curl_io_handler.h
@@ -44,7 +44,7 @@ class Config;
 
 class CurlIOHandler : public IOHandlerBufferHelper {
 public:
-    CurlIOHandler(std::shared_ptr<Config> config, const std::string& URL, CURL* curlHandle, std::size_t bufSize, std::size_t initialFillSize);
+    CurlIOHandler(const std::shared_ptr<Config>& config, const std::string& URL, CURL* curlHandle, std::size_t bufSize, std::size_t initialFillSize);
 
     void open(enum UpnpOpenFileMode mode) override;
     void close() override;

--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -85,7 +85,7 @@ void ProcessIOHandler::registerAll()
     for (auto&& i : procList) {
         auto exec = i->getExecutor();
         if (exec)
-            content->registerExecutor(std::move(exec));
+            content->registerExecutor(exec);
     }
 }
 

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -180,7 +180,7 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
     if (pFormatCtx->duration > 0) {
         auto duration = millisecondsToHMSF(pFormatCtx->duration / (AV_TIME_BASE / 1000));
         log_debug("Added duration: {}", duration);
-        resource->addAttribute(R_DURATION, std::move(duration));
+        resource->addAttribute(R_DURATION, duration);
     }
 
     // bitrate
@@ -220,7 +220,7 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
                 auto resolution = fmt::format("{}x{}", as_codecpar(st)->width, as_codecpar(st)->height);
 
                 log_debug("Added resolution: {} pixel from stream {}", resolution, i);
-                resource2->addAttribute(R_RESOLUTION, std::move(resolution));
+                resource2->addAttribute(R_RESOLUTION, resolution);
                 videoset = true;
             }
         }

--- a/src/transcoding/transcode_dispatcher.cc
+++ b/src/transcoding/transcode_dispatcher.cc
@@ -36,9 +36,9 @@
 #include "transcode_ext_handler.h"
 #include "transcoding.h"
 
-std::unique_ptr<IOHandler> TranscodeDispatcher::serveContent(std::shared_ptr<TranscodingProfile> profile,
+std::unique_ptr<IOHandler> TranscodeDispatcher::serveContent(const std::shared_ptr<TranscodingProfile>& profile,
     std::string location,
-    std::shared_ptr<CdsObject> obj,
+    const std::shared_ptr<CdsObject>& obj,
     const std::string& range)
 {
     if (!profile)
@@ -46,7 +46,7 @@ std::unique_ptr<IOHandler> TranscodeDispatcher::serveContent(std::shared_ptr<Tra
 
     if (profile->getType() == TR_External) {
         auto trExt = std::make_unique<TranscodeExternalHandler>(std::move(content));
-        return trExt->serveContent(std::move(profile), std::move(location), std::move(obj), range);
+        return trExt->serveContent(profile, std::move(location), obj, range);
     }
 
     throw_std_runtime_error("Unknown transcoding type for profile {}", profile->getName());

--- a/src/transcoding/transcode_dispatcher.h
+++ b/src/transcoding/transcode_dispatcher.h
@@ -39,9 +39,9 @@ class TranscodeDispatcher : public TranscodeHandler {
     using TranscodeHandler::TranscodeHandler;
 
 public:
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<TranscodingProfile> profile,
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<TranscodingProfile>& profile,
         std::string location,
-        std::shared_ptr<CdsObject> obj,
+        const std::shared_ptr<CdsObject>& obj,
         const std::string& range) override;
 };
 

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -50,8 +50,8 @@
 #include "iohandler/curl_io_handler.h"
 #endif
 
-std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(std::shared_ptr<TranscodingProfile> profile,
-    std::string location, std::shared_ptr<CdsObject> obj, const std::string& range)
+std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(const std::shared_ptr<TranscodingProfile>& profile,
+    std::string location, const std::shared_ptr<CdsObject>& obj, const std::string& range)
 {
     log_debug("Start transcoding file: {}", location);
     if (!profile)

--- a/src/transcoding/transcode_ext_handler.h
+++ b/src/transcoding/transcode_ext_handler.h
@@ -44,9 +44,9 @@ class TranscodeExternalHandler : public TranscodeHandler {
     using TranscodeHandler::TranscodeHandler;
 
 public:
-    std::unique_ptr<IOHandler> serveContent(std::shared_ptr<TranscodingProfile> profile,
+    std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<TranscodingProfile>& profile,
         std::string location,
-        std::shared_ptr<CdsObject> obj,
+        const std::shared_ptr<CdsObject>& obj,
         const std::string& range) override;
 
 private:

--- a/src/transcoding/transcode_handler.cc
+++ b/src/transcoding/transcode_handler.cc
@@ -28,8 +28,8 @@
 #include "content/content_manager.h"
 #include "context.h"
 
-TranscodeHandler::TranscodeHandler(std::shared_ptr<ContentManager> content)
+TranscodeHandler::TranscodeHandler(const std::shared_ptr<ContentManager>& content)
     : config(content->getContext()->getConfig())
-    , content(std::move(content))
+    , content(content)
 {
 }

--- a/src/transcoding/transcode_handler.h
+++ b/src/transcoding/transcode_handler.h
@@ -47,12 +47,12 @@ class TranscodingProfile;
 
 class TranscodeHandler {
 public:
-    explicit TranscodeHandler(std::shared_ptr<ContentManager> content);
+    explicit TranscodeHandler(const std::shared_ptr<ContentManager>& content);
     virtual ~TranscodeHandler() = default;
 
-    virtual std::unique_ptr<IOHandler> serveContent(std::shared_ptr<TranscodingProfile> profile,
+    virtual std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<TranscodingProfile>& profile,
         std::string location,
-        std::shared_ptr<CdsObject> obj,
+        const std::shared_ptr<CdsObject>& obj,
         const std::string& range)
         = 0;
 

--- a/src/util/grb_fs.cc
+++ b/src/util/grb_fs.cc
@@ -106,8 +106,8 @@ fs::path findInPath(const fs::path& exec)
     return {};
 }
 
-GrbFile::GrbFile(const fs::path& path)
-    : path(path)
+GrbFile::GrbFile(fs::path path)
+    : path(std::move(path))
 {
 }
 

--- a/src/util/grb_fs.h
+++ b/src/util/grb_fs.h
@@ -20,7 +20,7 @@ private:
     std::FILE* fd {};
 
 public:
-    GrbFile(const fs::path& path);
+    GrbFile(fs::path path);
     ~GrbFile();
 
     std::FILE* open(const char* mode, bool fail = true);

--- a/src/util/thread_runner.h
+++ b/src/util/thread_runner.h
@@ -41,8 +41,8 @@ using ThreadProc = void* (*)(void* target);
 template <class Condition, class Mutex>
 class ThreadRunner : public ThreadExecutor {
 public:
-    ThreadRunner(std::string name, ThreadProc targetProc, void* target, std::shared_ptr<Config> config)
-        : config(std::move(config))
+    ThreadRunner(std::string name, ThreadProc targetProc, void* target, const std::shared_ptr<Config>& config)
+        : config(config)
         , threadName(std::move(name))
         , targetProc(targetProc)
         , target(target)

--- a/src/util/timer.cc
+++ b/src/util/timer.cc
@@ -59,14 +59,14 @@ void Timer::threadProc()
     triggerWait();
 }
 
-void Timer::addTimerSubscriber(Subscriber* timerSubscriber, std::chrono::seconds notifyInterval, std::shared_ptr<Parameter> parameter, bool once)
+void Timer::addTimerSubscriber(Subscriber* timerSubscriber, std::chrono::seconds notifyInterval, const std::shared_ptr<Parameter>& parameter, bool once)
 {
     log_debug("Adding subscriber... interval: {} once: {} ", notifyInterval.count(), once);
     if (notifyInterval == std::chrono::seconds::zero())
         throw_std_runtime_error("Tried to add timer with illegal notifyInterval: {}", notifyInterval.count());
 
     auto lock = threadRunner->lockGuard();
-    auto element = TimerSubscriberElement(timerSubscriber, notifyInterval, std::move(parameter), once);
+    auto element = TimerSubscriberElement(timerSubscriber, notifyInterval, parameter, once);
 
     if (!subscribers.empty()) {
         bool err = std::find(subscribers.begin(), subscribers.end(), element) != subscribers.end();
@@ -79,12 +79,12 @@ void Timer::addTimerSubscriber(Subscriber* timerSubscriber, std::chrono::seconds
     threadRunner->notify();
 }
 
-void Timer::removeTimerSubscriber(Subscriber* timerSubscriber, std::shared_ptr<Parameter> parameter, bool dontFail)
+void Timer::removeTimerSubscriber(Subscriber* timerSubscriber, const std::shared_ptr<Parameter>& parameter, bool dontFail)
 {
     log_debug("Removing subscriber...");
     auto lock = threadRunner->lockGuard();
     if (!subscribers.empty()) {
-        auto element = TimerSubscriberElement(timerSubscriber, std::chrono::seconds::zero(), std::move(parameter));
+        auto element = TimerSubscriberElement(timerSubscriber, std::chrono::seconds::zero(), parameter);
         auto it = std::find(subscribers.begin(), subscribers.end(), element);
         if (it != subscribers.end()) {
             subscribers.erase(it);

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -72,7 +72,7 @@ public:
     public:
         Subscriber() = default;
         virtual ~Subscriber() = default;
-        virtual void timerNotify(std::shared_ptr<Parameter> parameter) = 0;
+        virtual void timerNotify(const std::shared_ptr<Parameter>& parameter) = 0;
     };
 
     explicit Timer(std::shared_ptr<Config> config);
@@ -87,17 +87,17 @@ public:
     /// the same parameter argument, unless the subscription is for a one-shot
     /// timer and the subscriber has already been notified (and removed from the
     /// subscribers list).
-    void addTimerSubscriber(Subscriber* timerSubscriber, std::chrono::seconds notifyInterval, std::shared_ptr<Parameter> parameter, bool once = false);
-    void removeTimerSubscriber(Subscriber* timerSubscriber, std::shared_ptr<Parameter> parameter, bool dontFail = false);
+    void addTimerSubscriber(Subscriber* timerSubscriber, std::chrono::seconds notifyInterval, const std::shared_ptr<Parameter>& parameter, bool once = false);
+    void removeTimerSubscriber(Subscriber* timerSubscriber, const std::shared_ptr<Parameter>& parameter, bool dontFail = false);
     void triggerWait();
 
 protected:
     class TimerSubscriberElement {
     public:
-        TimerSubscriberElement(Subscriber* subscriber, std::chrono::seconds notifyInterval, std::shared_ptr<Parameter> parameter, bool once = false)
+        TimerSubscriberElement(Subscriber* subscriber, std::chrono::seconds notifyInterval, const std::shared_ptr<Parameter>& parameter, bool once = false)
             : subscriber(subscriber)
             , notifyInterval(notifyInterval)
-            , parameter(std::move(parameter))
+            , parameter(parameter)
             , once(once)
         {
             updateNextNotify();

--- a/src/web/auth.cc
+++ b/src/web/auth.cc
@@ -61,9 +61,9 @@ static bool checkToken(const std::string& token, const std::string& password, co
     return (checksum == encPassword);
 }
 
-Web::Auth::Auth(std::shared_ptr<ContentManager> content)
-    : WebRequestHandler(std::move(content))
-    , timeout(std::chrono::seconds(60 * config->getIntOption(CFG_SERVER_UI_SESSION_TIMEOUT)))
+Web::Auth::Auth(const std::shared_ptr<ContentManager>& content)
+    : WebRequestHandler(content)
+    , timeout(std::chrono::minutes(config->getIntOption(CFG_SERVER_UI_SESSION_TIMEOUT)))
 {
 }
 

--- a/src/web/config_load.cc
+++ b/src/web/config_load.cc
@@ -40,8 +40,8 @@
 #include "transcoding/transcoding.h"
 #include "util/upnp_clients.h"
 
-Web::ConfigLoad::ConfigLoad(std::shared_ptr<ContentManager> content)
-    : WebRequestHandler(std::move(content))
+Web::ConfigLoad::ConfigLoad(const std::shared_ptr<ContentManager>& content)
+    : WebRequestHandler(content)
 {
     try {
         if (this->database) {

--- a/src/web/config_save.cc
+++ b/src/web/config_save.cc
@@ -37,8 +37,8 @@
 #include "metadata/metadata_handler.h"
 #include "util/upnp_clients.h"
 
-Web::ConfigSave::ConfigSave(std::shared_ptr<Context> context, std::shared_ptr<ContentManager> content)
-    : WebRequestHandler(std::move(content))
+Web::ConfigSave::ConfigSave(std::shared_ptr<Context> context, const std::shared_ptr<ContentManager>& content)
+    : WebRequestHandler(content)
     , context(std::move(context))
 {
 }

--- a/src/web/containers.cc
+++ b/src/web/containers.cc
@@ -37,8 +37,8 @@
 #include "server.h"
 #include "upnp_xml.h"
 
-Web::Containers::Containers(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
-    : WebRequestHandler(std::move(content))
+Web::Containers::Containers(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
+    : WebRequestHandler(content)
     , xmlBuilder(std::move(xmlBuilder))
 {
 }

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -40,8 +40,8 @@
 #include "upnp_xml.h"
 #include "util/tools.h"
 
-Web::EditLoad::EditLoad(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
-    : WebRequestHandler(std::move(content))
+Web::EditLoad::EditLoad(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
+    : WebRequestHandler(content)
     , xmlBuilder(std::move(xmlBuilder))
 {
 }

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -37,8 +37,8 @@
 #include "server.h"
 #include "upnp_xml.h"
 
-Web::Items::Items(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
-    : WebRequestHandler(std::move(content))
+Web::Items::Items(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
+    : WebRequestHandler(content)
     , xmlBuilder(std::move(xmlBuilder))
 {
 }

--- a/src/web/pages.cc
+++ b/src/web/pages.cc
@@ -34,45 +34,45 @@
 namespace Web {
 
 std::unique_ptr<WebRequestHandler> createWebRequestHandler(
-    std::shared_ptr<Context> context,
-    std::shared_ptr<ContentManager> content,
-    std::shared_ptr<UpnpXMLBuilder> xmlBuilder,
-    std::string_view page)
+    const std::shared_ptr<Context>& context,
+    const std::shared_ptr<ContentManager>& content,
+    const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder,
+    const std::string& page)
 {
     if (page == "add")
-        return std::make_unique<Web::Add>(std::move(content));
+        return std::make_unique<Web::Add>(content);
     if (page == "remove")
-        return std::make_unique<Web::Remove>(std::move(content));
+        return std::make_unique<Web::Remove>(content);
     if (page == "add_object")
-        return std::make_unique<Web::AddObject>(std::move(content));
+        return std::make_unique<Web::AddObject>(content);
     if (page == "auth")
-        return std::make_unique<Web::Auth>(std::move(content));
+        return std::make_unique<Web::Auth>(content);
     if (page == "containers")
-        return std::make_unique<Web::Containers>(std::move(content), std::move(xmlBuilder));
+        return std::make_unique<Web::Containers>(content, xmlBuilder);
     if (page == "directories")
-        return std::make_unique<Web::Directories>(std::move(content));
+        return std::make_unique<Web::Directories>(content);
     if (page == "files")
-        return std::make_unique<Web::Files>(std::move(content));
+        return std::make_unique<Web::Files>(content);
     if (page == "items")
-        return std::make_unique<Web::Items>(std::move(content), std::move(xmlBuilder));
+        return std::make_unique<Web::Items>(content, xmlBuilder);
     if (page == "edit_load")
-        return std::make_unique<Web::EditLoad>(std::move(content), std::move(xmlBuilder));
+        return std::make_unique<Web::EditLoad>(content, xmlBuilder);
     if (page == "edit_save")
-        return std::make_unique<Web::EditSave>(std::move(content));
+        return std::make_unique<Web::EditSave>(content);
     if (page == "autoscan")
-        return std::make_unique<Web::Autoscan>(std::move(content));
+        return std::make_unique<Web::Autoscan>(content);
     if (page == "void")
-        return std::make_unique<Web::VoidType>(std::move(content));
+        return std::make_unique<Web::VoidType>(content);
     if (page == "tasks")
-        return std::make_unique<Web::Tasks>(std::move(content));
+        return std::make_unique<Web::Tasks>(content);
     if (page == "action")
-        return std::make_unique<Web::Action>(std::move(content));
+        return std::make_unique<Web::Action>(content);
     if (page == "clients")
-        return std::make_unique<Web::Clients>(std::move(content));
+        return std::make_unique<Web::Clients>(content);
     if (page == "config_load")
-        return std::make_unique<Web::ConfigLoad>(std::move(content));
+        return std::make_unique<Web::ConfigLoad>(content);
     if (page == "config_save")
-        return std::make_unique<Web::ConfigSave>(std::move(context), std::move(content));
+        return std::make_unique<Web::ConfigSave>(context, content);
 
     throw_std_runtime_error("Unknown page: {}", page);
 }

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -54,7 +54,7 @@ protected:
     std::chrono::seconds timeout {};
 
 public:
-    explicit Auth(std::shared_ptr<ContentManager> content);
+    explicit Auth(const std::shared_ptr<ContentManager>& content);
     void process() override;
 };
 
@@ -64,7 +64,7 @@ protected:
     std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
 
 public:
-    explicit Containers(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
+    explicit Containers(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
     void process() override;
 };
 
@@ -90,7 +90,7 @@ protected:
     std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
 
 public:
-    explicit Items(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
+    explicit Items(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
     void process() override;
 };
 
@@ -116,7 +116,7 @@ protected:
     std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
 
 public:
-    explicit EditLoad(std::shared_ptr<ContentManager> content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
+    explicit EditLoad(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
     void process() override;
 };
 
@@ -180,10 +180,10 @@ public:
 /// \param page identifies what type of the request we are dealing with.
 /// \return the appropriate request handler.
 std::unique_ptr<WebRequestHandler> createWebRequestHandler(
-    std::shared_ptr<Context> context,
-    std::shared_ptr<ContentManager> content,
-    std::shared_ptr<UpnpXMLBuilder> xmlBuilder,
-    std::string_view page);
+    const std::shared_ptr<Context>& context,
+    const std::shared_ptr<ContentManager>& content,
+    const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder,
+    const std::string& page);
 
 /// \brief Browse clients list
 class Clients : public WebRequestHandler {
@@ -205,7 +205,7 @@ protected:
     static void addTypeMeta(pugi::xml_node& meta, const std::shared_ptr<ConfigSetup>& cs);
 
 public:
-    explicit ConfigLoad(std::shared_ptr<ContentManager> content);
+    explicit ConfigLoad(const std::shared_ptr<ContentManager>& content);
     void process() override;
 };
 
@@ -215,7 +215,7 @@ protected:
     std::shared_ptr<Context> context;
 
 public:
-    explicit ConfigSave(std::shared_ptr<Context> context, std::shared_ptr<ContentManager> content);
+    explicit ConfigSave(std::shared_ptr<Context> context, const std::shared_ptr<ContentManager>& content);
     void process() override;
 };
 

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -221,7 +221,7 @@ void SessionManager::checkTimer()
     }
 }
 
-void SessionManager::timerNotify(std::shared_ptr<Timer::Parameter> parameter)
+void SessionManager::timerNotify(const std::shared_ptr<Timer::Parameter>& parameter)
 {
     log_debug("notified... {} web sessions.", sessions.size());
 

--- a/src/web/session_manager.h
+++ b/src/web/session_manager.h
@@ -164,7 +164,7 @@ public:
 
     void containerChangedUI(const std::vector<int>& objectIDs);
 
-    void timerNotify([[maybe_unused]] std::shared_ptr<Timer::Parameter> parameter) override;
+    void timerNotify([[maybe_unused]] const std::shared_ptr<Timer::Parameter>& parameter) override;
 };
 
 } // namespace Web

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -41,8 +41,8 @@
 
 namespace Web {
 
-WebRequestHandler::WebRequestHandler(std::shared_ptr<ContentManager> content)
-    : RequestHandler(std::move(content))
+WebRequestHandler::WebRequestHandler(const std::shared_ptr<ContentManager>& content)
+    : RequestHandler(content)
     , sessionManager(this->content->getContext()->getSessionManager())
 {
 }

--- a/src/web/web_request_handler.h
+++ b/src/web/web_request_handler.h
@@ -121,7 +121,7 @@ protected:
 
 public:
     /// \brief Constructor, currently empty.
-    explicit WebRequestHandler(std::shared_ptr<ContentManager> content);
+    explicit WebRequestHandler(const std::shared_ptr<ContentManager>& content);
 
     /// \brief Returns information about the requested content.
     /// \param filename Requested URL

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -63,7 +63,7 @@ TEST_F(UpnpXmlTest, RenderObjectContainer)
     resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo("jpg"));
     resource->addAttribute(R_RESOURCE_FILE, "/home/resource/cover.jpg");
     resource->addParameter(RESOURCE_CONTENT_TYPE, ID3_ALBUM_ART);
-    obj->addResource(move(resource));
+    obj->addResource(resource);
 
     std::ostringstream expectedXml;
     expectedXml << "<DIDL-Lite>\n";
@@ -154,7 +154,7 @@ TEST_F(UpnpXmlTest, RenderObjectItemWithResources)
     resource->addAttribute(R_DURATION, "123456");
     resource->addAttribute(R_NRAUDIOCHANNELS, "2");
     resource->addAttribute(R_SIZE, "4711");
-    obj->addResource(move(resource));
+    obj->addResource(resource);
 
     resource = std::make_shared<CdsResource>(CH_SUBTITLE);
     std::string type = "srt";
@@ -162,14 +162,14 @@ TEST_F(UpnpXmlTest, RenderObjectItemWithResources)
     resource->addAttribute(R_RESOURCE_FILE, "/home/resource/subtitle.srt");
     resource->addParameter(RESOURCE_CONTENT_TYPE, VIDEO_SUB);
     resource->addParameter("type", type);
-    obj->addResource(move(resource));
+    obj->addResource(resource);
 
     resource = std::make_shared<CdsResource>(CH_FANART);
     resource->addAttribute(R_PROTOCOLINFO, renderProtocolInfo("jpg"));
     resource->addAttribute(R_RESOURCE_FILE, "/home/resource/cover.jpg");
     resource->addAttribute(R_RESOLUTION, "200x200");
     resource->addParameter(RESOURCE_CONTENT_TYPE, ID3_ALBUM_ART);
-    obj->addResource(move(resource));
+    obj->addResource(resource);
 
     std::ostringstream expectedXml;
     expectedXml << "<DIDL-Lite>\n";

--- a/test/database/mysql_config_fake.h
+++ b/test/database/mysql_config_fake.h
@@ -49,7 +49,7 @@ public:
         //        }
         return {};
     }
-    void addOption(config_option_t option, std::shared_ptr<ConfigOption> optionValue) override { }
+    void addOption(config_option_t option, const std::shared_ptr<ConfigOption>& optionValue) override { }
     int getIntOption(config_option_t option) const override { return 0; }
     bool getBoolOption(config_option_t option) const override { return false; }
     std::map<std::string, std::string> getDictionaryOption(config_option_t option) const override { return {}; }
@@ -57,7 +57,7 @@ public:
     std::shared_ptr<AutoscanList> getAutoscanListOption(config_option_t option) const override { return nullptr; }
     std::shared_ptr<ClientConfigList> getClientConfigListOption(config_option_t option) const override { return nullptr; }
     std::shared_ptr<DirectoryConfigList> getDirectoryTweakOption(config_option_t option) const override { return nullptr; }
-    void updateConfigFromDatabase(std::shared_ptr<Database> database) override { }
+    void updateConfigFromDatabase(const std::shared_ptr<Database>& database) override { }
     std::string getOrigValue(const std::string& item) const override { return {}; }
     void setOrigValue(const std::string& item, const std::string& value) override { }
     void setOrigValue(const std::string& item, bool value) override { }

--- a/test/database/sqlite_config_fake.h
+++ b/test/database/sqlite_config_fake.h
@@ -46,7 +46,7 @@ public:
         }
         return {};
     }
-    void addOption(config_option_t option, std::shared_ptr<ConfigOption> optionValue) override { }
+    void addOption(config_option_t option, const std::shared_ptr<ConfigOption>& optionValue) override { }
     int getIntOption(config_option_t option) const override { return 0; }
     bool getBoolOption(config_option_t option) const override
     {
@@ -60,7 +60,7 @@ public:
     std::shared_ptr<AutoscanList> getAutoscanListOption(config_option_t option) const override { return nullptr; }
     std::shared_ptr<ClientConfigList> getClientConfigListOption(config_option_t option) const override { return nullptr; }
     std::shared_ptr<DirectoryConfigList> getDirectoryTweakOption(config_option_t option) const override { return nullptr; }
-    void updateConfigFromDatabase(std::shared_ptr<Database> database) override { }
+    void updateConfigFromDatabase(const std::shared_ptr<Database>& database) override { }
     std::string getOrigValue(const std::string& item) const override { return {}; }
     void setOrigValue(const std::string& item, const std::string& value) override { }
     void setOrigValue(const std::string& item, bool value) override { }

--- a/test/database/test_sql_generators.cc
+++ b/test/database/test_sql_generators.cc
@@ -29,7 +29,7 @@ class TestDatabase : public SQLDatabase, public std::enable_shared_from_this<SQL
 public:
     using SQLDatabase::identifier;
 
-    TestDatabase(std::shared_ptr<Config> config, std::shared_ptr<Mime> mime)
+    TestDatabase(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime)
         : SQLDatabase(config, mime)
     {
         table_quote_begin = '[';

--- a/test/mock/config_mock.h
+++ b/test/mock/config_mock.h
@@ -10,7 +10,7 @@ class ConfigMock : public Config {
 public:
     fs::path getConfigFilename() const override { return {}; }
     MOCK_METHOD(std::string, getOption, (config_option_t option), (const override));
-    void addOption(config_option_t option, std::shared_ptr<ConfigOption> optionValue) override { }
+    void addOption(config_option_t option, const std::shared_ptr<ConfigOption>& optionValue) override { }
     int getIntOption(config_option_t option) const override { return 0; }
     bool getBoolOption(config_option_t option) const override { return false; }
     std::map<std::string, std::string> getDictionaryOption(config_option_t option) const override
@@ -38,7 +38,7 @@ public:
     std::shared_ptr<AutoscanList> getAutoscanListOption(config_option_t option) const override { return nullptr; }
     std::shared_ptr<ClientConfigList> getClientConfigListOption(config_option_t option) const override { return nullptr; }
     std::shared_ptr<DirectoryConfigList> getDirectoryTweakOption(config_option_t option) const override { return nullptr; }
-    void updateConfigFromDatabase(std::shared_ptr<Database> database) override { }
+    void updateConfigFromDatabase(const std::shared_ptr<Database>& database) override { }
     std::string getOrigValue(const std::string& item) const override { return {}; }
     void setOrigValue(const std::string& item, const std::string& value) override { }
     void setOrigValue(const std::string& item, bool value) override { }

--- a/test/mock/database_mock.h
+++ b/test/mock/database_mock.h
@@ -57,12 +57,12 @@ public:
     void updateConfigValue(const std::string& key, const std::string& item, const std::string& value, const std::string& status = "unchanged") override { }
 
     std::shared_ptr<AutoscanList> getAutoscanList(ScanMode scanode) override { return {}; }
-    void updateAutoscanList(ScanMode scanmode, std::shared_ptr<AutoscanList> list) override { }
+    void updateAutoscanList(ScanMode scanmode, const std::shared_ptr<AutoscanList>& list) override { }
 
     std::shared_ptr<AutoscanDirectory> getAutoscanDirectory(int objectID) override { return {}; }
-    void addAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override { }
-    void updateAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override { }
-    void removeAutoscanDirectory(std::shared_ptr<AutoscanDirectory> adir) override { }
+    void addAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) override { }
+    void updateAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) override { }
+    void removeAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir) override { }
     void checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir) override { }
 
     std::vector<int> getPathIDs(int objectID) override { return {}; }


### PR DESCRIPTION
Memory Sanitizer indicates memory leaks related to shared_ptrs passed by
value. Passing by const reference seems to fix most of them. While they
seem to be small, they probably add up over time.

Also smaller compiled size.

Signed-off-by: Rosen Penev <rosenp@gmail.com>