### PR TITLE
Refactor file_request_handler

### DIFF
--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -49,8 +49,9 @@ protected:
     std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
 
 private:
-    std::shared_ptr<CdsObject> obj;
-    std::unique_ptr<IOHandler> ioHandler;
+    std::unique_ptr<Quirks> getQuirks(const UpnpFileInfo* info) const;
+    std::pair<std::string, std::size_t> parseResourceInfo(std::map<std::string, std::string>& params) const;
+    std::unique_ptr<MetadataHandler> getResourceMetadataHandler(const std::shared_ptr<CdsObject>& obj, const std::string& resourceHandler, const std::shared_ptr<CdsResource>& resource) const;
 };
 
 #endif // __FILE_REQUEST_HANDLER_H__

--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -68,6 +68,9 @@ std::size_t IOHandlerBufferHelper::read(char* buf, std::size_t length)
     // length must be positive
     assert(length > 0);
 
+    // Lovely hack to ensure constuction of the child is complete before we try to do anything
+    StdThreadRunner::waitFor(
+        "IOHandlerBufferHelper", [this] { return threadRunner != nullptr; }, 100);
     auto lock = threadRunner->uniqueLock();
 
     while ((empty || waitForInitialFillSize) && !(threadShutdown || eof || readError)) {

--- a/src/request_handler.cc
+++ b/src/request_handler.cc
@@ -80,13 +80,13 @@ std::map<std::string, std::string> RequestHandler::parseParameters(std::string_v
     return pathToMap(parameters);
 }
 
-std::shared_ptr<CdsObject> RequestHandler::getObjectById(const std::map<std::string, std::string>& params) const
+std::shared_ptr<CdsObject> RequestHandler::loadObject(const std::map<std::string, std::string>& params) const
 {
     auto it = params.find("object_id");
     if (it == params.end()) {
-        throw_std_runtime_error("getObjectById: object_id not found");
+        throw_std_runtime_error("loadObject: object_id not found");
     }
 
-    int objectID = std::stoi(it->second);
+    int objectID = stoiString(it->second);
     return database->loadObject(objectID);
 }

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -80,7 +80,7 @@ public:
     static std::string joinUrl(const std::vector<std::string>& components, bool addToEnd = false, std::string_view separator = _URL_PARAM_SEPARATOR);
 
     static std::map<std::string, std::string> parseParameters(std::string_view filename, std::string_view baseLink);
-    std::shared_ptr<CdsObject> getObjectById(const std::map<std::string, std::string>& params) const;
+    std::shared_ptr<CdsObject> loadObject(const std::map<std::string, std::string>& params) const;
 
 protected:
     std::shared_ptr<ContentManager> content;

--- a/src/url_request_handler.cc
+++ b/src/url_request_handler.cc
@@ -49,7 +49,7 @@ void URLRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     log_debug("start");
 
     auto params = parseParameters(filename, LINK_URL_REQUEST_HANDLER);
-    auto obj = getObjectById(params);
+    auto obj = loadObject(params);
     if (!obj->isExternalItem()) {
         throw_std_runtime_error("getInfo: object is not an external url item");
     }
@@ -111,7 +111,7 @@ std::unique_ptr<IOHandler> URLRequestHandler::open(const char* filename, enum Up
         throw_std_runtime_error("UPNP_WRITE unsupported");
 
     auto params = parseParameters(filename, LINK_URL_REQUEST_HANDLER);
-    auto obj = getObjectById(params);
+    auto obj = loadObject(params);
     if (!obj->isExternalItem()) {
         throw_std_runtime_error("object is not an external url item");
     }

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -114,6 +114,15 @@ void WebRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
 
 std::unique_ptr<IOHandler> WebRequestHandler::open(const char* filename, enum UpnpOpenFileMode mode)
 {
+    this->filename = filename;
+    auto&& [path, parameters] = splitUrl(filename, URL_UI_PARAM_SEPARATOR);
+    auto decodedParams = dictDecode(parameters);
+    if (params.empty()) {
+        params = std::move(decodedParams);
+    } else {
+        params.merge(decodedParams);
+    }
+
     xmlDoc = std::make_unique<pugi::xml_document>();
     auto decl = xmlDoc->prepend_child(pugi::node_declaration);
     decl.append_attribute("version") = "1.0";


### PR DESCRIPTION
Reverts the changes to cache stuff across get_info()/open() calls, this
is not feasible because libupnp may not call open() in the case of HEAD
requests, giving us no opportunity to clean up resources.

This sucks because we have to parse/load everything twice per request,
but it should stop transcoding processes being leaked.

Fixes: #2139 