### PR TITLE
remove old libupnp compatibility

### DIFF
--- a/src/util/upnp_headers.cc
+++ b/src/util/upnp_headers.cc
@@ -26,11 +26,7 @@
 #include "upnp_headers.h" // API
 
 #if !defined(USING_NPUPNP)
-#if (UPNP_VERSION > 11299)
 #include <UpnpExtraHeaders.h>
-#else
-#include <ExtraHeaders.h>
-#endif
 #endif
 
 #include "common.h"


### PR DESCRIPTION
Minimum version is 1.14 now.

Signed-off-by: Rosen Penev <rosenp@gmail.com>