### PR TITLE
use constexpr parameter for fmt::format

### DIFF
--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -164,7 +164,7 @@ void Sqlite3Database::init()
     } catch (const std::runtime_error& e) {
         log_error("prematurely shutting down.");
         shutdown();
-        throw_std_runtime_error(e.what());
+        throw_std_runtime_error("{}", e.what());
     }
 }
 
@@ -245,7 +245,7 @@ std::shared_ptr<SQLResult> Sqlite3Database::select(const std::string& query)
             rollback("");
             shutdown();
         }
-        throw_std_runtime_error(e.what());
+        throw_std_runtime_error("{}", e.what());
     }
 }
 
@@ -263,7 +263,7 @@ int Sqlite3Database::exec(const std::string& query, bool getLastInsertId)
             rollback("");
             shutdown();
         }
-        throw_std_runtime_error(e.what());
+        throw_std_runtime_error("{}", e.what());
     }
 }
 
@@ -404,7 +404,7 @@ void SLTask::waitForTask()
 
     if (!getError().empty()) {
         log_debug("{}", getError());
-        throw_std_runtime_error(getError());
+        throw_std_runtime_error("{}", getError());
     }
 }
 

--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -141,7 +141,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
                 log_error("iconv: Incomplete multibyte sequence");
             }
             if (validate) {
-                throw_std_runtime_error(err);
+                throw_std_runtime_error("{}", err);
             }
 
             if (stoppedAt)
@@ -165,7 +165,7 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
         //        log_debug("iconv: converted part:  {}", output);
         dirty = true;
         delete[] output;
-        throw_std_runtime_error(err);
+        throw_std_runtime_error("{}", err);
     }
 
     // log_debug("iconv: AFTER: input bytes left: {}  output bytes left: {}",

--- a/src/util/url.cc
+++ b/src/util/url.cc
@@ -93,7 +93,7 @@ std::string URL::download(const std::string& url, long* httpRetcode,
         log_error("{}", errorBuffer);
         if (cleanup)
             curl_easy_cleanup(curlHandle);
-        throw_std_runtime_error(errorBuffer);
+        throw_std_runtime_error("{}", errorBuffer);
     }
 
     res = curl_easy_getinfo(curlHandle, CURLINFO_RESPONSE_CODE, httpRetcode);
@@ -101,7 +101,7 @@ std::string URL::download(const std::string& url, long* httpRetcode,
         log_error("{}", errorBuffer);
         if (cleanup)
             curl_easy_cleanup(curlHandle);
-        throw_std_runtime_error(errorBuffer);
+        throw_std_runtime_error("{}", errorBuffer);
     }
 
     if (cleanup)
@@ -138,7 +138,7 @@ URL::Stat URL::getInfo(const std::string& url, CURL* curlHandle)
         log_error("{}", errorBuffer);
         if (cleanup)
             curl_easy_cleanup(curlHandle);
-        throw_std_runtime_error(errorBuffer);
+        throw_std_runtime_error("{}", errorBuffer);
     }
 
     res = curl_easy_getinfo(curlHandle, CURLINFO_CONTENT_TYPE, &ct);
@@ -146,7 +146,7 @@ URL::Stat URL::getInfo(const std::string& url, CURL* curlHandle)
         log_error("{}", errorBuffer);
         if (cleanup)
             curl_easy_cleanup(curlHandle);
-        throw_std_runtime_error(errorBuffer);
+        throw_std_runtime_error("{}", errorBuffer);
     }
 
     std::string mt = ct ? ct : MIMETYPE_DEFAULT;
@@ -157,7 +157,7 @@ URL::Stat URL::getInfo(const std::string& url, CURL* curlHandle)
         log_error("{}", errorBuffer);
         if (cleanup)
             curl_easy_cleanup(curlHandle);
-        throw_std_runtime_error(errorBuffer);
+        throw_std_runtime_error("{}", errorBuffer);
     }
 
     std::string usedUrl = cUrl ? cUrl : url;

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -127,7 +127,6 @@ void Web::Items::process()
     // ouput objects of container
     int cnt = start + 1;
     auto cls = container->getClass();
-    auto trackFmt = (param.getTotalMatches() >= 100) ? "{:03}" : "{:02}";
     for (auto&& arrayObj : arr) {
         auto item = items.append_child("item");
         item.append_attribute("id") = arrayObj->getID();
@@ -136,10 +135,17 @@ void Web::Items::process()
         auto objItem = std::static_pointer_cast<CdsItem>(arrayObj);
         if (objItem->getPartNumber() > 0 && startswith(cls, UPNP_CLASS_MUSIC_ALBUM))
             item.append_child("part").append_child(pugi::node_pcdata).set_value(fmt::format("{:02}", objItem->getPartNumber()).c_str());
-        if (objItem->getTrackNumber() > 0 && !startswith(cls, UPNP_CLASS_CONTAINER))
-            item.append_child("track").append_child(pugi::node_pcdata).set_value(fmt::format(trackFmt, objItem->getTrackNumber()).c_str());
-        else
-            item.append_child("track").append_child(pugi::node_pcdata).set_value(fmt::format(trackFmt, cnt).c_str());
+        if (objItem->getTrackNumber() > 0 && !startswith(cls, UPNP_CLASS_CONTAINER)) {
+            if (param.getTotalMatches() >= 100)
+                item.append_child("track").append_child(pugi::node_pcdata).set_value(fmt::format("{:03}", objItem->getTrackNumber()).c_str());
+            else
+                item.append_child("track").append_child(pugi::node_pcdata).set_value(fmt::format("{:02}", objItem->getTrackNumber()).c_str());
+        } else {
+            if (param.getTotalMatches() >= 100)
+                item.append_child("track").append_child(pugi::node_pcdata).set_value(fmt::format("{:03}", cnt).c_str());
+            else
+                item.append_child("track").append_child(pugi::node_pcdata).set_value(fmt::format("{:02}", cnt).c_str());
+        }
         item.append_child("mtype").append_child(pugi::node_pcdata).set_value(objItem->getMimeType().c_str());
         item.append_child("upnp_class").append_child(pugi::node_pcdata).set_value(objItem->getClass().c_str());
         std::string res = UpnpXMLBuilder::getFirstResourcePath(objItem);


### PR DESCRIPTION
Fixes compilation with fmt 8+ and c++20.

Signed-off-by: Rosen Penev <rosenp@gmail.com>