### PR TITLE
replace some memcpy by std::copy_n

### DIFF
--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -100,9 +100,9 @@ std::size_t IOHandlerBufferHelper::read(std::byte* buf, std::size_t length)
     if (read2 > maxRead2)
         read2 = maxRead2;
 
-    std::memcpy(buf, buffer + a, read1);
+    std::copy_n(buffer + a, read1, buf);
     if (read2)
-        std::memcpy(buf + read1, buffer, read2);
+        std::copy_n(buffer, read2, buf + read1);
 
     std::size_t didRead = read1 + read2;
 

--- a/src/iohandler/mem_io_handler.cc
+++ b/src/iohandler/mem_io_handler.cc
@@ -42,7 +42,7 @@ MemIOHandler::MemIOHandler(const std::string& str)
     : buffer(new char[str.length()])
     , length(str.length())
 {
-    std::memcpy(this->buffer, str.c_str(), length);
+    std::copy_n(str.c_str(), length, this->buffer);
 }
 
 MemIOHandler::~MemIOHandler()
@@ -68,7 +68,7 @@ std::size_t MemIOHandler::read(std::byte* buf, std::size_t length)
     if (length > std::size_t(rest))
         length = rest;
 
-    std::memcpy(buf, buffer + pos, length);
+    std::copy_n(reinterpret_cast<std::byte*>(buffer) + pos, length, buf);
     pos = pos + length;
     ret = int(length);
 

--- a/src/util/grb_net.cc
+++ b/src/util/grb_net.cc
@@ -75,7 +75,7 @@ GrbNet::GrbNet(const std::string& addr, int af)
 
 GrbNet::GrbNet(const struct sockaddr_storage* addr)
 {
-    std::memcpy(&sockAddr, addr, sizeof(sockAddr));
+    sockAddr = *addr;
 }
 
 void GrbNet::setPort(in_port_t port)

--- a/src/util/mt_inotify.cc
+++ b/src/util/mt_inotify.cc
@@ -143,7 +143,7 @@ struct inotify_event* Inotify::nextEvent()
 
             // how much of the event do we have?
             bytes = reinterpret_cast<char*>(event.data()) + bytes - reinterpret_cast<char*>(ret);
-            std::memcpy(event.data(), ret, bytes);
+            std::copy_n(ret, bytes, event.data());
             return nextEvent();
         }
         return ret;


### PR DESCRIPTION
The latter compiles to the former. It's more restrictive as the types
have to match.

Signed-off-by: Rosen Penev <rosenp@gmail.com>