### PR TITLE
clang-tidy: remove defaulted constructors

### DIFF
--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -259,8 +259,6 @@ private:
         {
         }
         ~AddUpdateTable() = default;
-        AddUpdateTable(AddUpdateTable&&) = default;
-        AddUpdateTable& operator=(AddUpdateTable&&) = default;
         [[nodiscard]] const std::string& getTableName() const noexcept { return tableName; }
         [[nodiscard]] const std::map<std::string, std::string>& getDict() const noexcept { return dict; }
         [[nodiscard]] Operation getOperation() const noexcept { return operation; }


### PR DESCRIPTION
These can just be implicit.

Signed-off-by: Rosen Penev <rosenp@gmail.com>