### PR TITLE
clang-tidy: fix wrong erase

### DIFF
--- a/src/cds_objects.h
+++ b/src/cds_objects.h
@@ -280,9 +280,7 @@ public:
     /// \brief Removes metadata with the given key
     void removeMetaData(const metadata_fields_t key)
     {
-        auto&& field = MetadataHandler::getMetaFieldName(key);
-        while (std::find_if(metaData.begin(), metaData.end(), [=](auto&& md) { return md.first == field; }) != metaData.end())
-            metaData.erase(std::remove_if(metaData.begin(), metaData.end(), [=](auto&& md) { return md.first == field; }));
+        metaData.erase(std::remove_if(metaData.begin(), metaData.end(), [field = MetadataHandler::getMetaFieldName(key)](auto&& md) { return md.first == field; }), metaData.end());
     }
 
     /// \brief Query single auxdata value.


### PR DESCRIPTION
Found with bugprone-inaccurate-erase

Signed-off-by: Rosen Penev <rosenp@gmail.com>