### PR TITLE
clang-tidy: const string ref conversion

### DIFF
--- a/src/content/scripting/import_script.h
+++ b/src/content/scripting/import_script.h
@@ -47,7 +47,7 @@ public:
 
     void processCdsObject(const std::shared_ptr<CdsObject>& obj, const std::string& scriptPath);
     bool setRefId(const std::shared_ptr<CdsObject>& cdsObj, const std::shared_ptr<CdsObject>& origObject, int pcdId) override;
-    std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string rootPath) override
+    std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string& rootPath) override
     {
         return { dukObject2cdsObject(origObject), INVALID_OBJECT_ID };
     }

--- a/src/content/scripting/playlist_parser_script.cc
+++ b/src/content/scripting/playlist_parser_script.cc
@@ -234,7 +234,7 @@ PlaylistParserScript::PlaylistParserScript(const std::shared_ptr<ContentManager>
     load(scriptPath);
 }
 
-std::pair<std::shared_ptr<CdsObject>, int> PlaylistParserScript::createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string rootPath)
+std::pair<std::shared_ptr<CdsObject>, int> PlaylistParserScript::createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string& rootPath)
 {
     int otype = getIntProperty("objectType", -1);
     if (otype == -1) {
@@ -460,7 +460,7 @@ void MetafileParserScript::processObject(const std::shared_ptr<CdsObject>& obj, 
     }
 }
 
-std::pair<std::shared_ptr<CdsObject>, int> MetafileParserScript::createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string rootPath)
+std::pair<std::shared_ptr<CdsObject>, int> MetafileParserScript::createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string& rootPath)
 {
     return { {}, INVALID_OBJECT_ID };
 }

--- a/src/content/scripting/playlist_parser_script.h
+++ b/src/content/scripting/playlist_parser_script.h
@@ -71,7 +71,7 @@ public:
     PlaylistParserScript(const std::shared_ptr<ContentManager>& content, const std::shared_ptr<ScriptingRuntime>& runtime);
     void processPlaylistObject(const std::shared_ptr<CdsObject>& obj, std::shared_ptr<GenericTask> task, const std::string& rootPath);
 
-    std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string rootPath) override;
+    std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string& rootPath) override;
     bool setRefId(const std::shared_ptr<CdsObject>& cdsObj, const std::shared_ptr<CdsObject>& origObject, int pcdId) override;
 
 protected:
@@ -84,7 +84,7 @@ public:
     MetafileParserScript(const std::shared_ptr<ContentManager>& content, const std::shared_ptr<ScriptingRuntime>& runtime);
     void processObject(const std::shared_ptr<CdsObject>& obj, const fs::path& path);
 
-    std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string rootPath) override;
+    std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string& rootPath) override;
     bool setRefId(const std::shared_ptr<CdsObject>& cdsObj, const std::shared_ptr<CdsObject>& origObject, int pcdId) override;
 
 protected:

--- a/src/content/scripting/script.cc
+++ b/src/content/scripting/script.cc
@@ -435,7 +435,7 @@ void Script::execute(const std::shared_ptr<CdsObject>& obj, const std::string& r
     duk_pop(ctx);
 }
 
-void Script::setMetaData(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsItem>& item, const std::string& sym, const std::string val)
+void Script::setMetaData(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsItem>& item, const std::string& sym, const std::string& val)
 {
     if (sym == MetadataHandler::getMetaFieldName(M_TRACKNUMBER) && item) {
         int j = stoiString(val, 0);

--- a/src/content/scripting/script.h
+++ b/src/content/scripting/script.h
@@ -82,7 +82,7 @@ public:
     void cdsObject2dukObject(const std::shared_ptr<CdsObject>& obj);
 
     std::string convertToCharset(const std::string& str, charset_convert_t chr);
-    virtual std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string rootPath) = 0;
+    virtual std::pair<std::shared_ptr<CdsObject>, int> createObject2cdsObject(const std::shared_ptr<CdsObject>& origObject, const std::string& rootPath) = 0;
     virtual bool setRefId(const std::shared_ptr<CdsObject>& cdsObj, const std::shared_ptr<CdsObject>& origObject, int pcdId) = 0;
     static Script* getContextScript(duk_context* ctx);
 
@@ -99,7 +99,7 @@ protected:
     void execute(const std::shared_ptr<CdsObject>& obj, const std::string& rootPath);
     void cleanup();
     int gc_counter {};
-    void setMetaData(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsItem>& item, const std::string& sym, const std::string val);
+    void setMetaData(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsItem>& item, const std::string& sym, const std::string& val);
 
     virtual void handleObject2cdsItem(duk_context* ctx, const std::shared_ptr<CdsObject>& pcd, const std::shared_ptr<CdsItem>& item) { }
     virtual void handleObject2cdsContainer(duk_context* ctx, const std::shared_ptr<CdsObject>& pcd, const std::shared_ptr<CdsContainer>& cont) { }


### PR DESCRIPTION
These looks like mistakes.

Signed-off-by: Rosen Penev <rosenp@gmail.com>