### PR TITLE
Drop scan_level on update to DB 19

### DIFF
--- a/src/database/mysql/mysql-upgrade.xml
+++ b/src/database/mysql/mysql-upgrade.xml
@@ -127,5 +127,6 @@
     </version>
     <version number="19" remark="add autoscan content">
         <script>ALTER TABLE `mt_autoscan` ADD `media_type` int(11) NOT NULL default '-1'</script>
+        <script>ALTER TABLE `mt_autoscan` DROP COLUMN `scan_level`</script>
     </version>
 </upgrade>

--- a/src/database/mysql/mysql_database.cc
+++ b/src/database/mysql/mysql_database.cc
@@ -54,7 +54,7 @@ MySQLDatabase::MySQLDatabase(const std::shared_ptr<Config>& config, const std::s
     // if mysql.sql or mysql-upgrade.xml is changed hashies have to be updated
     hashies = { 4340373, // index 0 is used for create script mysql.sql
         928913698, 1984244483, 2241152998, 1748460509, 2860006966, 974692115, 70310290, 1863649106, 4238128129, 2979337694, // upgrade 1-10
-        1512596496, 507706380, 3545156190, 31528140, 372163748, 4097073836, 751952276, 2175417944 };
+        1512596496, 507706380, 3545156190, 31528140, 372163748, 4097073836, 751952276, 3893982139 };
 }
 
 MySQLDatabase::~MySQLDatabase()

--- a/src/database/sqlite3/sqlite3-upgrade.xml
+++ b/src/database/sqlite3/sqlite3-upgrade.xml
@@ -282,5 +282,32 @@
     </version>
     <version number="19" remark="add autoscan content">
         <script>ALTER TABLE "mt_autoscan" ADD "media_type" integer NOT NULL default(-1)</script>
+        <script>
+        PRAGMA foreign_keys = OFF;
+        CREATE TABLE "mt_autoscan_new" (
+          "id" integer primary key,
+          "obj_id" integer default NULL,
+          "scan_mode" varchar(10) NOT NULL,
+          "recursive" tinyint unsigned NOT NULL,
+          "media_type" integer NOT NULL,
+          "hidden" tinyint unsigned NOT NULL,
+          "interval" integer unsigned default NULL,
+          "last_modified" integer unsigned default NULL,
+          "persistent" tinyint unsigned NOT NULL default '0',
+          "location" text default NULL,
+          "path_ids" text default NULL,
+          "touched" tinyint unsigned NOT NULL default '1',
+          CONSTRAINT "mt_autoscan_id" FOREIGN KEY ("obj_id") REFERENCES "mt_cds_object" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+        );
+        INSERT INTO "mt_autoscan_new" (
+            id, obj_id, scan_mode, recursive, media_type, hidden, interval, last_modified, persistent, location, path_ids, touched
+        ) SELECT
+            id, obj_id, scan_mode, recursive, media_type, hidden, interval, last_modified, persistent, location, path_ids, touched
+        FROM mt_autoscan;
+        DROP TABLE mt_autoscan;
+        ALTER TABLE mt_autoscan_new RENAME TO mt_autoscan;
+        PRAGMA foreign_keys = ON;
+        VACUUM;
+        </script>
     </version>
 </upgrade>

--- a/src/database/sqlite3/sqlite_database.cc
+++ b/src/database/sqlite3/sqlite_database.cc
@@ -49,7 +49,7 @@ Sqlite3Database::Sqlite3Database(const std::shared_ptr<Config>& config, const st
     // if sqlite3.sql or sqlite3-upgrade.xml is changed hashies have to be updated
     hashies = { 3585221191, // index 0 is used for create script sqlite3.sql
         778996897, 3362507034, 853149842, 4035419264, 3497064885, 974692115, 119767663, 3167732653, 2427825904, 3305506356, // upgrade 1-10
-        43189396, 2767540493, 2512852146, 1273710965, 319062951, 3593597366, 1028160353, 2644417837 };
+        43189396, 2767540493, 2512852146, 1273710965, 319062951, 3593597366, 1028160353, 881071639 };
 }
 
 void Sqlite3Database::prepare()


### PR DESCRIPTION
closes #2622 

No new version, because if db was newly created it does not have the `scan_level` column to drop. Users who already updated need to execute the script manually.