### PR TITLE
Multiply out sample rate reported by FFMpeg

### DIFF
--- a/src/config/config_definition.cc
+++ b/src/config/config_definition.cc
@@ -252,8 +252,9 @@ static const std::map<std::string, std::string> mtTransferDefaults {
 static const std::map<std::string, std::string> extMtDefaults {
     { "asf", "video/x-ms-asf" },
     { "asx", MIME_TYPE_ASX_PLAYLIST }, // tweak to handle asx as playlist
-    { "dff", "audio/x-dsd" },
-    { "dsf", "audio/x-dsd" },
+    { "dff", "audio/x-dff" },
+    { "dsd", "audio/x-dsd" },
+    { "dsf", "audio/x-dsf" },
     { "flv", "video/x-flv" },
     { "m2ts", "video/mp2t" }, // LibMagic fails to identify MPEG2 Transport Streams
     { "m3u", "audio/x-mpegurl" },

--- a/test/config/fixtures/mock-config-all.xml
+++ b/test/config/fixtures/mock-config-all.xml
@@ -71,8 +71,9 @@
       <extension-mimetype ignore-unknown="no">
         <map from="asf" to="video/x-ms-asf" />
         <map from="asx" to="video/x-ms-asx" />
-        <map from="dff" to="audio/x-dsd" />
-        <map from="dsf" to="audio/x-dsd" />
+        <map from="dff" to="audio/x-dff" />
+        <map from="dsd" to="audio/x-dsd" />
+        <map from="dsf" to="audio/x-dsf" />
         <map from="flv" to="video/x-flv" />
         <map from="m2ts" to="video/mp2t" />
         <map from="m3u" to="audio/x-mpegurl" />

--- a/test/config/fixtures/mock-import-magic-js-online.xml
+++ b/test/config/fixtures/mock-import-magic-js-online.xml
@@ -11,8 +11,9 @@
     <extension-mimetype ignore-unknown="no">
       <map from="asf" to="video/x-ms-asf" />
       <map from="asx" to="video/x-ms-asx" />
-      <map from="dff" to="audio/x-dsd" />
-      <map from="dsf" to="audio/x-dsd" />
+      <map from="dff" to="audio/x-dff" />
+      <map from="dsd" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsf" />
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />

--- a/test/config/fixtures/mock-import-magic-js.xml
+++ b/test/config/fixtures/mock-import-magic-js.xml
@@ -11,8 +11,9 @@
     <extension-mimetype ignore-unknown="no">
       <map from="asf" to="video/x-ms-asf" />
       <map from="asx" to="video/x-ms-asx" />
-      <map from="dff" to="audio/x-dsd" />
-      <map from="dsf" to="audio/x-dsd" />
+      <map from="dff" to="audio/x-dff" />
+      <map from="dsd" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsf" />
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />

--- a/test/config/fixtures/mock-import-magic.xml
+++ b/test/config/fixtures/mock-import-magic.xml
@@ -7,8 +7,9 @@
     <extension-mimetype ignore-unknown="no">
       <map from="asf" to="video/x-ms-asf" />
       <map from="asx" to="video/x-ms-asx" />
-      <map from="dff" to="audio/x-dsd" />
-      <map from="dsf" to="audio/x-dsd" />
+      <map from="dff" to="audio/x-dff" />
+      <map from="dsd" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsf" />
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />

--- a/test/config/fixtures/mock-import-mappings.xml
+++ b/test/config/fixtures/mock-import-mappings.xml
@@ -2,8 +2,9 @@
   <extension-mimetype ignore-unknown="no">
     <map from="asf" to="video/x-ms-asf" />
     <map from="asx" to="video/x-ms-asx" />
-    <map from="dff" to="audio/x-dsd" />
-    <map from="dsf" to="audio/x-dsd" />
+    <map from="dff" to="audio/x-dff" />
+    <map from="dsd" to="audio/x-dsd" />
+    <map from="dsf" to="audio/x-dsf" />
     <map from="flv" to="video/x-flv" />
     <map from="m2ts" to="video/mp2t" />
     <map from="m3u" to="audio/x-mpegurl" />

--- a/test/config/fixtures/mock-import-none.xml
+++ b/test/config/fixtures/mock-import-none.xml
@@ -6,8 +6,9 @@
     <extension-mimetype ignore-unknown="no">
       <map from="asf" to="video/x-ms-asf" />
       <map from="asx" to="video/x-ms-asx" />
-      <map from="dff" to="audio/x-dsd" />
-      <map from="dsf" to="audio/x-dsd" />
+      <map from="dff" to="audio/x-dff" />
+      <map from="dsd" to="audio/x-dsd" />
+      <map from="dsf" to="audio/x-dsf" />
       <map from="flv" to="video/x-flv" />
       <map from="m2ts" to="video/mp2t" />
       <map from="m3u" to="audio/x-mpegurl" />


### PR DESCRIPTION
When there are multiple bits per sample we would have reported an
incorrect sample rate. For PCM bits per raw/coded are both 0.

Bug: https://github.com/gerbera/gerbera/issues/2401
