### PR TITLE
doc/install.rst: drop Entware

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -120,14 +120,6 @@ openSUSE
 
 Gerbera is available on `software.opensuse.org <https://software.opensuse.org/package/gerbera>`_.
 
-Entware (Optware)
-~~~~~~~~~~~~~~~~~
-.. index:: Entware
-.. index:: Optware
-
-Gerbera is available in `Entware <https://github.com/Entware/rtndev/tree/master/gerbera>`_ for your embedded device/router!
-
-
 OpenWrt (OpenWrt)
 ~~~~~~~~~~~~~~~~~
 .. index:: OpenWrt


### PR DESCRIPTION
gerbera has been dropped from Entware since https://github.com/Entware/rtndev/commit/6d6803f1b5fca0f03623c14a4bd924cbe8000166

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>