### PR TITLE
make all mutexes mutable

### DIFF
--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -81,13 +81,13 @@ std::size_t ClientConfigList::getEditSize() const
     return std::max_element(indexMap.begin(), indexMap.end(), [](auto a, auto b) { return (a.first < b.first); })->first + 1;
 }
 
-std::vector<std::shared_ptr<ClientConfig>> ClientConfigList::getArrayCopy()
+std::vector<std::shared_ptr<ClientConfig>> ClientConfigList::getArrayCopy() const
 {
     AutoLock lock(mutex);
     return list;
 }
 
-std::shared_ptr<ClientConfig> ClientConfigList::get(std::size_t id, bool edit)
+std::shared_ptr<ClientConfig> ClientConfigList::get(std::size_t id, bool edit) const
 {
     AutoLock lock(mutex);
     if (!edit) {
@@ -97,7 +97,7 @@ std::shared_ptr<ClientConfig> ClientConfigList::get(std::size_t id, bool edit)
         return list[id];
     }
     if (indexMap.find(id) != indexMap.end()) {
-        return indexMap[id];
+        return indexMap.at(id);
     }
     return nullptr;
 }

--- a/src/config/client_config.h
+++ b/src/config/client_config.h
@@ -45,7 +45,7 @@ public:
     /// \return scanID of the newly added ClientConfig
     void add(const std::shared_ptr<ClientConfig>& client, std::size_t index = std::numeric_limits<std::size_t>::max());
 
-    std::shared_ptr<ClientConfig> get(std::size_t id, bool edit = false);
+    std::shared_ptr<ClientConfig> get(std::size_t id, bool edit = false) const;
 
     std::size_t getEditSize() const;
 
@@ -55,13 +55,13 @@ public:
     void remove(std::size_t id, bool edit = false);
 
     /// \brief returns a copy of the client config list in the form of an array
-    std::vector<std::shared_ptr<ClientConfig>> getArrayCopy();
+    std::vector<std::shared_ptr<ClientConfig>> getArrayCopy() const;
 
 protected:
     std::size_t origSize {};
     std::map<std::size_t, std::shared_ptr<ClientConfig>> indexMap;
 
-    std::recursive_mutex mutex;
+    mutable std::recursive_mutex mutex;
     using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<ClientConfig>> list;

--- a/src/config/directory_tweak.cc
+++ b/src/config/directory_tweak.cc
@@ -79,13 +79,13 @@ std::size_t DirectoryConfigList::getEditSize() const
     return std::max_element(indexMap.begin(), indexMap.end(), [](auto a, auto b) { return (a.first < b.first); })->first + 1;
 }
 
-std::vector<std::shared_ptr<DirectoryTweak>> DirectoryConfigList::getArrayCopy()
+std::vector<std::shared_ptr<DirectoryTweak>> DirectoryConfigList::getArrayCopy() const
 {
     AutoLock lock(mutex);
     return list;
 }
 
-std::shared_ptr<DirectoryTweak> DirectoryConfigList::get(std::size_t id, bool edit)
+std::shared_ptr<DirectoryTweak> DirectoryConfigList::get(std::size_t id, bool edit) const
 {
     AutoLock lock(mutex);
     if (!edit) {
@@ -95,12 +95,12 @@ std::shared_ptr<DirectoryTweak> DirectoryConfigList::get(std::size_t id, bool ed
         return list[id];
     }
     if (indexMap.find(id) != indexMap.end()) {
-        return indexMap[id];
+        return indexMap.at(id);
     }
     return nullptr;
 }
 
-std::shared_ptr<DirectoryTweak> DirectoryConfigList::get(const fs::path& location)
+std::shared_ptr<DirectoryTweak> DirectoryConfigList::get(const fs::path& location) const
 {
     AutoLock lock(mutex);
     auto&& myLocation = location.has_filename() ? location.parent_path() : location;

--- a/src/config/directory_tweak.h
+++ b/src/config/directory_tweak.h
@@ -58,9 +58,9 @@ public:
     /// \return scanID of the newly added DirectoryTweak
     void add(const std::shared_ptr<DirectoryTweak>& dir, std::size_t index = std::numeric_limits<std::size_t>::max());
 
-    std::shared_ptr<DirectoryTweak> get(std::size_t id, bool edit = false);
+    std::shared_ptr<DirectoryTweak> get(std::size_t id, bool edit = false) const;
 
-    std::shared_ptr<DirectoryTweak> get(const fs::path& location);
+    std::shared_ptr<DirectoryTweak> get(const fs::path& location) const;
 
     std::size_t getEditSize() const;
 
@@ -70,13 +70,13 @@ public:
     void remove(std::size_t id, bool edit = false);
 
     /// \brief returns a copy of the directory config list in the form of an array
-    std::vector<std::shared_ptr<DirectoryTweak>> getArrayCopy();
+    std::vector<std::shared_ptr<DirectoryTweak>> getArrayCopy() const;
 
 protected:
     std::size_t origSize {};
     std::map<std::size_t, std::shared_ptr<DirectoryTweak>> indexMap;
 
-    std::recursive_mutex mutex;
+    mutable std::recursive_mutex mutex;
     using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<DirectoryTweak>> list;

--- a/src/config/dynamic_content.cc
+++ b/src/config/dynamic_content.cc
@@ -56,13 +56,13 @@ std::size_t DynamicContentList::getEditSize() const
     return std::max_element(indexMap.begin(), indexMap.end(), [](auto a, auto b) { return (a.first < b.first); })->first + 1;
 }
 
-std::vector<std::shared_ptr<DynamicContent>> DynamicContentList::getArrayCopy()
+std::vector<std::shared_ptr<DynamicContent>> DynamicContentList::getArrayCopy() const
 {
     AutoLock lock(mutex);
     return list;
 }
 
-std::shared_ptr<DynamicContent> DynamicContentList::get(std::size_t id, bool edit)
+std::shared_ptr<DynamicContent> DynamicContentList::get(std::size_t id, bool edit) const
 {
     AutoLock lock(mutex);
     if (!edit) {
@@ -72,12 +72,12 @@ std::shared_ptr<DynamicContent> DynamicContentList::get(std::size_t id, bool edi
         return list[id];
     }
     if (indexMap.find(id) != indexMap.end()) {
-        return indexMap[id];
+        return indexMap.at(id);
     }
     return nullptr;
 }
 
-std::shared_ptr<DynamicContent> DynamicContentList::get(const fs::path& location)
+std::shared_ptr<DynamicContent> DynamicContentList::get(const fs::path& location) const
 {
     AutoLock lock(mutex);
     auto entry = std::find_if(list.begin(), list.end(), [=](auto&& c) { return c->getLocation() == location; });

--- a/src/config/dynamic_content.h
+++ b/src/config/dynamic_content.h
@@ -45,9 +45,9 @@ public:
     /// \return index of the newly added DynamicContent
     void add(const std::shared_ptr<DynamicContent>& cont, std::size_t index = std::numeric_limits<std::size_t>::max());
 
-    std::shared_ptr<DynamicContent> get(std::size_t id, bool edit = false);
+    std::shared_ptr<DynamicContent> get(std::size_t id, bool edit = false) const;
 
-    std::shared_ptr<DynamicContent> get(const fs::path& location);
+    std::shared_ptr<DynamicContent> get(const fs::path& location) const;
 
     std::size_t getEditSize() const;
 
@@ -57,13 +57,13 @@ public:
     void remove(std::size_t id, bool edit = false);
 
     /// \brief returns a copy of the directory config list in the form of an array
-    std::vector<std::shared_ptr<DynamicContent>> getArrayCopy();
+    std::vector<std::shared_ptr<DynamicContent>> getArrayCopy() const;
 
 protected:
     std::size_t origSize {};
     std::map<std::size_t, std::shared_ptr<DynamicContent>> indexMap;
 
-    std::recursive_mutex mutex;
+    mutable std::recursive_mutex mutex;
     using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<DynamicContent>> list;

--- a/src/content/autoscan_inotify.h
+++ b/src/content/autoscan_inotify.h
@@ -76,7 +76,7 @@ private:
 
     std::unique_ptr<Inotify> inotify;
 
-    std::mutex mutex;
+    mutable std::mutex mutex;
     using AutoLock = std::scoped_lock<std::mutex>;
 
     std::queue<std::shared_ptr<AutoscanDirectory>> monitorQueue;

--- a/src/content/autoscan_list.cc
+++ b/src/content/autoscan_list.cc
@@ -84,14 +84,14 @@ std::size_t AutoscanList::getEditSize() const
     return std::max_element(indexMap.begin(), indexMap.end(), [](auto a, auto b) { return (a.first < b.first); })->first + 1;
 }
 
-std::vector<std::shared_ptr<AutoscanDirectory>> AutoscanList::getArrayCopy()
+std::vector<std::shared_ptr<AutoscanDirectory>> AutoscanList::getArrayCopy() const
 {
     AutoLock lock(mutex);
 
     return list;
 }
 
-std::shared_ptr<AutoscanDirectory> AutoscanList::get(std::size_t id, bool edit)
+std::shared_ptr<AutoscanDirectory> AutoscanList::get(std::size_t id, bool edit) const
 {
     AutoLock lock(mutex);
     if (!edit) {
@@ -101,12 +101,12 @@ std::shared_ptr<AutoscanDirectory> AutoscanList::get(std::size_t id, bool edit)
         return list[id];
     }
     if (indexMap.find(id) != indexMap.end()) {
-        return indexMap[id];
+        return indexMap.at(id);
     }
     return nullptr;
 }
 
-std::shared_ptr<AutoscanDirectory> AutoscanList::getByObjectID(int objectID)
+std::shared_ptr<AutoscanDirectory> AutoscanList::getByObjectID(int objectID) const
 {
     AutoLock lock(mutex);
 
@@ -114,7 +114,7 @@ std::shared_ptr<AutoscanDirectory> AutoscanList::getByObjectID(int objectID)
     return it != list.end() ? *it : nullptr;
 }
 
-std::shared_ptr<AutoscanDirectory> AutoscanList::get(const fs::path& location)
+std::shared_ptr<AutoscanDirectory> AutoscanList::get(const fs::path& location) const
 {
     AutoLock lock(mutex);
 

--- a/src/content/autoscan_list.h
+++ b/src/content/autoscan_list.h
@@ -47,11 +47,11 @@ public:
 
     [[maybe_unused]] void addList(const std::shared_ptr<AutoscanList>& list);
 
-    std::shared_ptr<AutoscanDirectory> get(std::size_t id, bool edit = false);
+    std::shared_ptr<AutoscanDirectory> get(std::size_t id, bool edit = false) const;
 
-    std::shared_ptr<AutoscanDirectory> get(const fs::path& location);
+    std::shared_ptr<AutoscanDirectory> get(const fs::path& location) const;
 
-    std::shared_ptr<AutoscanDirectory> getByObjectID(int objectID);
+    std::shared_ptr<AutoscanDirectory> getByObjectID(int objectID) const;
 
     std::size_t getEditSize() const;
 
@@ -75,7 +75,7 @@ public:
     void updateLMinDB();
 
     /// \brief returns a copy of the autoscan list in the form of an array
-    std::vector<std::shared_ptr<AutoscanDirectory>> getArrayCopy();
+    std::vector<std::shared_ptr<AutoscanDirectory>> getArrayCopy() const;
 
 protected:
     std::size_t origSize {};
@@ -83,7 +83,7 @@ protected:
 
     std::shared_ptr<Database> database;
 
-    std::recursive_mutex mutex;
+    mutable std::recursive_mutex mutex;
     using AutoLock = std::scoped_lock<std::recursive_mutex>;
 
     std::vector<std::shared_ptr<AutoscanDirectory>> list;

--- a/src/content/scripting/scripting_runtime.h
+++ b/src/content/scripting/scripting_runtime.h
@@ -41,7 +41,7 @@
 class ScriptingRuntime {
 protected:
     duk_context* ctx;
-    std::recursive_mutex mutex;
+    mutable std::recursive_mutex mutex;
 
 public:
     ScriptingRuntime();
@@ -55,7 +55,7 @@ public:
     void destroyContext(const std::string& name);
 
     using AutoLock = std::scoped_lock<std::recursive_mutex>;
-    std::recursive_mutex& getMutex() { return mutex; }
+    std::recursive_mutex& getMutex() const { return mutex; }
 };
 
 #endif // __SCRIPTING_RUNTIME_H__

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -208,7 +208,7 @@ protected:
     char table_quote_end { '\0' };
     std::array<unsigned int, DBVERSION> hashies;
 
-    std::recursive_mutex sqlMutex;
+    mutable std::recursive_mutex sqlMutex;
     using SqlAutoLock = std::scoped_lock<decltype(sqlMutex)>;
     std::map<int, std::shared_ptr<CdsContainer>> dynamicContainers;
 

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -84,7 +84,7 @@ protected:
     bool decontamination {};
 
     std::condition_variable cond;
-    std::mutex mutex;
+    mutable std::mutex mutex;
 
     std::string error;
 };

--- a/src/main.cc
+++ b/src/main.cc
@@ -74,7 +74,7 @@ static struct {
     int restartFlag = 0;
     pthread_t mainThreadId;
 
-    std::mutex mutex;
+    mutable std::mutex mutex;
     std::unique_lock<std::mutex> lock { mutex };
     std::condition_variable cond;
 } _ctx;

--- a/src/metadata/ffmpeg_handler.h
+++ b/src/metadata/ffmpeg_handler.h
@@ -58,7 +58,7 @@ public:
 private:
     // The ffmpegthumbnailer code (ffmpeg?) is not threading safe.
     // Add a lock around the usage to avoid crashing randomly.
-    std::mutex thumb_mutex;
+    mutable std::mutex thumb_mutex;
     std::map<std::string, std::string> specialPropertyMap;
 
     void addFfmpegAuxdataFields(const std::shared_ptr<CdsItem>& item, const AVFormatContext* pFormatCtx) const;

--- a/src/util/thread_executor.h
+++ b/src/util/thread_executor.h
@@ -63,7 +63,7 @@ protected:
     bool threadRunning {};
 
     std::condition_variable cond;
-    std::mutex mutex;
+    mutable std::mutex mutex;
     pthread_t thread {};
 
     /// \brief abstract thread method, which needs to be overridden

--- a/src/util/thread_runner.h
+++ b/src/util/thread_runner.h
@@ -213,7 +213,7 @@ private:
     ThreadProc targetProc;
     void* target;
     Condition cond;
-    Mutex mutex;
+    mutable Mutex mutex;
     bool isReady {};
 };
 

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -229,7 +229,7 @@ const ClientInfo* Clients::getInfoByType(const std::string& match, ClientMatchTy
     return nullptr;
 }
 
-const ClientInfo* Clients::getInfoByCache(const struct sockaddr_storage* addr)
+const ClientInfo* Clients::getInfoByCache(const struct sockaddr_storage* addr) const
 {
     AutoLock lock(mutex);
 

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -104,12 +104,12 @@ private:
     const ClientInfo* getInfoByAddr(const struct sockaddr_storage* addr) const;
     const ClientInfo* getInfoByType(const std::string& match, ClientMatchType type) const;
 
-    const ClientInfo* getInfoByCache(const struct sockaddr_storage* addr);
+    const ClientInfo* getInfoByCache(const struct sockaddr_storage* addr) const;
     void updateCache(const struct sockaddr_storage* addr, const std::string& userAgent, const ClientInfo* pInfo);
 
     static std::unique_ptr<pugi::xml_document> downloadDescription(const std::string& location);
 
-    std::mutex mutex;
+    mutable std::mutex mutex;
     using AutoLock = std::scoped_lock<std::mutex>;
     std::vector<ClientCacheEntry> cache;
 

--- a/src/web/session_manager.cc
+++ b/src/web/session_manager.cc
@@ -54,7 +54,7 @@ void Session::put(const std::string& key, std::string value)
     dict[key] = std::move(value);
 }
 
-std::string Session::get(const std::string& key)
+std::string Session::get(const std::string& key) const
 {
     AutoLockR lock(rmutex);
     return getValueOrDefault(dict, key);

--- a/src/web/session_manager.h
+++ b/src/web/session_manager.h
@@ -60,7 +60,7 @@ public:
     explicit Session(std::chrono::seconds timeout);
 
     void put(const std::string& key, std::string value);
-    std::string get(const std::string& key);
+    std::string get(const std::string& key) const;
 
     /// \brief Returns the time of last access to the session.
     /// \return std::chrono::seconds
@@ -98,7 +98,7 @@ protected:
 
     void containerChangedUI(const std::vector<int>& objectIDs);
 
-    std::recursive_mutex rmutex;
+    mutable std::recursive_mutex rmutex;
     using AutoLockR = std::scoped_lock<decltype(rmutex)>;
     std::map<std::string, std::string> dict;
 
@@ -127,7 +127,7 @@ class SessionManager : public Timer::Subscriber {
 protected:
     std::shared_ptr<Timer> timer;
 
-    std::mutex mutex;
+    mutable std::mutex mutex;
     using AutoLock = std::scoped_lock<decltype(mutex)>;
 
     /// \brief This array is holding available sessions.


### PR DESCRIPTION
Allows using them in const member functions.

Signed-off-by: Rosen Penev <rosenp@gmail.com>