### PR TITLE
CI: build-deb: Pass API key to docker env, again

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -35,7 +35,7 @@ jobs:
           docker run \
             --platform=${{ matrix.arch }} \
             -e TZ=Etc/UTC \
-            -e ART_API_KEY \
+            -e ART_API_KEY=${{ secrets.ART_API_KEY }} \
             -v "$(pwd):/build" \
             -w /build \
           ${{ matrix.os-ver }} \


### PR DESCRIPTION
Bug: https://github.com/gerbera/gerbera/issues/2468
