### PR TITLE
Respect ContainerID when performing search

### DIFF
--- a/src/database/database.h
+++ b/src/database/database.h
@@ -150,6 +150,7 @@ public:
     {
     }
     const std::string& searchCriteria() const { return searchCrit; }
+    const std::string& getContainerID() const { return containerID; }
     bool getSearchableContainers() const { return searchableContainers; }
     int getStartingIndex() const { return startingIndex; }
     int getRequestedCount() const { return requestedCount; }

--- a/src/database/search_handler.h
+++ b/src/database/search_handler.h
@@ -379,6 +379,12 @@ public:
     {
         return fmt::format("{}{}{}", table_quote_begin, tableName, table_quote_end);
     }
+
+    std::string getAlias() const
+    {
+        return fmt::format("{}{}{}", table_quote_begin, tableAlias, table_quote_end);
+    }
+
     std::string mapQuoted(En tag) const
     {
         auto it = std::find_if(colMap.begin(), colMap.end(), [=](auto&& map) { return map.first == tag; });

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -1045,12 +1045,12 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::search(const SearchParam& p
 
     std::string countSQL;
     if (rootContainer) {
-        // Use fater, non-recursive search for root container
+        // Use faster, non-recursive search for root container
         countSQL = fmt::format("SELECT COUNT(DISTINCT {}) FROM {} WHERE {}", searchColumnMapper->mapQuoted(UPNP_SEARCH_ID), sql_search_query, searchSQL);
     } else {
         // Use recursive container search
         const std::string countSelect = fmt::format("COUNT(DISTINCT {})", searchColumnMapper->mapQuoted(UPNP_SEARCH_ID));
-        countSQL = fmt::format(this->sql_search_container_query_format, param.getContainerID(), countSelect);
+        countSQL = fmt::format(sql_search_container_query_format, param.getContainerID(), countSelect);
         countSQL += fmt::format(" WHERE {}", searchSQL);
     }
 
@@ -1087,12 +1087,12 @@ std::vector<std::shared_ptr<CdsObject>> SQLDatabase::search(const SearchParam& p
 
     std::string retrievalSQL;
     if (rootContainer) {
-        // Use fater, non-recursive search for root container
+        // Use faster, non-recursive search for root container
         retrievalSQL = fmt::format("SELECT DISTINCT {} {} FROM {} {} WHERE {}{}{}", sql_search_columns, addColumns, sql_search_query, addJoin, searchSQL, orderBy, limit);
     } else {
         // Use recursive container search
         const std::string retrievalSelect = fmt::format("DISTINCT {} {}", sql_search_columns, addColumns);
-        retrievalSQL = fmt::format(this->sql_search_container_query_format, param.getContainerID(), retrievalSelect);
+        retrievalSQL = fmt::format(sql_search_container_query_format, param.getContainerID(), retrievalSelect);
         retrievalSQL += fmt::format(" {} WHERE {}{}{}", addJoin, searchSQL, orderBy, limit);
     }
 

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -299,6 +299,21 @@ static const std::vector<std::pair<std::string, AutoscanColumn>> autoscanTagMap 
     { "obj_location", AutoscanColumn::ObjLocation },
 };
 
+// Format string for a recursive query of a parent container
+static constexpr auto sql_search_container_query_raw = R"(
+-- Find all children of parent_id
+WITH {0} AS (SELECT * FROM {2} WHERE {4} = {{}}
+UNION
+SELECT {3}.* FROM {2} JOIN {0} AS {1} ON {3}.{4} = {1}.{5}
+),
+-- Find all physical items and de-reference any virtual item (i.e. follow ref-id)
+items AS (SELECT * from {0} AS {1} WHERE {6} IS NULL
+UNION
+SELECT {3}.* FROM {0} AS {1} JOIN {2} ON {1}.{6} = {3}.{5}
+)
+-- Select desired cols from items
+SELECT {{}} FROM items AS {3})";
+
 #define getCol(rw, idx) (rw)->col(to_underlying((idx)))
 
 static std::shared_ptr<EnumColumnMapper<BrowseCol>> browseColumnMapper;
@@ -389,7 +404,7 @@ void SQLDatabase::init()
         this->sql_search_query = fmt::format("{} {} {}", searchColumnMapper->tableQuoted(), join1, join2);
 
         // Build container query format string
-        auto sql_container_query = fmt::format(sql_search_container_query_raw, searchColumnMapper->tableQuoted(), searchColumnMapper->getAlias(), searchColumnMapper->mapQuoted(UPNP_SEARCH_PARENTID, true), searchColumnMapper->mapQuoted(UPNP_SEARCH_ID, true), searchColumnMapper->mapQuoted(UPNP_SEARCH_REFID, true));
+        auto sql_container_query = fmt::format(sql_search_container_query_raw, identifier("containers"), identifier("cont"), searchColumnMapper->tableQuoted(), searchColumnMapper->getAlias(), searchColumnMapper->mapQuoted(UPNP_SEARCH_PARENTID, true), searchColumnMapper->mapQuoted(UPNP_SEARCH_ID, true), searchColumnMapper->mapQuoted(UPNP_SEARCH_REFID, true));
         this->sql_search_container_query_format = fmt::format("{} {} {}", sql_container_query, join1, join2);
     }
     // Statement for metadata

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -226,21 +226,6 @@ protected:
     virtual void _exec(const std::string& query) = 0;
 
 private:
-    // Format string for a recursive query of a parent container
-    static constexpr auto sql_search_container_query_raw = R"(
--- Find all children of parent_id
-WITH containers AS (SELECT * FROM {0} WHERE {2} = {{}}
-UNION
-SELECT {1}.* FROM {0} JOIN containers AS cont ON {1}.{2} = cont.{3}
-),
--- Find all physical items and de-reference any virtual item (i.e. follow ref-id)
-items AS (SELECT * from containers AS cont WHERE {4} IS NULL
-UNION
-SELECT {1}.* FROM containers AS cont JOIN {0} ON cont.{4} = {1}.{3}
-)
--- Select desired cols from items
-SELECT {{}} FROM items AS {1})";
-
     std::string sql_browse_columns;
     std::string sql_browse_query;
     std::string sql_search_columns;

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -226,7 +226,6 @@ protected:
     virtual void _exec(const std::string& query) = 0;
 
 private:
-
     // Format string for a recursive query of a parent container
     static constexpr auto container_query_raw = R"(
 -- Find all children of parent_id

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -227,7 +227,7 @@ protected:
 
 private:
     // Format string for a recursive query of a parent container
-    static constexpr auto container_query_raw = R"(
+    static constexpr auto sql_search_container_query_raw = R"(
 -- Find all children of parent_id
 WITH containers AS (SELECT * FROM {0} WHERE {2} = {{}}
 UNION
@@ -244,7 +244,8 @@ SELECT {{}} FROM items AS {1})";
     std::string sql_browse_columns;
     std::string sql_browse_query;
     std::string sql_search_columns;
-    std::string sql_search_query_format;
+    std::string sql_search_container_query_format;
+    std::string sql_search_query;
     std::string sql_meta_query;
     std::string sql_autoscan_query;
     std::string sql_resource_query;

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -226,10 +226,26 @@ protected:
     virtual void _exec(const std::string& query) = 0;
 
 private:
+
+    // Format string for a recursive query of a parent container
+    static constexpr auto container_query_raw = R"(
+-- Find all children of parent_id
+WITH containers AS (SELECT * FROM {0} WHERE {2} = {{}}
+UNION
+SELECT {1}.* FROM {0} JOIN containers AS cont ON {1}.{2} = cont.{3}
+),
+-- Find all physical items and de-reference any virtual item (i.e. follow ref-id)
+items AS (SELECT * from containers AS cont WHERE {4} IS NULL
+UNION
+SELECT {1}.* FROM containers AS cont JOIN {0} ON cont.{4} = {1}.{3}
+)
+-- Select desired cols from items
+SELECT {{}} FROM items AS {1})";
+
     std::string sql_browse_columns;
     std::string sql_browse_query;
     std::string sql_search_columns;
-    std::string sql_search_query;
+    std::string sql_search_query_format;
     std::string sql_meta_query;
     std::string sql_autoscan_query;
     std::string sql_resource_query;

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -160,8 +160,8 @@ void ContentDirectoryService::doSearch(ActionRequest& request)
     std::string requestedCount = reqRoot.child("RequestedCount").text().as_string();
     std::string sortCriteria = reqRoot.child("SortCriteria").text().as_string();
 
-    log_debug("Search received parameters: ContainerID [{}] SearchCriteria [{}] SortCriteria [{}] StartingIndex [{}] RequestedCount [{}] RequestedCount [{}]",
-        containerID, searchCriteria, sortCriteria, startingIndex, requestedCount, requestedCount);
+    log_debug("Search received parameters: ContainerID [{}] SearchCriteria [{}] SortCriteria [{}] StartingIndex [{}] RequestedCount [{}]",
+        containerID, searchCriteria, sortCriteria, startingIndex, requestedCount);
 
     auto&& quirks = request.getQuirks();
     pugi::xml_document didlLite;


### PR DESCRIPTION
Respect ContainerID when performing searches against the database. Close #2364.

This is implemented using a recursive query that finds all children of a given parent_id. The children's ref_id's are then followed to find the actual physical items.

I am a little unclear on the desired styles of this project. There appears to be mix of `snake_case` and `camelCase` for variable names. Some accessors also take the form`getSomeVariable()` while others are `someVariable()`. I will gladly update the changes to match the desired style.