### PR TITLE
Explicitly cast scanmode enum to int

### DIFF
--- a/src/content/autoscan.cc
+++ b/src/content/autoscan.cc
@@ -121,7 +121,7 @@ std::string_view AutoscanDirectory::mapScanmode(ScanMode scanmode)
     case ScanMode::INotify:
         return "inotify";
     }
-    throw_std_runtime_error("Illegal scanmode ({}) given to mapScanmode()", scanmode);
+    throw_std_runtime_error("Illegal scanmode ({}) given to mapScanmode()", static_cast<int>(scanmode));
 }
 
 ScanMode AutoscanDirectory::remapScanmode(const std::string& scanmode)


### PR DESCRIPTION
Newer fmt library needs this now, fmt::format does not accept
the enum as part of va_list

Fixes
/usr/include/fmt/core.h:1727:3: error: static_assert failed due to requ
irement 'formattable' "Cannot format an argument. To make type T formattable provide a formatter<T> specialization: https://fmt.dev/latest/api.html#udt"
  static_assert(

Signed-off-by: Khem Raj <raj.khem@gmail.com>