### PR TITLE
shared_ptr conversions

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -35,7 +35,7 @@
 #include "util/grb_net.h"
 #include "util/upnp_quirks.h"
 
-ActionRequest::ActionRequest(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clients, UpnpActionRequest* upnpRequest)
+ActionRequest::ActionRequest(std::shared_ptr<UpnpXMLBuilder> xmlBuilder, const std::shared_ptr<ClientManager>& clients, UpnpActionRequest* upnpRequest)
     : upnp_request(upnpRequest)
     , actionName(UpnpActionRequest_get_ActionName_cstr(upnpRequest))
     , UDN(UpnpActionRequest_get_DevUDN_cstr(upnpRequest))
@@ -43,7 +43,7 @@ ActionRequest::ActionRequest(const UpnpXMLBuilder& xmlBuilder, const ClientManag
 {
     auto ctrlPtIPAddr = std::make_shared<GrbNet>(UpnpActionRequest_get_CtrlPtIPAddr(upnpRequest));
     std::string userAgent = UpnpActionRequest_get_Os_cstr(upnpRequest);
-    quirks = std::make_unique<Quirks>(xmlBuilder, clients, ctrlPtIPAddr, userAgent);
+    quirks = std::make_unique<Quirks>(std::move(xmlBuilder), clients, ctrlPtIPAddr, userAgent);
 }
 
 std::string ActionRequest::getActionName() const

--- a/src/action_request.h
+++ b/src/action_request.h
@@ -84,7 +84,7 @@ protected:
 public:
     /// \brief The Constructor takes the values from the upnp_request and fills in internal variables.
     /// \param *upnp_request Pointer to the Upnp_Action_Request structure.
-    explicit ActionRequest(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clients, UpnpActionRequest* upnpRequest);
+    explicit ActionRequest(std::shared_ptr<UpnpXMLBuilder> xmlBuilder, const std::shared_ptr<ClientManager>& clients, UpnpActionRequest* upnpRequest);
     ~ActionRequest() = default;
 
     /// \brief Returns the name of the action.

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -262,5 +262,5 @@ std::unique_ptr<Quirks> FileRequestHandler::getQuirks(const UpnpFileInfo* info) 
     auto ctrlPtIPAddr = std::make_shared<GrbNet>(UpnpFileInfo_get_CtrlPtIPAddr(info));
     // HINT: most clients do not report exactly the same User-Agent for UPnP services and file request.
     std::string userAgent = UpnpFileInfo_get_Os_cstr(info);
-    return std::make_unique<Quirks>(*xmlBuilder, *context->getClients(), ctrlPtIPAddr, std::move(userAgent));
+    return std::make_unique<Quirks>(xmlBuilder, context->getClients(), ctrlPtIPAddr, std::move(userAgent));
 }

--- a/src/server.cc
+++ b/src/server.cc
@@ -385,7 +385,7 @@ int Server::handleUpnpRootDeviceEvent(Upnp_EventType eventType, const void* even
     case UPNP_CONTROL_ACTION_REQUEST:
         log_debug("UPNP_CONTROL_ACTION_REQUEST");
         try {
-            auto request = ActionRequest(*xmlbuilder, *clients, static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
+            auto request = ActionRequest(xmlbuilder, clients, static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
             routeActionRequest(request);
             request.update();
         } catch (const UpnpException& upnpE) {

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -37,11 +37,11 @@
 #include "util/upnp_clients.h"
 #include "util/upnp_headers.h"
 
-Quirks::Quirks(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clients, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent)
-    : xmlBuilder(xmlBuilder)
+Quirks::Quirks(std::shared_ptr<UpnpXMLBuilder> xmlBuilder, const std::shared_ptr<ClientManager>& clients, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent)
+    : xmlBuilder(std::move(xmlBuilder))
 {
     if (addr || !userAgent.empty())
-        pClientInfo = clients.getInfo(addr, userAgent);
+        pClientInfo = clients->getInfo(addr, userAgent);
 }
 
 int Quirks::checkFlags(int flags) const
@@ -62,7 +62,7 @@ void Quirks::addCaptionInfo(const std::shared_ptr<CdsItem>& item, Headers& heade
     if (item->getClass() != UPNP_CLASS_VIDEO_ITEM)
         return;
 
-    auto subAdded = xmlBuilder.renderSubtitleURL(item, pClientInfo->mimeMappings);
+    auto subAdded = xmlBuilder->renderSubtitleURL(item, pClientInfo->mimeMappings);
     if (subAdded) {
         log_debug("Call for Samsung CaptionInfo.sec: {}", subAdded.value());
         headers.addHeader("CaptionInfo.sec", subAdded.value());

--- a/src/util/upnp_quirks.h
+++ b/src/util/upnp_quirks.h
@@ -56,7 +56,7 @@ struct ClientInfo;
 
 class Quirks {
 public:
-    Quirks(const UpnpXMLBuilder& builder, const ClientManager& clients, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent);
+    Quirks(std::shared_ptr<UpnpXMLBuilder> builder, const std::shared_ptr<ClientManager>& clients, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent);
 
     // Look for subtitle file and returns its URL in CaptionInfo.sec response header.
     // To be more compliant with original Samsung server we should check for getCaptionInfo.sec: 1 request header.
@@ -162,7 +162,7 @@ public:
     std::map<std::string, std::string> getMimeMappings() const;
 
 private:
-    const UpnpXMLBuilder& xmlBuilder;
+    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
     const ClientInfo* pClientInfo;
 };
 


### PR DESCRIPTION
matches the type instead of dereferencing.

Signed-off-by: Rosen Penev <rosenp@gmail.com>