### PR TITLE
don't use std::map 's merge

### DIFF
--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -90,7 +90,8 @@ void WebRequestHandler::getInfo(const char* filename, UpnpFileInfo* info)
     if (params.empty()) {
         params = std::move(decodedParams);
     } else {
-        params.merge(decodedParams);
+        for (auto&& [key, value] : decodedParams)
+            params.emplace(key, value);
     }
 
     UpnpFileInfo_set_FileLength(info, -1); // length is unknown
@@ -120,7 +121,8 @@ std::unique_ptr<IOHandler> WebRequestHandler::open(const char* filename, enum Up
     if (params.empty()) {
         params = std::move(decodedParams);
     } else {
-        params.merge(decodedParams);
+        for (auto&& [key, value] : decodedParams)
+            params.emplace(key, value);
     }
 
     xmlDoc = std::make_unique<pugi::xml_document>();


### PR DESCRIPTION
libcxx 7 does not support it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>

I'm unsure about this commit. Debian 10, which comes with libcxx 7 by default, does not compile without it. OTOH buster-backports has libcxx 8 and 11. So maybe moot.