### PR TITLE
clang-tidy: add missing variable name in declaration

### DIFF
--- a/src/content/scripting/script.h
+++ b/src/content/scripting/script.h
@@ -99,7 +99,7 @@ public:
 protected:
     Script(const std::shared_ptr<ContentManager>& content,
         const std::shared_ptr<ScriptingRuntime>& runtime, const std::string& name,
-        std::string objName, std::unique_ptr<StringConverter>);
+        std::string objName, std::unique_ptr<StringConverter> sc);
 
     void execute(const std::shared_ptr<CdsObject>& obj, const std::string& scriptPath);
     void cleanup();

--- a/src/transcoding/transcoding.h
+++ b/src/transcoding/transcoding.h
@@ -129,7 +129,7 @@ public:
     ///
     /// \param name attribute name
     /// \param value attribute value
-    void setAttributeOverride(CdsResource::Attribute, const std::string& value);
+    void setAttributeOverride(CdsResource::Attribute attribute, const std::string& value);
     std::string getAttributeOverride(CdsResource::Attribute attribute) const;
 
     std::map<CdsResource::Attribute, std::string> getAttributeOverrides() const;


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>