### PR TITLE
fix compilation

### DIFF
--- a/src/util/jpeg_resolution.cc
+++ b/src/util/jpeg_resolution.cc
@@ -30,7 +30,9 @@
 /// \file jpeg_resolution.cc
 
 #include <cstddef>
+#include <fmt/core.h>
 
+#include "exceptions.h"
 #include "iohandler/io_handler.h"
 #include "jpeg_resolution.h"
 #include "metadata/resolution.h"


### PR DESCRIPTION
Missing headers for throw_std_runtime_error

Signed-off-by: Rosen Penev <rosenp@gmail.com>