### PR TITLE
CdsContainer: Comment out overriden function

### DIFF
--- a/src/cds_objects.cc
+++ b/src/cds_objects.cc
@@ -203,13 +203,15 @@ bool CdsContainer::equals(const std::shared_ptr<CdsObject>& obj, bool exactly) c
     return CdsObject::equals(obj, exactly) && isSearchable() == cont->isSearchable();
 }
 
+/*
 void CdsContainer::validate() const
 {
     CdsObject::validate();
     /// \todo well.. we have to know if a container is a real directory or just a virtual container in the database
-    /*    if (!fs::is_directory(this->location, true))
-        throw_std_runtime_error("validation failed"); */
+      if (!fs::is_directory(this->location, true))
+        throw_std_runtime_error("validation failed");
 }
+*/
 
 std::string_view CdsObject::mapObjectType(unsigned int type)
 {

--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -530,9 +530,10 @@ public:
     ///
     /// See description for CdsObject::equals() for details.
     bool equals(const std::shared_ptr<CdsObject>& obj, bool exactly = false) const override;
-
-    /// \brief Checks if the minimum required parameters for the object have been set and are valid.
-    void validate() const override;
+    /*
+        /// \brief Checks if the minimum required parameters for the object have been set and are valid.
+        void validate() const override;
+    */
 };
 
 #endif // __CDS_OBJECTS_H__


### PR DESCRIPTION
Doing so simply inherits it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>