### PR TITLE
Handle config sourced autoscans in DB more gracefully

### DIFF
--- a/src/content/autoscan_list.cc
+++ b/src/content/autoscan_list.cc
@@ -46,7 +46,7 @@ int AutoscanList::add(const std::shared_ptr<AutoscanDirectory>& dir, std::size_t
 int AutoscanList::_add(const std::shared_ptr<AutoscanDirectory>& dir, std::size_t index)
 {
     if (std::any_of(list.begin(), list.end(), [loc = dir->getLocation()](auto&& item) { return loc == item->getLocation(); })) {
-        throw_std_runtime_error("Attempted to add same autoscan path twice");
+        throw_std_runtime_error("Attempted to add same autoscan path twice: {}", dir->getLocation().string());
     }
     if (index == std::numeric_limits<std::size_t>::max()) {
         index = getEditSize();


### PR DESCRIPTION
Fixes: https://github.com/gerbera/gerbera/issues/2567
