### PR TITLE
Web logo link

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,2 +1,5 @@
+[*.js]
+indent_size = 2
+
 [*.xsd]
 indent_size = 4

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ sudo make install
 | inotify       |               |               |               | Optional      | Efficient file monitoring  | Enabled  |
 
 
-## Licence
+## License
 
     GPLv2
 

--- a/gerbera-web/test/e2e/menu.spec.js
+++ b/gerbera-web/test/e2e/menu.spec.js
@@ -68,12 +68,6 @@ describe('Menu Suite', () => {
       expect(tree.length).to.equal(0);
     });
 
-    it('shows the friendly name in the Home menu', async () => {
-      const homeMenu = await homePage.getHomeMenu();
-      const text = await homeMenu.getText();
-      expect(text).to.equal('Home [Gerbera Media Server]')
-    });
-
     it('shows the friendly name in the document title', async () => {
       const title = await homePage.getTitle();
       expect(title).to.equal('Gerbera Media Server | Gerbera Media Server')
@@ -92,4 +86,3 @@ describe('Menu Suite', () => {
     });
   });
 });
-

--- a/web/index.html
+++ b/web/index.html
@@ -18,12 +18,9 @@
                     aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <a class="navbar-brand" href="https://github.com/gerbera/gerbera" title="Gerbera"><img src="assets/theme/gerbera-logo-white.png" class="d-inline-block align-top" alt="Gerbera Logo"></a>
+            <a id="nav-home" class="navbar-brand" href="#" data-gerbera-menu-cmd="HOME" title="Gerbera"><img src="assets/theme/gerbera-logo-white.png" class="d-inline-block align-top" alt="Gerbera Logo"></a>
             <div class="collapse navbar-collapse" id="navbarContent">
                 <ul class="navbar-nav mr-auto">
-                    <li class="nav-item">
-                        <a id="nav-home" class="nav-link" href="#" data-gerbera-menu-cmd="HOME"><i class="fa fa-home"></i><span> Home</span> <span class="sr-only">(current)</span></a>
-                    </li>
                     <li class="nav-item">
                         <a id="nav-db" class="nav-link disabled" href="#database" data-gerbera-menu-cmd="SELECT_TYPE" data-gerbera-type="db"><i class="fa fa-database"></i><span> Database</span></a>
                     </li>
@@ -65,7 +62,7 @@
             <div class="row">
                 <div class="col-sm offset-sm-2">
                     <h2>Welcome to Gerbera</h2>
-                    <p>Gerbera is an open source UPnP-AV media server.</p>
+                    <p><a href="https://github.com/gerbera/gerbera">Gerbera</a> is an open source UPnP-AV media server.</p>
                 </div>
             </div>
         </div>

--- a/web/js/gerbera-menu.module.js
+++ b/web/js/gerbera-menu.module.js
@@ -29,7 +29,7 @@ import {Clients} from "./gerbera-clients.module.js";
 import {Config} from "./gerbera-config.module.js";
 
 const disable = () => {
-  const allLinks = $('nav li a');
+  const allLinks = $('nav li a, nav > a.navbar-brand');
   $('.nav li').removeClass('active');
   allLinks.addClass('disabled');
   allLinks.click(function () {
@@ -49,14 +49,11 @@ const hideMenu = () => {
 };
 
 const initialize = () => {
-  const allLinks = $('nav li a');
+  const allLinks = $('nav li a, nav > a.navbar-brand');
   if (GerberaApp.isLoggedIn()) {
     allLinks.click(Menu.click);
     allLinks.removeClass('disabled');
     $('#nav-home').click();
-    if(GerberaApp.serverConfig.friendlyName) {
-      $('#nav-home').text('Home [' + GerberaApp.serverConfig.friendlyName +']');
-    }
     const version = $('#gerbera-version');
     if(GerberaApp.serverConfig.version) {
       version.children('span').text(GerberaApp.serverConfig.version);
@@ -111,7 +108,12 @@ const selectConfig = (menuItem) => {
 };
 
 var click = (event) => {
-  const menuItem = $(event.target).closest('.nav-link');
+  var menuItem;
+  if ($(event.target).closest('a').attr('id') == 'nav-home') {
+    menuItem = $(event.target).closest('a');
+  } else {
+    menuItem = $(event.target).closest('.nav-link');
+  }
 
   if (!menuItem.hasClass("noactive")) {
     $('.nav-item').removeClass('active');


### PR DESCRIPTION
Most users expect the top left logo to go to the web site's main page
and not to the homepage of the application that is used.

Instead link the Gerbera github page in the introduction text
on the home screen.

Resolves: https://github.com/gerbera/gerbera/issues/2316

This PR also contains a README fix and editorconfig adjustments for .js files.