### PR TITLE
remove cast with make_shared

### DIFF
--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -1885,7 +1885,7 @@ void CMFetchOnlineContentTask::run()
         return;
     }
     try {
-        auto t = std::static_pointer_cast<GenericTask>(std::make_shared<TPFetchOnlineContentTask>(content, task_processor, timer, service, layout, cancellable, unscheduled_refresh));
+        auto t = std::make_shared<TPFetchOnlineContentTask>(content, task_processor, timer, service, layout, cancellable, unscheduled_refresh);
         task_processor->addTask(t);
     } catch (const std::runtime_error& ex) {
         log_error("{}", ex.what());


### PR DESCRIPTION
shared_ptr handles this automatically.

Signed-off-by: Rosen Penev <rosenp@gmail.com>