### PR TITLE
string to string_view conversion

### DIFF
--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -745,16 +745,16 @@ std::string sockAddrGetNameInfo(const struct sockaddr* sa, bool withPort)
 #define M_SOCK_ADDR_IN_ADDR(sa) M_SOCK_ADDR_IN_PTR(sa)->sin_addr
 #define M_SOCK_ADDR_IN6_PTR(sa) reinterpret_cast<struct sockaddr_in6*>(sa)
 #define M_SOCK_ADDR_IN6_ADDR(sa) M_SOCK_ADDR_IN6_PTR(sa)->sin6_addr
-struct sockaddr_storage readAddr(std::string addr, int af)
+struct sockaddr_storage readAddr(std::string_view addr, int af)
 {
     struct sockaddr_storage sa;
     bzero(&sa, sizeof(struct sockaddr_storage));
     reinterpret_cast<struct sockaddr*>(&sa)->sa_family = af;
     int err = 0;
     if (af == AF_INET) {
-        err = inet_pton(af, addr.c_str(), &(M_SOCK_ADDR_IN_ADDR(&sa)));
+        err = inet_pton(af, addr.data(), &(M_SOCK_ADDR_IN_ADDR(&sa)));
     } else if (af == AF_INET6) {
-        err = inet_pton(af, addr.c_str(), &(M_SOCK_ADDR_IN6_ADDR(&sa)));
+        err = inet_pton(af, addr.data(), &(M_SOCK_ADDR_IN6_ADDR(&sa)));
     }
     if (err != 1)
         log_error("Could not parse address {}", addr);

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -295,6 +295,6 @@ std::string getDLNATransferHeader([[maybe_unused]] const std::shared_ptr<Config>
 std::string getHostName(const struct sockaddr* addr);
 int sockAddrCmpAddr(const struct sockaddr* sa, const struct sockaddr* sb);
 std::string sockAddrGetNameInfo(const struct sockaddr* sa, bool withPort = true);
-struct sockaddr_storage readAddr(std::string addr, int af);
+struct sockaddr_storage readAddr(std::string_view addr, int af);
 
 #endif // __TOOLS_H__


### PR DESCRIPTION
clang-tidy suggests const std::string&. Probably better to pass a view.

Signed-off-by: Rosen Penev <rosenp@gmail.com>