### PR TITLE
CI: build-deb: Pass API key to docker env

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -35,6 +35,7 @@ jobs:
           docker run \
             --platform=${{ matrix.arch }} \
             -e TZ=Etc/UTC \
+            -e ART_API_KEY \
             -v "$(pwd):/build" \
             -w /build \
           ${{ matrix.os-ver }} \

--- a/scripts/debian/build-deb.sh
+++ b/scripts/debian/build-deb.sh
@@ -254,6 +254,8 @@ if [[ "${my_sys}" != "HEAD" ]]; then
     [[ $is_tag == 1 ]] && upload_to_artifactory debian
     # Git builds go to git
     upload_to_artifactory debian-git
+  else
+    printf "Skipping upload due to missing ART_API_KEY"
   fi
 else
   ctest --output-on-failure


### PR DESCRIPTION
Bug: https://github.com/gerbera/gerbera/issues/2468
