### PR TITLE
clang-tidy: use at() instead of []

### DIFF
--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -183,7 +183,7 @@ public:
     static std::string getSortCapabilities();
     static std::string getSearchCapabilities();
 
-    unsigned int getHash(std::size_t index) const { return index < DBVERSION ? hashies[index] : 0; }
+    unsigned int getHash(std::size_t index) const { return index < DBVERSION ? hashies.at(index) : 0; }
 
     int insert(std::string_view tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::string>& values, bool getLastInsertId = false);
     void insertMultipleRows(std::string_view tableName, const std::vector<SQLIdentifier>& fields, const std::vector<std::vector<std::string>>& valuesets);

--- a/src/util/process_executor.cc
+++ b/src/util/process_executor.cc
@@ -47,15 +47,15 @@ ProcessExecutor::ProcessExecutor(const std::string& command, const std::vector<s
 #define MAX_ARGS 255
     std::array<const char*, MAX_ARGS> argv;
 
-    argv[0] = command.c_str();
+    argv.front() = command.c_str();
     int apos = 0;
 
     for (auto&& i : arglist) {
-        argv[++apos] = i.c_str();
+        argv.at(++apos) = i.c_str();
         if (apos >= MAX_ARGS - 2)
             break;
     }
-    argv[++apos] = nullptr;
+    argv.at(++apos) = nullptr;
 
     pid = fork();
     switch (pid) {


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

I changed ++apos to apos++ since the latter seems to be the correct thing to do. Please check.