### PR TITLE
remove const from map

### DIFF
--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -117,7 +117,7 @@ enum metadata_fields_t {
     M_MAX
 };
 
-const static auto mt_keys = std::map<metadata_fields_t, const std::string> {
+static const auto mt_keys = std::map<metadata_fields_t, std::string> {
     std::pair(M_TITLE, "dc:title"),
     std::pair(M_ARTIST, "upnp:artist"),
     std::pair(M_ALBUM, "upnp:album"),

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -237,6 +237,7 @@ public:
 template <typename K, typename V>
 V getValueOrDefault(const std::vector<std::pair<K, V>>& m, const K& key, const V& defval)
 {
+    static_assert(!std::is_const_v<V>);
     auto it = std::find_if(m.begin(), m.end(), [&](auto&& v) { return v.first == key; });
     return (it == m.end()) ? defval : it->second;
 }
@@ -244,6 +245,7 @@ V getValueOrDefault(const std::vector<std::pair<K, V>>& m, const K& key, const V
 template <typename K, typename V>
 V getValueOrDefault(const std::map<K, V>& m, const K& key, const V& defval)
 {
+    static_assert(!std::is_const_v<V>);
     auto it = m.find(key);
     return (it == m.end()) ? defval : it->second;
 }


### PR DESCRIPTION
Avoids clang-tidy warning about the return value of template being const
V.

Signed-off-by: Rosen Penev <rosenp@gmail.com>