### PR TITLE
replace make_unique with reinterpret_pointer_cast

### DIFF
--- a/src/transcoding/transcode_dispatcher.cc
+++ b/src/transcoding/transcode_dispatcher.cc
@@ -46,7 +46,7 @@ std::unique_ptr<IOHandler> TranscodeDispatcher::serveContent(const std::shared_p
         throw_std_runtime_error("Transcoding of file {} requested but no profile given ", location.c_str());
 
     if (profile->getType() == TR_External) {
-        auto trExt = std::make_unique<TranscodeExternalHandler>(std::move(content));
+        auto trExt = std::reinterpret_pointer_cast<TranscodeExternalHandler>(content);
         return trExt->serveContent(profile, location, obj, group, range);
     }
 


### PR DESCRIPTION
content is a shared_ptr. reinterpret_pointer_cast is the correct thing
to do here. There's also a quite significant size reduction.

Signed-off-by: Rosen Penev <rosenp@gmail.com>