### PR TITLE
fix memory leak

### DIFF
--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -632,7 +632,11 @@ std::pair<bool, int> UpnpXMLBuilder::insertTempTranscodingResource(const std::sh
             if (tp->hideOriginalResource())
                 hideOriginalResource = true;
 
-            auto urlBase = (skipURL) ? getPathBase(item, true) : getPathBase(item);
+            auto urlBase = [&] {
+                if (skipURL)
+                    return getPathBase(item, true);
+                return getPathBase(item);
+            }();
             tRes->addOption("urlBase", fmt::format("{}{}", urlBase->pathBase, URL_VALUE_TRANSCODE_NO_RES_ID));
 
             if (tp->firstResource()) {


### PR DESCRIPTION
Using unique_ptr with a ternary operator seems to allocate both pointers
and only one ends up getting freed. Changed to lambda to avoid this.

Found with clang-tidy.

Signed-off-by: Rosen Penev <rosenp@gmail.com>