### PR TITLE
replace quote functions with template

### DIFF
--- a/src/content/autoscan.cc
+++ b/src/content/autoscan.cc
@@ -113,7 +113,7 @@ void AutoscanDirectory::setScanID(int id)
     timer_parameter->setID(id);
 }
 
-std::string_view AutoscanDirectory::mapScanmode(ScanMode scanmode)
+const char* AutoscanDirectory::mapScanmode(ScanMode scanmode)
 {
     switch (scanmode) {
     case ScanMode::Timed:

--- a/src/content/autoscan.h
+++ b/src/content/autoscan.h
@@ -141,7 +141,7 @@ public:
     std::shared_ptr<Timer::Parameter> getTimerParameter() const;
 
     /* helpers for autoscan stuff */
-    static std::string_view mapScanmode(ScanMode scanmode);
+    static const char* mapScanmode(ScanMode scanmode);
     static ScanMode remapScanmode(const std::string& scanmode);
 
 protected:

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -291,7 +291,7 @@ Script::Script(const std::shared_ptr<ContentManager>& content,
 
             duk_push_object(ctx);
             setProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_LOCATION), adir->getLocation());
-            setProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_MODE), AutoscanDirectory::mapScanmode(adir->getScanMode()).data());
+            setProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_MODE), AutoscanDirectory::mapScanmode(adir->getScanMode()));
             setIntProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_INTERVAL), adir->getInterval().count());
             setIntProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_RECURSIVE), adir->getRecursive());
             setIntProperty(ConfigDefinition::removeAttribute(ATTR_AUTOSCAN_DIRECTORY_HIDDENFILES), adir->getHidden());

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <fmt/chrono.h>
+#include <fmt/ostream.h>
 #include <vector>
 
 #include "cds_objects.h"

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -95,15 +95,17 @@ class SQLDatabase : public Database {
 public:
     /* methods to override in subclasses */
     virtual std::string quote(const std::string& str) const = 0;
-    /* wrapper functions for different types */
-    std::string quote(const char* str) const { return quote(std::string(str)); }
-    std::string quote(char val) const { return quote(fmt::to_string(val)); }
-    static std::string quote(int val) { return fmt::to_string(val); }
-    static std::string quote(unsigned int val) { return fmt::to_string(val); }
-    static std::string quote(long val) { return fmt::to_string(val); }
-    static std::string quote(unsigned long val) { return fmt::to_string(val); }
-    static std::string quote(bool val) { return val ? "1" : "0"; }
-    static std::string quote(long long val) { return fmt::to_string(val); }
+    template <typename T>
+    std::string quote(T val)
+    {
+        if constexpr (std::is_same_v<T, bool>)
+            return val ? "1" : "0";
+        if constexpr (std::is_same_v<T, char>)
+            return quote(fmt::to_string(val));
+        if constexpr (std::is_integral_v<T>)
+            return fmt::to_string(val);
+        return quote(fmt::to_string(val));
+    }
 
     // hooks for transactions
     virtual void beginTransaction(std::string_view tName) { }

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -96,8 +96,6 @@ public:
     /* methods to override in subclasses */
     virtual std::string quote(const std::string& str) const = 0;
     /* wrapper functions for different types */
-    std::string quote(std::string_view str) const { return quote(std::string(str)); }
-    // required to handle #defines
     std::string quote(const char* str) const { return quote(std::string(str)); }
     std::string quote(char val) const { return quote(fmt::to_string(val)); }
     static std::string quote(int val) { return fmt::to_string(val); }

--- a/src/web/web_autoscan.cc
+++ b/src/web/web_autoscan.cc
@@ -122,7 +122,7 @@ void Web::Autoscan::process()
             autoscanEl.append_attribute("objectID") = autoscanDir->getObjectID();
 
             autoscanEl.append_child("location").append_child(pugi::node_pcdata).set_value(autoscanDir->getLocation().c_str());
-            autoscanEl.append_child("scan_mode").append_child(pugi::node_pcdata).set_value(AutoscanDirectory::mapScanmode(autoscanDir->getScanMode()).data());
+            autoscanEl.append_child("scan_mode").append_child(pugi::node_pcdata).set_value(AutoscanDirectory::mapScanmode(autoscanDir->getScanMode()));
             autoscanEl.append_child("from_config").append_child(pugi::node_pcdata).set_value(autoscanDir->persistent() ? "1" : "0");
             // autoscanEl.append_child("scan_level").append_child(pugi::node_pcdata)
             //     .set_value(AutoscanDirectory::mapScanlevel(autoscanDir->getScanLevel()).c_str());
@@ -140,7 +140,7 @@ void Web::Autoscan::autoscan2XML(const std::shared_ptr<AutoscanDirectory>& adir,
         element.append_child("interval").append_child(pugi::node_pcdata).set_value("1800");
         element.append_child("persistent").append_child(pugi::node_pcdata).set_value("0");
     } else {
-        element.append_child("scan_mode").append_child(pugi::node_pcdata).set_value(AutoscanDirectory::mapScanmode(adir->getScanMode()).data());
+        element.append_child("scan_mode").append_child(pugi::node_pcdata).set_value(AutoscanDirectory::mapScanmode(adir->getScanMode()));
         element.append_child("recursive").append_child(pugi::node_pcdata).set_value(adir->getRecursive() ? "1" : "0");
         element.append_child("hidden").append_child(pugi::node_pcdata).set_value(adir->getHidden() ? "1" : "0");
         element.append_child("interval").append_child(pugi::node_pcdata).set_value(fmt::to_string(adir->getInterval().count()).c_str());


### PR DESCRIPTION
The ostream include is to add compatibility with std::filesystem.