### PR TITLE
Delay release of ixmlDocument

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -108,6 +108,8 @@ void ActionRequest::update()
         if (err != IXML_SUCCESS) {
             log_error("ActionRequest::update(): could not convert to iXML");
             UpnpActionRequest_set_ErrCode(upnp_request, UPNP_E_ACTION_FAILED);
+            if (result)
+                ixmlDocument_free(result);
         } else {
             log_debug("ActionRequest::update(): converted to iXML, code {}", errCode);
             UpnpActionRequest_set_ActionResult(upnp_request, result);

--- a/src/server.cc
+++ b/src/server.cc
@@ -337,6 +337,8 @@ void Server::shutdown()
     timer->shutdown();
     timer = nullptr;
 
+    context = nullptr;
+
     mime = nullptr;
     clients = nullptr;
 }


### PR DESCRIPTION
Avoid early ixmlDocument_free.
Make sure object is not needed anymore.