### PR TITLE
clang-tidy: fix case style of class/structs

### DIFF
--- a/src/cds_resource.cc
+++ b/src/cds_resource.cc
@@ -100,13 +100,13 @@ std::string CdsResource::getAttribute(CdsResource::Attribute attr) const
     return getValueOrDefault(attributes, attr, { "" });
 }
 
-struct profMapping {
+struct ProfMapping {
     std::string_view val;
     unsigned int mx;
     unsigned int my;
 };
 
-static const std::vector<struct profMapping> resSteps {
+static const std::vector<struct ProfMapping> resSteps {
     { "ICO", 48, 48 },
     { "LICO", 120, 120 },
     { "TN", 160, 160 },


### PR DESCRIPTION
Signed-off-by: Rosen Penev <rosenp@gmail.com>

Actually this should probably use std::tuple...