### PR TITLE
fix bugs in addFfmpegMetadataFields()

### DIFF
--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -111,6 +111,7 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
         std::pair(M_COMPOSER, "composer"),
     };
     while ((e = av_dict_get(pFormatCtx->metadata, "", e, AV_DICT_IGNORE_SUFFIX))) {
+        std::string key = e->key;
         std::string value = e->value;
         auto it = specialPropertyMap.find(e->key);
         if (it != specialPropertyMap.end()) {
@@ -122,7 +123,7 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
             }
         }
         auto pIt = std::find_if(propertyMap.begin(), propertyMap.end(),
-            [&](auto&& p) { return strcmp(p.second, e->key) == 0 && item->getMetaData(p.first).empty(); });
+            [&](auto&& p) { return p.second == key && item->getMetaData(p.first).empty(); });
         if (pIt != propertyMap.end()) {
             log_debug("Identified default metadata '{}': {}", pIt->second, value);
             field = pIt->first;
@@ -134,7 +135,7 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
             }
             continue; // iterate while loop
         }
-        if (std::strcmp(e->key, "date") == 0) {
+        if (key == "date") {
             field = M_DATE;
             /// \todo parse possible ISO8601 timestamp
             if (item->getMetaData(field).empty() && (value.length() == 4) && std::all_of(value.begin(), value.end(), ::isdigit) && (std::stoi(value) > 0)) {
@@ -143,7 +144,7 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
 
                 item->addMetaData(field, value);
             }
-        } else if (std::strcmp(e->key, "creation_time") == 0) {
+        } else if (key == "creation_time") {
             field = M_CREATION_DATE;
             if (item->getMetaData(field).empty()) {
                 log_debug("Identified metadata 'creation_time': {}", e->value);

--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -122,20 +122,19 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
             }
         }
         auto pIt = std::find_if(propertyMap.begin(), propertyMap.end(),
-            [&](auto&& p) { return p.second == e->key && item->getMetaData(p.first).empty(); });
+            [&](auto&& p) { return strcmp(p.second, e->key) == 0 && item->getMetaData(p.first).empty(); });
         if (pIt != propertyMap.end()) {
             log_debug("Identified default metadata '{}': {}", pIt->second, value);
             field = pIt->first;
             item->addMetaData(field, sc->convert(trimString(value)));
-        }
-
-        if (field != M_MAX) {
             if (field == M_TRACKNUMBER) {
                 item->setTrackNumber(stoiString(value));
             } else if (field == M_PARTNUMBER) {
                 item->setPartNumber(stoiString(value));
             }
-        } else if (std::strcmp(e->key, "date") == 0) {
+            continue; // iterate while loop
+        }
+        if (std::strcmp(e->key, "date") == 0) {
             field = M_DATE;
             /// \todo parse possible ISO8601 timestamp
             if (item->getMetaData(field).empty() && (value.length() == 4) && std::all_of(value.begin(), value.end(), ::isdigit) && (std::stoi(value) > 0)) {

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -632,7 +632,11 @@ std::pair<bool, int> UpnpXMLBuilder::insertTempTranscodingResource(const std::sh
             if (tp->hideOriginalResource())
                 hideOriginalResource = true;
 
-            auto urlBase = (skipURL) ? getPathBase(item, true) : getPathBase(item);
+            auto urlBase = [&] {
+                if (skipURL)
+                    return getPathBase(item, true);
+                return getPathBase(item);
+            }();
             tRes->addOption("urlBase", fmt::format("{}{}", urlBase->pathBase, URL_VALUE_TRANSCODE_NO_RES_ID));
 
             if (tp->firstResource()) {


### PR DESCRIPTION
I found 2 bugs in FfmpegHandler::addFfmpegMetadataFields().

1. Because both propertyMap.second and FFMpeg::metadata->key are `const char *`, we need to use `strcmp()` instead of `==`.
2.  If the metadata which is not included in `propertyMap` is found after this method processed M_TRACKNUMBER (or M_PARTNUMBER), `item->setTrackNumber(stoiString(value));` is called again incorrectly because `field` is still `M_TRACKNUMBER`.

I fixed the bugs and confirmed metadata of DSF file are set to DB correctly.