### PR TITLE
Drop resourceHandler concept

### DIFF
--- a/src/cds_resource.h
+++ b/src/cds_resource.h
@@ -41,11 +41,6 @@
 /// \brief name for external urls that can appear in object resources (i.e.
 /// a YouTube thumbnail)
 #define RESOURCE_OPTION_URL "url"
-
-/// \brief if set, overrides the OBJECT_FLAG_PROXY_URL setting for the given
-/// resource
-#define RESOURCE_OPTION_PROXY_URL "prx"
-
 #define RESOURCE_OPTION_FOURCC "4cc"
 
 class CdsResource {

--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -50,8 +50,8 @@ protected:
 
 private:
     std::unique_ptr<Quirks> getQuirks(const UpnpFileInfo* info) const;
-    std::pair<std::string, std::size_t> parseResourceInfo(std::map<std::string, std::string>& params) const;
-    std::unique_ptr<MetadataHandler> getResourceMetadataHandler(const std::shared_ptr<CdsObject>& obj, const std::string& resourceHandler, const std::shared_ptr<CdsResource>& resource) const;
+    std::size_t parseResourceInfo(std::map<std::string, std::string>& params) const;
+    std::unique_ptr<MetadataHandler> getResourceMetadataHandler(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsResource>& resource) const;
 };
 
 #endif // __FILE_REQUEST_HANDLER_H__

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -255,7 +255,6 @@ void FfmpegHandler::addFfmpegResourceFields(const std::shared_ptr<CdsItem>& item
             std::string thumbMimetype = it != mappings.end() && !it->second.empty() ? it->second : "image/jpeg";
 
             auto ffres = std::make_shared<CdsResource>(CH_FFTH);
-            ffres->addParameter(RESOURCE_HANDLER, fmt::to_string(CH_FFTH));
             ffres->addOption(RESOURCE_CONTENT_TYPE, THUMBNAIL);
             ffres->addAttribute(R_PROTOCOLINFO, renderProtocolInfo(thumbMimetype));
 

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -79,7 +79,6 @@ class IOHandler;
 #define CONTENT_TYPE_WMA "wma"
 
 #define RESOURCE_CONTENT_TYPE "rct"
-#define RESOURCE_HANDLER "rh"
 
 #define ID3_ALBUM_ART "aa"
 #define VIDEO_SUB "vs"

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -400,7 +400,6 @@ std::pair<std::string, bool> UpnpXMLBuilder::renderContainerImage(const std::str
             dict[URL_OBJECT_ID] = fmt::to_string(cont->getID());
 
             auto resParams = res->getParameters();
-            resParams[RESOURCE_HANDLER] = fmt::to_string(res->getHandlerType());
             auto url = virtualURL + RequestHandler::joinUrl({ CONTENT_MEDIA_HANDLER, dictEncodeSimple(dict), URL_RESOURCE_ID, fmt::to_string(res->getResId()), dictEncodeSimple(resParams) });
             return { url, true };
         }

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -78,7 +78,7 @@ TEST_F(UpnpXmlTest, RenderObjectContainer)
     expectedXml << "<upnp:conductor>Conductor</upnp:conductor>\n";
     expectedXml << "<upnp:date>2001-01-01</upnp:date>\n";
     expectedXml << "<upnp:orchestra>Orchestra</upnp:orchestra>\n";
-    expectedXml << "<upnp:albumArtURI>http://server/content/media/object_id/1/res_id/0/rct/aa/rh/11</upnp:albumArtURI>\n";
+    expectedXml << "<upnp:albumArtURI>http://server/content/media/object_id/1/res_id/0/rct/aa</upnp:albumArtURI>\n";
     expectedXml << "</container>\n";
     expectedXml << "</DIDL-Lite>\n";
 


### PR DESCRIPTION
Nowadays thanks to Karls great work we no longer have the virtual
resource mess to deal with as things like album art now live in
the DB, so we can simplify this code a bit.

Fixes broken artwork.

In fact with this change the `rct` handler is also ignored, just
`res_id/1` is enough to get the image.
