### PR TITLE
Server: Clean up virtualURL handling

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -35,7 +35,7 @@
 #include "util/grb_net.h"
 #include "util/upnp_quirks.h"
 
-ActionRequest::ActionRequest(const std::shared_ptr<Context>& context, UpnpActionRequest* upnpRequest)
+ActionRequest::ActionRequest(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clients, UpnpActionRequest* upnpRequest)
     : upnp_request(upnpRequest)
     , actionName(UpnpActionRequest_get_ActionName_cstr(upnpRequest))
     , UDN(UpnpActionRequest_get_DevUDN_cstr(upnpRequest))
@@ -43,7 +43,7 @@ ActionRequest::ActionRequest(const std::shared_ptr<Context>& context, UpnpAction
 {
     auto ctrlPtIPAddr = std::make_shared<GrbNet>(UpnpActionRequest_get_CtrlPtIPAddr(upnpRequest));
     std::string userAgent = UpnpActionRequest_get_Os_cstr(upnpRequest);
-    quirks = std::make_unique<Quirks>(context, ctrlPtIPAddr, userAgent);
+    quirks = std::make_unique<Quirks>(xmlBuilder, clients, ctrlPtIPAddr, userAgent);
 }
 
 std::string ActionRequest::getActionName() const

--- a/src/action_request.h
+++ b/src/action_request.h
@@ -40,8 +40,9 @@
 #include "common.h"
 
 // forward declaration
-class Context;
+class UpnpXMLBuilder;
 class Quirks;
+class ClientManager;
 
 /// \brief This class represents the Upnp_Action_Request type from the SDK.
 ///
@@ -83,7 +84,7 @@ protected:
 public:
     /// \brief The Constructor takes the values from the upnp_request and fills in internal variables.
     /// \param *upnp_request Pointer to the Upnp_Action_Request structure.
-    explicit ActionRequest(const std::shared_ptr<Context>& context, UpnpActionRequest* upnpRequest);
+    explicit ActionRequest(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clients, UpnpActionRequest* upnpRequest);
     ~ActionRequest() = default;
 
     /// \brief Returns the name of the action.

--- a/src/common.h
+++ b/src/common.h
@@ -72,7 +72,7 @@ static constexpr bool IS_FORBIDDEN_CDS_ID(int id) { return id <= CDS_ID_FS_ROOT;
 #define MIMETYPE_DEFAULT "application/octet-stream"
 
 // default protocol
-static constexpr auto PROTOCOL = std::string_view("http-get");
+constexpr auto PROTOCOL = std::string_view("http-get");
 
 // device description defaults
 #define DESC_MANUFACTURER_URL "http://gerbera.io/"

--- a/src/context.cc
+++ b/src/context.cc
@@ -29,13 +29,11 @@ Context::Context(std::shared_ptr<Config> config,
     std::shared_ptr<ClientManager> clients,
     std::shared_ptr<Mime> mime,
     std::shared_ptr<Database> database,
-    std::shared_ptr<Server> server,
     std::shared_ptr<Web::SessionManager> sessionManager)
     : config(std::move(config))
     , clients(std::move(clients))
     , mime(std::move(mime))
     , database(std::move(database))
-    , server(std::move(server))
     , session_manager(std::move(sessionManager))
 {
 }

--- a/src/context.h
+++ b/src/context.h
@@ -45,7 +45,6 @@ public:
         std::shared_ptr<ClientManager> clients,
         std::shared_ptr<Mime> mime,
         std::shared_ptr<Database> database,
-        std::shared_ptr<Server> server,
         std::shared_ptr<Web::SessionManager> sessionManager);
 
     std::shared_ptr<Config> getConfig() const
@@ -68,11 +67,6 @@ public:
         return database;
     }
 
-    std::shared_ptr<Server> getServer() const
-    {
-        return server;
-    }
-
     std::shared_ptr<Web::SessionManager> getSessionManager() const
     {
         return session_manager;
@@ -83,7 +77,6 @@ private:
     std::shared_ptr<ClientManager> clients;
     std::shared_ptr<Mime> mime;
     std::shared_ptr<Database> database;
-    std::shared_ptr<Server> server;
     std::shared_ptr<Web::SessionManager> session_manager;
 };
 

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -262,5 +262,5 @@ std::unique_ptr<Quirks> FileRequestHandler::getQuirks(const UpnpFileInfo* info) 
     auto ctrlPtIPAddr = std::make_shared<GrbNet>(UpnpFileInfo_get_CtrlPtIPAddr(info));
     // HINT: most clients do not report exactly the same User-Agent for UPnP services and file request.
     std::string userAgent = UpnpFileInfo_get_Os_cstr(info);
-    return std::make_unique<Quirks>(context, ctrlPtIPAddr, std::move(userAgent));
+    return std::make_unique<Quirks>(*xmlBuilder, *context->getClients(), ctrlPtIPAddr, std::move(userAgent));
 }

--- a/src/request_handler.cc
+++ b/src/request_handler.cc
@@ -43,7 +43,6 @@ RequestHandler::RequestHandler(std::shared_ptr<ContentManager> content)
     , config(this->context->getConfig())
     , mime(this->context->getMime())
     , database(this->context->getDatabase())
-    , server(this->context->getServer())
 {
 }
 

--- a/src/request_handler.h
+++ b/src/request_handler.h
@@ -73,7 +73,6 @@ protected:
     std::shared_ptr<Config> config;
     std::shared_ptr<Mime> mime;
     std::shared_ptr<Database> database;
-    std::shared_ptr<Server> server;
 };
 
 #endif // __REQUEST_HANDLER_H__

--- a/src/server.cc
+++ b/src/server.cc
@@ -307,6 +307,8 @@ std::string Server::getVirtualUrl() const
     if (!startswith(virtUrl, "http")) { // url does not start with http
         virtUrl = fmt::format("http://{}", virtUrl);
     }
+    if (*virtUrl.end() == '/')
+        virtUrl.pop_back();
     return virtUrl;
 }
 

--- a/src/server.cc
+++ b/src/server.cc
@@ -85,7 +85,7 @@ void Server::init()
 
     clients = std::make_shared<ClientManager>(config, database);
     session_manager = std::make_shared<Web::SessionManager>(config, timer);
-    context = std::make_shared<Context>(config, clients, mime, database, self, session_manager);
+    context = std::make_shared<Context>(config, clients, mime, database, session_manager);
 
     content = std::make_shared<ContentManager>(context, self, timer);
 }

--- a/src/server.h
+++ b/src/server.h
@@ -123,13 +123,6 @@ protected:
     /// should be sufficient here.
     std::string virtual_directory;
 
-    /// \brief Full virtual web server url.
-    ///
-    /// The URL is constructed upon server initialization, since
-    /// the real port is not known before. The value of this variable
-    /// is returned by the getVirtualURL() function.
-    std::string virtualUrl;
-
     /// \brief Time interval to send ssdp:alive advertisements.
     ///
     /// The value is read from the configuration.

--- a/src/server.h
+++ b/src/server.h
@@ -70,14 +70,6 @@ public:
     /// web callbacks. Starts the update manager task.
     void run();
 
-    /// \brief Returns the content url of the server.
-    ///
-    /// Returns a string representation of the server url. Although
-    /// the port is also specified in the config, we can never be sure
-    /// that we actually get that port after startup. This function
-    /// contains the port on which the server is actually running.
-    std::string getVirtualUrl() const;
-
     /// \brief Tells if the server is about to be terminated.
     ///
     /// This function returns true if the server is about to be
@@ -214,6 +206,14 @@ protected:
 
     std::string getPresentationUrl() const;
     int startupInterface(const std::string& iface, in_port_t inPort);
+
+    /// \brief Returns the content url of the server.
+    ///
+    /// Returns a string representation of the server url. Although
+    /// the port is also specified in the config, we can never be sure
+    /// that we actually get that port after startup. This function
+    /// contains the port on which the server is actually running.
+    std::string getVirtualUrl() const;
 };
 
 #endif // __SERVER_H__

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -78,7 +78,7 @@ void ContentDirectoryService::doBrowse(ActionRequest& request)
         throw UpnpException(UPNP_E_NO_SUCH_ID, "empty object id");
 
     auto&& quirks = request.getQuirks();
-    auto arr = quirks->getSamsungFeatureRoot(objID);
+    auto arr = quirks->getSamsungFeatureRoot(*database, objID);
     int objectID = stoiString(objID);
 
     unsigned int flag = BROWSE_ITEMS | BROWSE_CONTAINERS | BROWSE_EXACT_CHILDCOUNT;
@@ -132,7 +132,7 @@ void ContentDirectoryService::doBrowse(ActionRequest& request)
     std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", 0);
     log_debug("didl {}", didlLiteXml);
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto respRoot = response->document_element();
     respRoot.append_child("Result").append_child(pugi::node_pcdata).set_value(didlLiteXml.c_str());
     respRoot.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(arr.size()).c_str());
@@ -219,7 +219,7 @@ void ContentDirectoryService::doSearch(ActionRequest& request)
     std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", 0);
     log_debug("didl {}", didlLiteXml);
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto respRoot = response->document_element();
     respRoot.append_child("Result").append_child(pugi::node_pcdata).set_value(didlLiteXml.c_str());
     respRoot.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(results.size()).c_str());
@@ -263,7 +263,7 @@ void ContentDirectoryService::doGetSearchCapabilities(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("SearchCaps").append_child(pugi::node_pcdata).set_value(SQLDatabase::getSearchCapabilities().c_str());
     request.setResponse(std::move(response));
@@ -275,7 +275,7 @@ void ContentDirectoryService::doGetSortCapabilities(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("SortCaps").append_child(pugi::node_pcdata).set_value(SQLDatabase::getSortCapabilities().c_str());
     request.setResponse(std::move(response));
@@ -287,7 +287,7 @@ void ContentDirectoryService::doGetSystemUpdateID(ActionRequest& request) const
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Id").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     request.setResponse(std::move(response));
@@ -299,7 +299,7 @@ void ContentDirectoryService::doSamsungBookmark(ActionRequest& request)
 {
     log_debug("start");
 
-    request.getQuirks()->saveSamsungBookMarkedPosition(request);
+    request.getQuirks()->saveSamsungBookMarkedPosition(*database, request);
 
     log_debug("end");
 }
@@ -366,7 +366,7 @@ void ContentDirectoryService::processSubscriptionRequest(const SubscriptionReque
 {
     log_debug("start");
 
-    auto propset = UpnpXMLBuilder::createEventPropertySet();
+    auto propset = xmlBuilder->createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     auto obj = database->loadObject(DEFAULT_CLIENT_GROUP, 0);
@@ -403,7 +403,7 @@ void ContentDirectoryService::sendSubscriptionUpdate(const std::string& containe
 
     systemUpdateID++;
 
-    auto propset = UpnpXMLBuilder::createEventPropertySet();
+    auto propset = xmlBuilder->createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(containerUpdateIDsCsv.c_str());
     property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());

--- a/src/upnp_cds.h
+++ b/src/upnp_cds.h
@@ -77,13 +77,13 @@ private:
     /// \param request Incoming ActionRequest.
     ///
     /// GetSearchCapabilities(string SearchCaps)
-    static void doGetSearchCapabilities(ActionRequest& request);
+    void doGetSearchCapabilities(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetSortCapabilities()
     /// \param request Incoming ActionRequest.
     ///
     /// GetSortCapabilities(string SortCaps)
-    static void doGetSortCapabilities(ActionRequest& request);
+    void doGetSortCapabilities(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetSystemUpdateID()
     /// \param request Incoming ActionRequest.
@@ -94,20 +94,20 @@ private:
     /// \brief Samsung Extension X_SetBookmark
     /// \param request Incoming ActionRequest.
     ///
-    static void doSamsungBookmark(ActionRequest& request);
+    void doSamsungBookmark(ActionRequest& request);
 
     /// \brief Samsung Extension X_GetFeatureListResponse
     /// \param request Incoming ActionRequest.
     ///
-    static void doSamsungFeatureList(ActionRequest& request);
+    void doSamsungFeatureList(ActionRequest& request);
 
     /// \brief Samsung Extension X_GetObjectIDfromIndex
     /// \param request Incoming ActionRequest.
-    static void doSamsungGetObjectIDfromIndex(ActionRequest& request);
+    void doSamsungGetObjectIDfromIndex(ActionRequest& request);
 
     /// \brief Samsung Extension X_GetIndexfromRID
     /// \param request Incoming ActionRequest.
-    static void doSamsungGetIndexfromRID(ActionRequest& request);
+    void doSamsungGetIndexfromRID(ActionRequest& request);
 
     /// \brief mark played item if activated
     /// \param cdsObject item to mark

--- a/src/upnp_cm.cc
+++ b/src/upnp_cm.cc
@@ -50,7 +50,7 @@ void ConnectionManagerService::doGetCurrentConnectionIDs(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("ConnectionID").append_child(pugi::node_pcdata).set_value("0");
 
@@ -73,7 +73,7 @@ void ConnectionManagerService::doGetProtocolInfo(ActionRequest& request) const
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
     auto csv = mimeTypesToCsv(database->getMimeTypes());
     auto root = response->document_element();
 
@@ -109,7 +109,7 @@ void ConnectionManagerService::processActionRequest(ActionRequest& request)
 void ConnectionManagerService::processSubscriptionRequest(const SubscriptionRequest& request)
 {
     auto csv = mimeTypesToCsv(database->getMimeTypes());
-    auto propset = UpnpXMLBuilder::createEventPropertySet();
+    auto propset = xmlBuilder->createEventPropertySet();
     auto property = propset->document_element().first_child();
 
     property.append_child("CurrentConnectionIDs").append_child(pugi::node_pcdata).set_value("0");
@@ -141,7 +141,7 @@ void ConnectionManagerService::processSubscriptionRequest(const SubscriptionRequ
 
 void ConnectionManagerService::sendSubscriptionUpdate(const std::string& sourceProtocolCsv)
 {
-    auto propset = UpnpXMLBuilder::createEventPropertySet();
+    auto propset = xmlBuilder->createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("SourceProtocolInfo").append_child(pugi::node_pcdata).set_value(sourceProtocolCsv.c_str());
 

--- a/src/upnp_cm.h
+++ b/src/upnp_cm.h
@@ -51,7 +51,7 @@ protected:
     /// GetCurrentConnectionIDs(string ConnectionIDs)
     ///
     /// This is currently unsupported (returns empty string)
-    static void doGetCurrentConnectionIDs(ActionRequest& request);
+    void doGetCurrentConnectionIDs(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetCurrentConnectionInfo()
     /// \param request Incoming ActionRequest.
@@ -60,7 +60,7 @@ protected:
     /// string PeerConnectionManager, i4 PeerConnectionID, string Direction, string Status)
     ///
     /// This action is currently unsupported.
-    static void doGetCurrentConnectionInfo(ActionRequest& request);
+    void doGetCurrentConnectionInfo(ActionRequest& request);
 
     /// \brief UPnP standard defined action: GetProtocolInfo()
     /// \param request Incoming ActionRequest.

--- a/src/upnp_mrreg.cc
+++ b/src/upnp_mrreg.cc
@@ -50,7 +50,7 @@ void MRRegistrarService::doIsAuthorized(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 
@@ -73,7 +73,7 @@ void MRRegistrarService::doIsValidated(ActionRequest& request)
 {
     log_debug("start");
 
-    auto response = UpnpXMLBuilder::createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
+    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
     auto root = response->document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 
@@ -105,7 +105,7 @@ void MRRegistrarService::processActionRequest(ActionRequest& request)
 
 void MRRegistrarService::processSubscriptionRequest(const SubscriptionRequest& request)
 {
-    auto propset = UpnpXMLBuilder::createEventPropertySet();
+    auto propset = xmlBuilder->createEventPropertySet();
     auto property = propset->document_element().first_child();
     property.append_child("ValidationRevokedUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("ValidationSucceededUpdateID").append_child(pugi::node_pcdata).set_value("0");

--- a/src/upnp_mrreg.h
+++ b/src/upnp_mrreg.h
@@ -51,7 +51,7 @@
 class MRRegistrarService {
 protected:
     /// \brief ID of the service.
-    static std::string serviceID;
+    std::string serviceID;
 
     /// \brief Media Receiver Registrar service action: IsAuthorized()
     /// \param request Incoming ActionRequest.
@@ -59,7 +59,7 @@ protected:
     /// IsAuthorized(string DeviceID, i4 Result)
     ///
     /// This is currently unsupported (always returns 1)
-    static void doIsAuthorized(ActionRequest& request);
+    void doIsAuthorized(ActionRequest& request);
 
     /// \brief Media Receiver Registrar service action: RegisterDevice()
     /// \param request Incoming ActionRequest.
@@ -67,13 +67,13 @@ protected:
     /// RegisterDevice(bin.base64 RegistrationReqMsg, bin.base64 RegistrationRespMsg)
     ///
     /// This action is currently unsupported.
-    static void doRegisterDevice(ActionRequest& request);
+    void doRegisterDevice(ActionRequest& request);
 
     /// \brief Media Receiver Registrar service action: IsValidated()
     /// \param request Incoming ActionRequest.
     ///
     /// IsValidated(string DeviceID, i4 Result)
-    static void doIsValidated(ActionRequest& request);
+    void doIsValidated(ActionRequest& request);
 
     std::shared_ptr<Config> config;
 
@@ -91,7 +91,7 @@ public:
     ///
     /// This function looks at the incoming ActionRequest and passes it on
     /// to the appropriate action for processing.
-    static void processActionRequest(ActionRequest& request);
+    void processActionRequest(ActionRequest& request);
 
     /// \brief Processes an incoming SubscriptionRequest.
     /// \param request Incoming SubscriptionRequest.

--- a/src/upnp_xml.cc
+++ b/src/upnp_xml.cc
@@ -61,7 +61,7 @@ UpnpXMLBuilder::UpnpXMLBuilder(const std::shared_ptr<Context>& context,
     transferMappings = config->getDictionaryOption(CFG_IMPORT_MAPPINGS_CONTENTTYPE_TO_DLNATRANSFER_LIST);
 }
 
-std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createResponse(const std::string& actionName, const std::string& serviceType)
+std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createResponse(const std::string& actionName, const std::string& serviceType) const
 {
     auto response = std::make_unique<pugi::xml_document>();
     auto root = response->append_child(fmt::format("u:{}Response", actionName).c_str());
@@ -71,7 +71,7 @@ std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createResponse(const std::st
 }
 
 void UpnpXMLBuilder::addPropertyList(pugi::xml_node& result, const std::vector<std::pair<std::string, std::string>>& meta, const std::map<std::string, std::string>& auxData,
-    config_option_t itemProps, config_option_t nsProp)
+    config_option_t itemProps, config_option_t nsProp) const
 {
     auto namespaceMap = config->getDictionaryOption(nsProp);
     for (auto&& [xmlns, uri] : namespaceMap) {
@@ -103,7 +103,7 @@ std::string UpnpXMLBuilder::printXml(const pugi::xml_node& entry, const char* in
     return buf.str();
 }
 
-void UpnpXMLBuilder::addField(pugi::xml_node& entry, const std::string& key, const std::string& val)
+void UpnpXMLBuilder::addField(pugi::xml_node& entry, const std::string& key, const std::string& val) const
 {
     // e.g. used for M_ALBUMARTIST
     // name@attr[val] => <name attr="val">
@@ -123,7 +123,7 @@ void UpnpXMLBuilder::addField(pugi::xml_node& entry, const std::string& key, con
     }
 }
 
-void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, std::size_t stringLimit, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks)
+void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, std::size_t stringLimit, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks) const
 {
     auto result = parent.append_child("");
 
@@ -180,7 +180,7 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, std::si
             }
         }
         auto meta = obj->getMetaData();
-        auto [url, artAdded] = renderItemImage(virtualURL, item);
+        auto [url, artAdded] = renderItemImage(item);
         if (artAdded) {
             meta.emplace_back(MetadataHandler::getMetaFieldName(M_ALBUMARTURI), url);
         }
@@ -218,7 +218,7 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, std::si
             addPropertyList(result, meta, auxData, CFG_UPNP_PLAYLIST_PROPERTIES, CFG_UPNP_PLAYLIST_NAMESPACES);
         }
         if (startswith(upnpClass, UPNP_CLASS_MUSIC_ALBUM) || startswith(upnpClass, UPNP_CLASS_MUSIC_ARTIST) || startswith(upnpClass, UPNP_CLASS_CONTAINER) || startswith(upnpClass, UPNP_CLASS_PLAYLIST_CONTAINER)) {
-            auto [url, artAdded] = renderContainerImage(virtualURL, cont);
+            auto [url, artAdded] = renderContainerImage(cont);
             if (artAdded) {
                 result.append_child(MetadataHandler::getMetaFieldName(M_ALBUMARTURI).data()).append_child(pugi::node_pcdata).set_value(url.c_str());
             }
@@ -232,7 +232,7 @@ void UpnpXMLBuilder::renderObject(const std::shared_ptr<CdsObject>& obj, std::si
     log_debug("Rendered DIDL: {}", printXml(result, "  "));
 }
 
-std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createEventPropertySet()
+std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createEventPropertySet() const
 {
     auto doc = std::make_unique<pugi::xml_document>();
 
@@ -244,7 +244,7 @@ std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createEventPropertySet()
     return doc;
 }
 
-std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription()
+std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription() const
 {
     auto doc = std::make_unique<pugi::xml_document>();
 
@@ -353,7 +353,7 @@ std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::renderDeviceDescription()
     return doc;
 }
 
-void UpnpXMLBuilder::renderResource(const std::string& url, const CdsResource& resource, pugi::xml_node& parent, const std::map<std::string, std::string>& clientSpecificAttrs)
+void UpnpXMLBuilder::renderResource(const std::string& url, const CdsResource& resource, pugi::xml_node& parent, const std::map<std::string, std::string>& clientSpecificAttrs) const
 {
     auto res = parent.append_child("res");
     res.append_child(pugi::node_pcdata).set_value(url.c_str());
@@ -370,7 +370,7 @@ void UpnpXMLBuilder::renderResource(const std::string& url, const CdsResource& r
     }
 }
 
-std::unique_ptr<UpnpXMLBuilder::PathBase> UpnpXMLBuilder::getPathBase(const std::shared_ptr<CdsItem>& item, bool forceLocal)
+std::unique_ptr<UpnpXMLBuilder::PathBase> UpnpXMLBuilder::getPathBase(const std::shared_ptr<CdsItem>& item, bool forceLocal) const
 {
     /// \todo resource options must be read from configuration files
 
@@ -395,7 +395,7 @@ std::unique_ptr<UpnpXMLBuilder::PathBase> UpnpXMLBuilder::getPathBase(const std:
 
 /// \brief build path for first resource from item
 /// depending on the item type it returns the url to the media
-std::string UpnpXMLBuilder::getFirstResourcePath(const std::shared_ptr<CdsItem>& item)
+std::string UpnpXMLBuilder::getFirstResourcePath(const std::shared_ptr<CdsItem>& item) const
 {
     auto urlBase = getPathBase(item);
 
@@ -411,7 +411,7 @@ std::string UpnpXMLBuilder::getFirstResourcePath(const std::shared_ptr<CdsItem>&
     return fmt::format(SERVER_VIRTUAL_DIR "{}", urlBase->pathBase);
 }
 
-std::pair<std::string, bool> UpnpXMLBuilder::renderContainerImage(const std::string& virtualURL, const std::shared_ptr<CdsContainer>& cont)
+std::pair<std::string, bool> UpnpXMLBuilder::renderContainerImage(const std::shared_ptr<CdsContainer>& cont) const
 {
     auto orderedResources = getOrderedResources(cont);
     for (auto&& res : orderedResources) {
@@ -435,7 +435,7 @@ std::pair<std::string, bool> UpnpXMLBuilder::renderContainerImage(const std::str
             result = true;
         }
         if (result) {
-            auto pathVector = std::vector<std::string> { CONTENT_MEDIA_HANDLER, dictEncodeSimple(dict), URL_RESOURCE_ID, resId };
+            auto pathVector = std::vector<std::string> { SERVER_VIRTUAL_DIR, CONTENT_MEDIA_HANDLER, dictEncodeSimple(dict), URL_RESOURCE_ID, resId };
             auto resParams = res->getParameters();
             if (!resParams.empty()) {
                 pathVector.push_back(dictEncodeSimple(resParams));
@@ -446,7 +446,7 @@ std::pair<std::string, bool> UpnpXMLBuilder::renderContainerImage(const std::str
     return {};
 }
 
-std::string UpnpXMLBuilder::renderOneResource(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item, const std::shared_ptr<CdsResource>& res)
+std::string UpnpXMLBuilder::renderOneResource(const std::shared_ptr<CdsItem>& item, const std::shared_ptr<CdsResource>& res) const
 {
     auto resParams = res->getParameters();
     auto urlBase = getPathBase(item);
@@ -454,7 +454,7 @@ std::string UpnpXMLBuilder::renderOneResource(const std::string& virtualURL, con
         return item->getLocation();
     std::string url;
     if (urlBase->addResID) {
-        url = fmt::format("{}{}{}{}", virtualURL, urlBase->pathBase, res->getResId(), _URL_PARAM_SEPARATOR);
+        url = fmt::format("{}/{}{}{}{}", virtualURL, SERVER_VIRTUAL_DIR, urlBase->pathBase, res->getResId(), _URL_PARAM_SEPARATOR);
     } else
         url = virtualURL + urlBase->pathBase;
 
@@ -464,29 +464,29 @@ std::string UpnpXMLBuilder::renderOneResource(const std::string& virtualURL, con
     return url;
 }
 
-std::pair<std::string, bool> UpnpXMLBuilder::renderItemImage(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item)
+std::pair<std::string, bool> UpnpXMLBuilder::renderItemImage(const std::shared_ptr<CdsItem>& item) const
 {
     auto orderedResources = getOrderedResources(item);
     auto resFound = std::find_if(orderedResources.begin(), orderedResources.end(),
         [](auto&& res) { return res->getPurpose() == CdsResource::Purpose::Thumbnail; });
     if (resFound != orderedResources.end()) {
-        return { renderOneResource(virtualURL, item, *resFound), true };
+        return { renderOneResource(item, *resFound), true };
     }
 
     return {};
 }
 
-std::pair<std::string, bool> UpnpXMLBuilder::renderSubtitle(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item, const Quirks* quirks)
+std::pair<std::string, bool> UpnpXMLBuilder::renderSubtitle(const std::shared_ptr<CdsItem>& item, const Quirks* quirks) const
 {
     auto resFound = item->getResource(CdsResource::Purpose::Subtitle);
     if (resFound) {
-        auto url = renderOneResource(virtualURL, item, resFound) + renderExtension("", resFound->getAttribute(CdsResource::Attribute::RESOURCE_FILE), quirks);
+        auto url = renderOneResource(item, resFound) + renderExtension("", resFound->getAttribute(CdsResource::Attribute::RESOURCE_FILE), quirks);
         return { url, true };
     }
     return {};
 }
 
-std::string UpnpXMLBuilder::renderExtension(const std::string& contentType, const fs::path& location, const Quirks* quirks)
+std::string UpnpXMLBuilder::renderExtension(const std::string& contentType, const fs::path& location, const Quirks* quirks) const
 {
     auto urlExt = URLUtils::joinUrl({ URL_FILE_EXTENSION, "file" });
 
@@ -595,7 +595,7 @@ std::deque<std::shared_ptr<CdsResource>> UpnpXMLBuilder::getOrderedResources(con
     return orderedResources;
 }
 
-std::pair<bool, int> UpnpXMLBuilder::insertTempTranscodingResource(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Quirks>& quirks, std::deque<std::shared_ptr<CdsResource>>& orderedResources, bool skipURL)
+std::pair<bool, int> UpnpXMLBuilder::insertTempTranscodingResource(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Quirks>& quirks, std::deque<std::shared_ptr<CdsResource>>& orderedResources, bool skipURL) const
 {
     bool hideOriginalResource = false;
     int originalResource = -1;
@@ -745,7 +745,7 @@ std::pair<bool, int> UpnpXMLBuilder::insertTempTranscodingResource(const std::sh
     return { hideOriginalResource, originalResource };
 }
 
-void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks)
+void UpnpXMLBuilder::addResources(const std::shared_ptr<CdsItem>& item, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks) const
 {
     auto urlBase = getPathBase(item);
     bool skipURL = (item->isExternalItem() && !item->getFlag(OBJECT_FLAG_PROXY_URL));

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -43,6 +43,8 @@
 #include "context.h"
 #include "util/upnp_quirks.h"
 
+class Quirks;
+
 class UpnpXMLBuilder {
 public:
     explicit UpnpXMLBuilder(const std::shared_ptr<Context>& context,
@@ -57,43 +59,43 @@ public:
     /// <u:actionNameResponse xmlns:u="serviceType"/>
     /// Further response information (various parameters, DIDL-Lite or
     /// whatever can then be adapted to it.
-    static std::unique_ptr<pugi::xml_document> createResponse(const std::string& actionName, const std::string& serviceType);
+    std::unique_ptr<pugi::xml_document> createResponse(const std::string& actionName, const std::string& serviceType) const;
 
     /// \brief Renders the DIDL-Lite representation of an object in the content directory.
     /// \param obj Object to be rendered as XML.
     ///
     /// This function looks at the object, and renders the DIDL-Lite representation of it -
     /// either a container or an item
-    void renderObject(const std::shared_ptr<CdsObject>& obj, std::size_t stringLimit, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks = nullptr);
+    void renderObject(const std::shared_ptr<CdsObject>& obj, std::size_t stringLimit, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks = nullptr) const;
 
     /// \brief Renders XML for the event property set.
     /// \return pugi::xml_document representing the newly created XML.
-    static std::unique_ptr<pugi::xml_document> createEventPropertySet();
+    std::unique_ptr<pugi::xml_document> createEventPropertySet() const;
 
     /// \brief Renders the device description XML.
     /// \return pugi::xml_document representing the newly created device description.
     ///
     /// Some elements are statically defined in common.h, others are loaded
     /// from the config with the help of the ConfigManager.
-    std::unique_ptr<pugi::xml_document> renderDeviceDescription();
+    std::unique_ptr<pugi::xml_document> renderDeviceDescription() const;
 
     /// \brief Renders a resource tag (part of DIDL-Lite XML)
     /// \param URL download location of the item (will be child element of the <res> tag)
     /// \param resource The CDSResource itself
     /// \param parent Parent node to render the result into
     /// \param clientSpecificAttrs A map containing extra client specific res attributes (like resolution, etc.)
-    static void renderResource(const std::string& url, const CdsResource& resource, pugi::xml_node& parent, const std::map<std::string, std::string>& clientSpecificAttrs);
+    void renderResource(const std::string& url, const CdsResource& resource, pugi::xml_node& parent, const std::map<std::string, std::string>& clientSpecificAttrs) const;
 
-    std::pair<std::string, bool> renderContainerImage(const std::string& virtualURL, const std::shared_ptr<CdsContainer>& cont);
-    std::pair<std::string, bool> renderItemImage(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item);
-    static std::pair<std::string, bool> renderSubtitle(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item, const Quirks* quirks);
-    static std::string renderOneResource(const std::string& virtualURL, const std::shared_ptr<CdsItem>& item, const std::shared_ptr<CdsResource>& res);
+    std::pair<std::string, bool> renderContainerImage(const std::shared_ptr<CdsContainer>& cont) const;
+    std::pair<std::string, bool> renderItemImage(const std::shared_ptr<CdsItem>& item) const;
+    std::pair<std::string, bool> renderSubtitle(const std::shared_ptr<CdsItem>& item, const Quirks* quirks) const;
+    std::string renderOneResource(const std::shared_ptr<CdsItem>& item, const std::shared_ptr<CdsResource>& res) const;
 
-    void addResources(const std::shared_ptr<CdsItem>& item, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks);
+    void addResources(const std::shared_ptr<CdsItem>& item, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks) const;
 
     /// \brief build path for first resource from item
     /// depending on the item type it returns the url to the media
-    static std::string getFirstResourcePath(const std::shared_ptr<CdsItem>& item);
+    std::string getFirstResourcePath(const std::shared_ptr<CdsItem>& item) const;
 
     /// \brief convert xml tree to string
     static std::string printXml(const pugi::xml_node& entry, const char* indent = PUGIXML_TEXT("\t"), int flags = pugi::format_default);
@@ -126,12 +128,12 @@ protected:
         bool addResID;
     };
     std::deque<std::shared_ptr<CdsResource>> getOrderedResources(const std::shared_ptr<CdsObject>& object) const;
-    std::pair<bool, int> insertTempTranscodingResource(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Quirks>& quirks, std::deque<std::shared_ptr<CdsResource>>& orderedResources, bool skipURL);
+    std::pair<bool, int> insertTempTranscodingResource(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Quirks>& quirks, std::deque<std::shared_ptr<CdsResource>>& orderedResources, bool skipURL) const;
 
-    static std::unique_ptr<PathBase> getPathBase(const std::shared_ptr<CdsItem>& item, bool forceLocal = false);
-    static std::string renderExtension(const std::string& contentType, const fs::path& location, const Quirks* quirks);
-    static void addField(pugi::xml_node& entry, const std::string& key, const std::string& val);
-    void addPropertyList(pugi::xml_node& result, const std::vector<std::pair<std::string, std::string>>& meta, const std::map<std::string, std::string>& auxData, config_option_t itemProps, config_option_t nsProp);
+    std::unique_ptr<PathBase> getPathBase(const std::shared_ptr<CdsItem>& item, bool forceLocal = false) const;
+    std::string renderExtension(const std::string& contentType, const fs::path& location, const Quirks* quirks) const;
+    void addField(pugi::xml_node& entry, const std::string& key, const std::string& val) const;
+    void addPropertyList(pugi::xml_node& result, const std::vector<std::pair<std::string, std::string>>& meta, const std::map<std::string, std::string>& auxData, config_option_t itemProps, config_option_t nsProp) const;
     std::string findDlnaProfile(const std::shared_ptr<CdsResource>& res, const std::string& contentType) const;
     std::string dlnaProfileString(const std::shared_ptr<CdsResource>& res, const std::string& contentType, bool formatted = true) const;
 };

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -80,16 +80,18 @@ public:
     std::unique_ptr<pugi::xml_document> renderDeviceDescription() const;
 
     /// \brief Renders a resource tag (part of DIDL-Lite XML)
-    /// \param URL download location of the item (will be child element of the <res> tag)
+    /// \param obj Object containing this resource
     /// \param resource The CDSResource itself
     /// \param parent Parent node to render the result into
     /// \param clientSpecificAttrs A map containing extra client specific res attributes (like resolution, etc.)
-    void renderResource(const std::string& url, const CdsResource& resource, pugi::xml_node& parent, const std::map<std::string, std::string>& clientSpecificAttrs) const;
+    /// \param clientGroup The clients group for play tracking
+    void renderResource(const CdsObject& obj, const CdsResource& resource, pugi::xml_node& parent, const std::map<std::string, std::string>& clientSpecificAttrs, const std::string& clientGroup) const;
 
-    std::pair<std::string, bool> renderContainerImage(const std::shared_ptr<CdsContainer>& cont) const;
-    std::pair<std::string, bool> renderItemImage(const std::shared_ptr<CdsItem>& item) const;
-    std::pair<std::string, bool> renderSubtitle(const std::shared_ptr<CdsItem>& item, const Quirks* quirks) const;
-    std::string renderOneResource(const std::shared_ptr<CdsItem>& item, const std::shared_ptr<CdsResource>& res) const;
+    std::optional<std::string> renderContainerImageURL(const std::shared_ptr<CdsContainer>& cont) const;
+    std::optional<std::string> renderItemImageURL(const std::shared_ptr<CdsItem>& item) const;
+    std::optional<std::string> renderSubtitleURL(const std::shared_ptr<CdsItem>& item) const;
+
+    std::string renderResourceURL(const CdsObject& item, const CdsResource& res, const std::string& clientGroup = "") const;
 
     void addResources(const std::shared_ptr<CdsItem>& item, pugi::xml_node& parent, const std::unique_ptr<Quirks>& quirks) const;
 
@@ -117,24 +119,16 @@ protected:
     std::vector<std::vector<std::pair<std::string, std::string>>> profMappings;
     std::map<std::string, std::string> transferMappings;
 
-    /// \brief Holds a part of path and bool which says if we need to append the resource
-    struct PathBase {
-        PathBase(std::string pathBase, bool addResID)
-            : pathBase(std::move(pathBase))
-            , addResID(addResID)
-        {
-        }
-        std::string pathBase;
-        bool addResID;
-    };
-    std::deque<std::shared_ptr<CdsResource>> getOrderedResources(const std::shared_ptr<CdsObject>& object) const;
+    std::deque<std::shared_ptr<CdsResource>> getOrderedResources(const CdsObject& object) const;
     std::pair<bool, int> insertTempTranscodingResource(const std::shared_ptr<CdsItem>& item, const std::unique_ptr<Quirks>& quirks, std::deque<std::shared_ptr<CdsResource>>& orderedResources, bool skipURL) const;
 
-    std::unique_ptr<PathBase> getPathBase(const std::shared_ptr<CdsItem>& item, bool forceLocal = false) const;
-    std::string renderExtension(const std::string& contentType, const fs::path& location, const Quirks* quirks) const;
+    std::string renderExtension(const std::string& contentType, const fs::path& location, const std::string& language) const;
     void addField(pugi::xml_node& entry, const std::string& key, const std::string& val) const;
     void addPropertyList(pugi::xml_node& result, const std::vector<std::pair<std::string, std::string>>& meta, const std::map<std::string, std::string>& auxData, config_option_t itemProps, config_option_t nsProp) const;
-    std::string findDlnaProfile(const std::shared_ptr<CdsResource>& res, const std::string& contentType) const;
-    std::string dlnaProfileString(const std::shared_ptr<CdsResource>& res, const std::string& contentType, bool formatted = true) const;
+    std::string findDlnaProfile(const CdsResource& res, const std::string& contentType) const;
+    std::string dlnaProfileString(const CdsResource& res, const std::string& contentType, bool formatted = true) const;
+
+    std::string buildProtocolInfo(CdsResource& res) const;
+    std::string getMimeType(const CdsResource& resource) const;
 };
 #endif // __UPNP_XML_H__

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -192,7 +192,7 @@ void ClientManager::addClientByDiscovery(const std::shared_ptr<GrbNet>& addr, co
 #endif
 }
 
-const ClientInfo* ClientManager::getInfo(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent)
+const ClientInfo* ClientManager::getInfo(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent) const
 {
     // 1. by IP address
     auto info = getInfoByAddr(addr);
@@ -267,7 +267,7 @@ const ClientInfo* ClientManager::getInfoByCache(const std::shared_ptr<GrbNet>& a
     return nullptr;
 }
 
-void ClientManager::updateCache(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const ClientInfo* pInfo)
+void ClientManager::updateCache(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const ClientInfo* pInfo) const
 {
     AutoLock lock(mutex);
 

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -140,7 +140,7 @@ public:
     void refresh(const std::shared_ptr<Config>& config);
 
     // always return something, 'Unknown' if we do not know better
-    const ClientInfo* getInfo(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent);
+    const ClientInfo* getInfo(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent) const;
 
     void addClientByDiscovery(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const std::string& descLocation);
     const std::vector<ClientCacheEntry>& getClientList() const { return cache; }
@@ -150,13 +150,13 @@ private:
     const ClientInfo* getInfoByType(const std::string& match, ClientMatchType type) const;
 
     const ClientInfo* getInfoByCache(const std::shared_ptr<GrbNet>& addr) const;
-    void updateCache(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const ClientInfo* pInfo);
+    void updateCache(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const ClientInfo* pInfo) const;
 
     static std::unique_ptr<pugi::xml_document> downloadDescription(const std::string& location);
 
     mutable std::mutex mutex;
     using AutoLock = std::scoped_lock<std::mutex>;
-    std::vector<ClientCacheEntry> cache;
+    mutable std::vector<ClientCacheEntry> cache;
 
     std::vector<ClientInfo> clientInfo;
     std::shared_ptr<Database> database;

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -62,11 +62,11 @@ void Quirks::addCaptionInfo(const std::shared_ptr<CdsItem>& item, Headers& heade
     if (item->getClass() != UPNP_CLASS_VIDEO_ITEM)
         return;
 
-    auto [url, subAdded] = xmlBuilder.renderSubtitle(item, this);
+    auto subAdded = xmlBuilder.renderSubtitleURL(item);
     if (subAdded) {
-        log_debug("Call for Samsung CaptionInfo.sec: {}", url);
-        headers.addHeader("CaptionInfo.sec", url);
-        headers.addHeader("getCaptionInfo.sec", url);
+        log_debug("Call for Samsung CaptionInfo.sec: {}", subAdded.value());
+        headers.addHeader("CaptionInfo.sec", subAdded.value());
+        headers.addHeader("getCaptionInfo.sec", subAdded.value());
     }
 }
 

--- a/src/util/upnp_quirks.h
+++ b/src/util/upnp_quirks.h
@@ -26,6 +26,7 @@
 #ifndef __UPNP_QUIRKS_H__
 #define __UPNP_QUIRKS_H__
 
+#include "upnp_xml.h"
 #include <memory>
 #include <pugixml.hpp>
 #include <vector>
@@ -50,11 +51,12 @@ class CdsItem;
 class CdsObject;
 class GrbNet;
 class Headers;
+class UpnpXMLBuilder;
 struct ClientInfo;
 
 class Quirks {
 public:
-    Quirks(std::shared_ptr<Context> context, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent);
+    Quirks(const UpnpXMLBuilder& builder, const ClientManager& clients, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent);
 
     // Look for subtitle file and returns its URL in CaptionInfo.sec response header.
     // To be more compliant with original Samsung server we should check for getCaptionInfo.sec: 1 request header.
@@ -75,7 +77,7 @@ public:
      * \return void
      *
      */
-    void saveSamsungBookMarkedPosition(ActionRequest& request);
+    void saveSamsungBookMarkedPosition(Database& database, ActionRequest& request) const;
 
     /** \brief get Samsung Feature List
      *
@@ -84,7 +86,7 @@ public:
      *
      */
     void getSamsungFeatureList(ActionRequest& request) const;
-    std::vector<std::shared_ptr<CdsObject>> getSamsungFeatureRoot(const std::string& objId) const;
+    std::vector<std::shared_ptr<CdsObject>> getSamsungFeatureRoot(Database& database, const std::string& objId) const;
 
     /** \brief get Samsung ObjectID from Index
      *
@@ -139,8 +141,7 @@ public:
     std::string getGroup() const;
 
 private:
-    std::shared_ptr<Context> context;
-    std::shared_ptr<ContentManager> content;
+    const UpnpXMLBuilder& xmlBuilder;
     const ClientInfo* pClientInfo;
 };
 

--- a/src/web/containers.cc
+++ b/src/web/containers.cc
@@ -75,9 +75,9 @@ void Web::Containers::process()
         int autoscanType = cont->getAutoscanType();
         ce.append_attribute("autoscan_type") = mapAutoscanType(autoscanType).data();
 
-        auto [url, artAdded] = xmlBuilder->renderContainerImage(cont);
-        if (artAdded) {
-            ce.append_attribute("image") = url.c_str();
+        auto url = xmlBuilder->renderContainerImageURL(cont);
+        if (url) {
+            ce.append_attribute("image") = url.value().c_str();
         }
 
         std::string autoscanMode = "none";

--- a/src/web/containers.cc
+++ b/src/web/containers.cc
@@ -75,7 +75,7 @@ void Web::Containers::process()
         int autoscanType = cont->getAutoscanType();
         ce.append_attribute("autoscan_type") = mapAutoscanType(autoscanType).data();
 
-        auto [url, artAdded] = xmlBuilder->renderContainerImage(server->getVirtualUrl(), cont);
+        auto [url, artAdded] = xmlBuilder->renderContainerImage(cont);
         if (artAdded) {
             ce.append_attribute("image") = url.c_str();
         }

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -185,7 +185,7 @@ void Web::EditLoad::process()
 
         // write resource content
         if (objItem) {
-            std::string url = xmlBuilder->renderOneResource(objItem, resItem);
+            std::string url = xmlBuilder->renderResourceURL(*objItem, *resItem);
             if (resItem->getPurpose() == CdsResource::Purpose::Thumbnail) {
                 auto image = resources.append_child("resources");
                 image.append_attribute("resname") = "image";
@@ -242,10 +242,10 @@ void Web::EditLoad::process()
         mimeType.append_attribute("value") = objItem->getMimeType().c_str();
         mimeType.append_attribute("editable") = true;
 
-        auto [url, artAdded] = xmlBuilder->renderItemImage(objItem);
-        if (artAdded) {
+        auto url = xmlBuilder->renderItemImageURL(objItem);
+        if (url) {
             auto image = item.append_child("image");
-            image.append_attribute("value") = url.c_str();
+            image.append_attribute("value") = url.value().c_str();
             image.append_attribute("editable") = false;
         }
 
@@ -285,10 +285,10 @@ void Web::EditLoad::process()
     // write container meta info
     if (obj->isContainer()) {
         auto cont = std::static_pointer_cast<CdsContainer>(obj);
-        auto [url, artAdded] = xmlBuilder->renderContainerImage(cont);
-        if (artAdded) {
+        auto url = xmlBuilder->renderContainerImageURL(cont);
+        if (url) {
             auto image = item.append_child("image");
-            image.append_attribute("value") = url.c_str();
+            image.append_attribute("value") = url.value().c_str();
             image.append_attribute("editable") = false;
         }
     }

--- a/src/web/edit_load.cc
+++ b/src/web/edit_load.cc
@@ -185,7 +185,7 @@ void Web::EditLoad::process()
 
         // write resource content
         if (objItem) {
-            std::string url = UpnpXMLBuilder::renderOneResource(server->getVirtualUrl(), objItem, resItem);
+            std::string url = xmlBuilder->renderOneResource(objItem, resItem);
             if (resItem->getPurpose() == CdsResource::Purpose::Thumbnail) {
                 auto image = resources.append_child("resources");
                 image.append_attribute("resname") = "image";
@@ -242,7 +242,7 @@ void Web::EditLoad::process()
         mimeType.append_attribute("value") = objItem->getMimeType().c_str();
         mimeType.append_attribute("editable") = true;
 
-        auto [url, artAdded] = xmlBuilder->renderItemImage(server->getVirtualUrl(), objItem);
+        auto [url, artAdded] = xmlBuilder->renderItemImage(objItem);
         if (artAdded) {
             auto image = item.append_child("image");
             image.append_attribute("value") = url.c_str();
@@ -285,7 +285,7 @@ void Web::EditLoad::process()
     // write container meta info
     if (obj->isContainer()) {
         auto cont = std::static_pointer_cast<CdsContainer>(obj);
-        auto [url, artAdded] = xmlBuilder->renderContainerImage(server->getVirtualUrl(), cont);
+        auto [url, artAdded] = xmlBuilder->renderContainerImage(cont);
         if (artAdded) {
             auto image = item.append_child("image");
             image.append_attribute("value") = url.c_str();

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -145,9 +145,9 @@ void Web::Items::process()
         std::string res = xmlBuilder->getFirstResourcePath(objItem);
         item.append_child("res").append_child(pugi::node_pcdata).set_value(res.c_str());
 
-        auto [url, artAdded] = xmlBuilder->renderItemImage(objItem);
-        if (artAdded) {
-            item.append_child("image").append_child(pugi::node_pcdata).set_value(url.c_str());
+        auto url = xmlBuilder->renderItemImageURL(objItem);
+        if (url) {
+            item.append_child("image").append_child(pugi::node_pcdata).set_value(url.value().c_str());
         }
         cnt++;
     }

--- a/src/web/items.cc
+++ b/src/web/items.cc
@@ -142,10 +142,10 @@ void Web::Items::process()
             item.append_child("track").append_child(pugi::node_pcdata).set_value(fmt::format(trackFmt, cnt).c_str());
         item.append_child("mtype").append_child(pugi::node_pcdata).set_value(objItem->getMimeType().c_str());
         item.append_child("upnp_class").append_child(pugi::node_pcdata).set_value(objItem->getClass().c_str());
-        std::string res = UpnpXMLBuilder::getFirstResourcePath(objItem);
+        std::string res = xmlBuilder->getFirstResourcePath(objItem);
         item.append_child("res").append_child(pugi::node_pcdata).set_value(res.c_str());
 
-        auto [url, artAdded] = xmlBuilder->renderItemImage(server->getVirtualUrl(), objItem);
+        auto [url, artAdded] = xmlBuilder->renderItemImage(objItem);
         if (artAdded) {
             item.append_child("image").append_child(pugi::node_pcdata).set_value(url.c_str());
         }

--- a/test/core/test_ffmpeg_cache_paths.cc
+++ b/test/core/test_ffmpeg_cache_paths.cc
@@ -10,7 +10,7 @@ using ::testing::Return;
 
 TEST(Thumbnailer_Cache, BaseDirFromConfig)
 {
-    auto ctx = std::make_shared<Context>(std::make_shared<ConfigMock>(), nullptr, nullptr, nullptr, nullptr, nullptr);
+    auto ctx = std::make_shared<Context>(std::make_shared<ConfigMock>(), nullptr, nullptr, nullptr, nullptr);
     auto cfg = std::static_pointer_cast<ConfigMock>(ctx->getConfig());
     EXPECT_CALL(*cfg, getOption(CFG_SERVER_EXTOPTS_FFMPEGTHUMBNAILER_CACHE_DIR))
         .WillOnce(Return("/var/lib/cache"));
@@ -19,7 +19,7 @@ TEST(Thumbnailer_Cache, BaseDirFromConfig)
 
 TEST(Thumbnailer_Cache, BaseDirDefaultFromUserHome)
 {
-    auto ctx = std::make_shared<Context>(std::make_shared<ConfigMock>(), nullptr, nullptr, nullptr, nullptr, nullptr);
+    auto ctx = std::make_shared<Context>(std::make_shared<ConfigMock>(), nullptr, nullptr, nullptr, nullptr);
     auto cfg = std::static_pointer_cast<ConfigMock>(ctx->getConfig());
     EXPECT_CALL(*cfg, getOption(CFG_SERVER_EXTOPTS_FFMPEGTHUMBNAILER_CACHE_DIR))
         .WillOnce(Return(""));

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -15,17 +15,14 @@ using ::testing::Return;
 class UpnpXmlTest : public ::testing::Test {
 
 public:
-    UpnpXmlTest() = default;
-    ~UpnpXmlTest() override = default;
-
     void SetUp() override
     {
         config = std::make_shared<ConfigMock>();
 
         database = std::make_shared<DatabaseMock>(config);
-        context = std::make_shared<Context>(config, nullptr, nullptr, database, nullptr, nullptr);
+        context = std::make_shared<Context>(config, nullptr, nullptr, database, nullptr);
 
-        std::string virtualDir = "http://server/";
+        std::string virtualDir = "http://server";
         std::string presentationURl = "http://someurl/";
         subject = new UpnpXMLBuilder(context, virtualDir, presentationURl);
     }
@@ -78,7 +75,7 @@ TEST_F(UpnpXmlTest, RenderObjectContainer)
     expectedXml << "<upnp:conductor>Conductor</upnp:conductor>\n";
     expectedXml << "<upnp:date>2001-01-01</upnp:date>\n";
     expectedXml << "<upnp:orchestra>Orchestra</upnp:orchestra>\n";
-    expectedXml << "<upnp:albumArtURI>http://server/content/media/object_id/1/res_id/0</upnp:albumArtURI>\n";
+    expectedXml << "<upnp:albumArtURI>http://server/content/media/object_id/1/res_id/0/ext/file.jpg</upnp:albumArtURI>\n";
     expectedXml << "</container>\n";
     expectedXml << "</DIDL-Lite>\n";
 
@@ -163,8 +160,15 @@ TEST_F(UpnpXmlTest, RenderObjectItemWithResources)
 
     resource = std::make_shared<CdsResource>(ContentHandler::SUBTITLE, CdsResource::Purpose::Subtitle);
     std::string type = "srt";
-    resource->addAttribute(CdsResource::Attribute::PROTOCOLINFO, renderProtocolInfo(type));
+    resource->addAttribute(CdsResource::Attribute::PROTOCOLINFO, renderProtocolInfo("text/" + type));
     resource->addAttribute(CdsResource::Attribute::RESOURCE_FILE, "/home/resource/subtitle.srt");
+    resource->addParameter("type", type);
+    obj->addResource(resource);
+
+    resource = std::make_shared<CdsResource>(ContentHandler::SUBTITLE, CdsResource::Purpose::Subtitle);
+    resource->addAttribute(CdsResource::Attribute::PROTOCOLINFO, renderProtocolInfo("text/" + type));
+    resource->addAttribute(CdsResource::Attribute::RESOURCE_FILE, "/home/resource/subtitle.srt");
+    resource->addAttribute(CdsResource::Attribute::LANGUAGE, "fr");
     resource->addParameter("type", type);
     obj->addResource(resource);
 
@@ -184,10 +188,12 @@ TEST_F(UpnpXmlTest, RenderObjectItemWithResources)
     expectedXml << "<upnp:album>Album</upnp:album>\n";
     expectedXml << "<upnp:date>2002-01-01</upnp:date>\n";
     expectedXml << "<upnp:originalTrackNumber>7</upnp:originalTrackNumber>\n";
-    expectedXml << "<upnp:albumArtURI xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0\" dlna:profileID=\"JPEG_TN\">http://server/content/media/object_id/42/res_id/2</upnp:albumArtURI>\n";
-    expectedXml << "<sec:CaptionInfoEx protocolInfo=\"http-get:*:srt:*\" sec:type=\"srt\">http://server/content/media/object_id/42/res_id/1/type/srt/ext/file.subtitle.srt</sec:CaptionInfoEx>\n";
+    expectedXml << "<upnp:albumArtURI xmlns:dlna=\"urn:schemas-dlna-org:metadata-1-0\" dlna:profileID=\"JPEG_TN\">http://server/content/media/object_id/42/res_id/3/ext/file.jpg</upnp:albumArtURI>\n";
+    expectedXml << "<sec:CaptionInfoEx protocolInfo=\"http-get:*:text/srt:*\" sec:type=\"srt\">http://server/content/media/object_id/42/res_id/1/type/srt/ext/file.srt</sec:CaptionInfoEx>\n";
     expectedXml << "<res size=\"4711\" duration=\"123456\" bitrate=\"16044\" nrAudioChannels=\"2\" protocolInfo=\"http-get:*:audio/mpeg:DLNA.ORG_PN=MP3;DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=01700000000000000000000000000000\">http://server/content/media/object_id/42/res_id/0/group/default/ext/file.mp3</res>\n";
-    expectedXml << "<res protocolInfo=\"http-get:*:srt:DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=00d00000000000000000000000000000\">http://server/content/media/object_id/42/res_id/1/group/default/type/srt/ext/file.subtitle.srt</res>\n";
+    expectedXml << "<res protocolInfo=\"http-get:*:text/srt:DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=00d00000000000000000000000000000\">http://server/content/media/object_id/42/res_id/1/type/srt/ext/file.srt</res>\n";
+    expectedXml << "<res protocolInfo=\"http-get:*:text/srt:DLNA.ORG_OP=01;DLNA.ORG_CI=0;DLNA.ORG_FLAGS=00d00000000000000000000000000000\" dc:language=\"fr\">http://server/content/media/object_id/42/res_id/2/type/srt/ext/file.fr.srt</res>\n";
+    expectedXml << "<res resolution=\"200x200\" protocolInfo=\"http-get:*:jpg:DLNA.ORG_OP=01;DLNA.ORG_CI=0\">http://server/content/media/object_id/42/res_id/3/ext/file.jpg</res>\n";
     expectedXml << "</item>\n";
     expectedXml << "</DIDL-Lite>\n";
 
@@ -257,7 +263,7 @@ TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToExternalUrlWhenOnlineWithP
     std::string result = subject->getFirstResourcePath(item);
 
     EXPECT_NE(result, "");
-    EXPECT_STREQ(result.c_str(), "content/online/object_id/12345/res_id/0");
+    EXPECT_STREQ(result.c_str(), "http://server/content/online/object_id/12345/res_id/0");
 }
 
 TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToItem)
@@ -271,19 +277,5 @@ TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToItem)
     std::string result = subject->getFirstResourcePath(item);
 
     EXPECT_NE(result, "");
-    EXPECT_STREQ(result.c_str(), "content/media/object_id/12345/res_id/0");
-}
-
-TEST_F(UpnpXmlTest, RenderContainerImage)
-{
-    auto obj = std::make_shared<CdsContainer>();
-    obj->setLocation("local/content");
-    obj->setID(12345);
-
-    auto result = subject->renderContainerImage(obj);
-
-    EXPECT_TRUE(result.has_value());
-
-    EXPECT_NE(result, "");
-    EXPECT_STREQ(result.c_str(), "content/media/object_id/12345/res_id/0");
+    EXPECT_STREQ(result.c_str(), "http://server/content/media/object_id/12345/res_id/0");
 }

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -209,7 +209,7 @@ TEST_F(UpnpXmlTest, RenderObjectItemWithResources)
 
 TEST_F(UpnpXmlTest, CreatesEventPropertySet)
 {
-    auto result = UpnpXMLBuilder::createEventPropertySet();
+    auto result = subject->createEventPropertySet();
     auto root = result->document_element();
 
     EXPECT_NE(root, nullptr);
@@ -223,7 +223,7 @@ TEST_F(UpnpXmlTest, CreateResponse)
     std::string actionName = "action";
     std::string serviceType = "urn:schemas-upnp-org:service:ContentDirectory:1";
 
-    auto result = UpnpXMLBuilder::createResponse(actionName, serviceType);
+    auto result = subject->createResponse(actionName, serviceType);
     EXPECT_NE(result, nullptr);
 
     auto root = result->document_element();
@@ -238,7 +238,7 @@ TEST_F(UpnpXmlTest, FirstResourceRendersPureWhenExternalUrl)
 
     auto item = std::static_pointer_cast<CdsItem>(obj);
 
-    std::string result = UpnpXMLBuilder::getFirstResourcePath(item);
+    std::string result = subject->getFirstResourcePath(item);
 
     EXPECT_NE(result, "");
     EXPECT_STREQ(result.c_str(), "http://localhost/external/url");
@@ -254,7 +254,7 @@ TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToExternalUrlWhenOnlineWithP
 
     auto item = std::static_pointer_cast<CdsItem>(obj);
 
-    std::string result = UpnpXMLBuilder::getFirstResourcePath(item);
+    std::string result = subject->getFirstResourcePath(item);
 
     EXPECT_NE(result, "");
     EXPECT_STREQ(result.c_str(), "content/online/object_id/12345/res_id/0");
@@ -268,7 +268,21 @@ TEST_F(UpnpXmlTest, FirstResourceAddsLocalResourceIdToItem)
 
     auto item = std::static_pointer_cast<CdsItem>(obj);
 
-    std::string result = UpnpXMLBuilder::getFirstResourcePath(item);
+    std::string result = subject->getFirstResourcePath(item);
+
+    EXPECT_NE(result, "");
+    EXPECT_STREQ(result.c_str(), "content/media/object_id/12345/res_id/0");
+}
+
+TEST_F(UpnpXmlTest, RenderContainerImage)
+{
+    auto obj = std::make_shared<CdsContainer>();
+    obj->setLocation("local/content");
+    obj->setID(12345);
+
+    auto result = subject->renderContainerImage(obj);
+
+    EXPECT_TRUE(result.has_value());
 
     EXPECT_NE(result, "");
     EXPECT_STREQ(result.c_str(), "content/media/object_id/12345/res_id/0");

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -25,7 +25,7 @@ public:
         database = std::make_shared<DatabaseMock>(config);
         context = std::make_shared<Context>(config, nullptr, nullptr, database, nullptr, nullptr);
 
-        std::string virtualDir = "http://server/content";
+        std::string virtualDir = "http://server/";
         std::string presentationURl = "http://someurl/";
         subject = new UpnpXMLBuilder(context, virtualDir, presentationURl);
     }

--- a/web/js/jquery.gerbera.editor.js
+++ b/web/js/jquery.gerbera.editor.js
@@ -162,7 +162,7 @@
     if (item) {
       reset(modal);
       if (item.image) {
-        modal.find('#mediaimage').prop('src', '//' + item.image.value);
+        modal.find('#mediaimage').prop('src', item.image.value);
         modal.find('#mediaimage').show();
       }
       modal.find('#editObjectType').val(item.obj_type);
@@ -219,7 +219,7 @@
             tbody = $('<tbody></tbody>');
             restable.append(tbody);
           } else if (item.resources.resources[i].resname === 'image') {
-            appendMetaItem(tbody, 'content', null, $('<img width="50px" class="resourceImage" src="//' +  item.resources.resources[i].resvalue + '"/>'));
+            appendMetaItem(tbody, 'content', null, $('<img width="50px" class="resourceImage" src="' +  item.resources.resources[i].resvalue + '"/>'));
           } else if (item.resources.resources[i].resname === 'link') {
             appendMetaItem(tbody, 'content', null, $('<a href=' +  item.resources.resources[i].resvalue + '>Open</span>'));
           } else {

--- a/web/js/jquery.gerbera.items.js
+++ b/web/js/jquery.gerbera.items.js
@@ -106,7 +106,7 @@ $.widget('grb.dataitems', {
           text.text(itemText).appendTo(content);
         }
         if (item.image) {
-          text.prepend($('<img class="pull-left rounded grb-thumbnail" src="//' + item.image + '"/>'));
+          text.prepend($('<img class="pull-left rounded grb-thumbnail" src="' + item.image + '"/>'));
         } else {
           let icon = "fa-file-o";
           if (item.upnp_class) {

--- a/web/js/jquery.gerbera.tree.js
+++ b/web/js/jquery.gerbera.tree.js
@@ -86,7 +86,7 @@ $.widget('grb.tree', {
         }
       }
       if (data[i].gerbera.image) {
-        title.prepend($('<img class="rounded" style="margin-right: 10px" width="36" src="//' + data[i].gerbera.image + '"/>'));
+        title.prepend($('<img class="rounded" style="margin-right: 10px" width="36" src="' + data[i].gerbera.image + '"/>'));
       }
 
       item.append(icon);


### PR DESCRIPTION
Single way to get the virtualUrl.

VirtualURL no longer includes the SERVER_VIRTUAL_DIR (content)
component for consistency with configuration and code.
