### PR TITLE
remove const from member variables

### DIFF
--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -110,8 +110,8 @@ protected:
 
     std::vector<ContentHandler> orderedHandler;
 
-    const std::string virtualURL;
-    const std::string presentationURL;
+    std::string virtualURL;
+    std::string presentationURL;
     std::string entrySeparator;
     bool multiValue {};
     std::map<std::string, std::string> ctMappings;


### PR DESCRIPTION
These are moved in from the constructor. const prevents moves.

Signed-off-by: Rosen Penev <rosenp@gmail.com>