### PR TITLE
Handle deleted objects in sqlite queue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,19 @@ add_library(libgerbera STATIC
         src/context.h
         src/contrib/md5.c
         src/contrib/md5.h
+        src/database/mysql/mysql_database.cc
+        src/database/mysql/mysql_database.h
+        src/database/sqlite3/sqlite_database.cc
+        src/database/sqlite3/sqlite_database.h
+        src/database/sqlite3/sl_task.cc
+        src/database/sqlite3/sl_task.h
+        src/database/sql_database.cc
+        src/database/sql_database.h
+        src/database/sql_format.h
+        src/database/database.cc
+        src/database/database.h
+        src/database/search_handler.cc
+        src/database/search_handler.h
         src/device_description_handler.cc
         src/device_description_handler.h
         src/exceptions.cc
@@ -179,17 +192,6 @@ add_library(libgerbera STATIC
         src/request_handler.h
         src/server.cc
         src/server.h
-        src/database/mysql/mysql_database.cc
-        src/database/mysql/mysql_database.h
-        src/database/sqlite3/sqlite_database.cc
-        src/database/sqlite3/sqlite_database.h
-        src/database/sql_database.cc
-        src/database/sql_database.h
-        src/database/sql_format.h
-        src/database/database.cc
-        src/database/database.h
-        src/database/search_handler.cc
-        src/database/search_handler.h
         src/subscription_request.cc
         src/subscription_request.h
         src/transcoding/transcode_dispatcher.cc

--- a/doc/config-import.rst
+++ b/doc/config-import.rst
@@ -436,7 +436,7 @@ the removed directory if it becomes available/gets created again.
 
         ::
 
-            mediatype="Music|AudioBook"
+            media-type="Music|AudioBook"
 
         * Optional
         * Default: **Any**

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -611,17 +611,17 @@ std::vector<int> ContentManager::_removeObject(const std::shared_ptr<AutoscanDir
         throw_std_runtime_error("tried to remove illegal object id");
 
     bool parentRemoved = false;
-    std::shared_ptr<CdsObject> obj;
+    std::shared_ptr<CdsObject> obj = database->loadObject(objectID);
+
     if (rescanResource) {
-        obj = database->loadObject(objectID);
         if (obj && obj->hasResource(ContentHandler::RESOURCE)) {
             auto parentPath = obj->getLocation().parent_path();
             parentRemoved = updateAttachedResources(adir, obj, parentPath, all);
         }
+    }
 
-        if (obj->isContainer()) {
-            cleanupTasks(obj->getLocation());
-        }
+    if (obj->isContainer()) {
+        cleanupTasks(obj->getLocation());
     }
     // Removing a file can lead to virtual directories to drop empty and be removed
     // So current container cache must be invalidated
@@ -636,11 +636,9 @@ std::vector<int> ContentManager::_removeObject(const std::shared_ptr<AutoscanDir
         }
     }
 
-    if (obj)
+    if (rescanResource && obj && parentRemoved)
         return { obj->getParentID() };
     return {};
-    // reload accounting
-    // loadAccounting();
 }
 
 int ContentManager::ensurePathExistence(const fs::path& path) const

--- a/src/database/mysql/mysql_database.h
+++ b/src/database/mysql/mysql_database.h
@@ -65,6 +65,8 @@ private:
     std::string quote(const std::string& value) const override;
 
     std::shared_ptr<SQLResult> select(const std::string& query) override;
+    void del(std::string_view tableName, const std::string& clause, const std::vector<int>& ids) override;
+    void exec(std::string_view tableName, const std::string& query, int objId) override;
     int exec(const std::string& query, bool getLastInsertId = false) override;
 
     void storeInternalSetting(const std::string& key, const std::string& value) override;

--- a/src/database/sql_database.h
+++ b/src/database/sql_database.h
@@ -121,6 +121,8 @@ public:
     virtual void rollback(std::string_view tName) { }
     virtual void commit(std::string_view tName) { }
 
+    virtual void del(std::string_view tableName, const std::string& clause, const std::vector<int>& ids) = 0;
+    virtual void exec(std::string_view tableName, const std::string& query, int objId) = 0;
     virtual int exec(const std::string& query, bool getLastInsertId = false) = 0;
     virtual std::shared_ptr<SQLResult> select(const std::string& query) = 0;
 

--- a/src/database/sqlite3/sl_task.cc
+++ b/src/database/sqlite3/sl_task.cc
@@ -1,0 +1,226 @@
+/*GRB*
+    Gerbera - https://gerbera.io/
+
+    sl_task.cc - this file is part of Gerbera.
+
+    Copyright (C) 2022 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file sl_task.cc
+
+#include "sl_task.h" // API
+
+#include "config/config_manager.h"
+#include "sqlite_database.h"
+
+bool SLTask::is_running() const
+{
+    return running;
+}
+
+void SLTask::sendSignal()
+{
+    if (is_running()) { // we check before we lock first, because there is no need to lock then
+        std::scoped_lock<decltype(mutex)> lock(mutex);
+        running = false;
+        cond.notify_one();
+    }
+}
+
+void SLTask::sendSignal(std::string error)
+{
+    this->error = std::move(error);
+    sendSignal();
+}
+
+void SLTask::waitForTask()
+{
+    if (is_running()) { // we check before we lock first, because there is no need to lock then
+        std::unique_lock<decltype(mutex)> lock(mutex);
+        if (is_running()) { // we check it a second time after locking to ensure we didn't miss the pthread_cond_signal
+            cond.wait(lock); // waiting for the task to complete
+        }
+    }
+
+    if (!getError().empty()) {
+        log_debug("{}", getError());
+        throw_std_runtime_error(getError());
+    }
+}
+
+/* SLInitTask */
+SLInitTask::SLInitTask(std::shared_ptr<Config> config, unsigned int hashie)
+    : config(std::move(config))
+    , hashie(hashie)
+{
+}
+
+void SLInitTask::run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError)
+{
+    log_debug("Running: init");
+    std::string dbFilePath = config->getOption(CFG_SERVER_STORAGE_SQLITE_DATABASE_FILE);
+
+    sqlite3_close(db);
+
+    int res = sqlite3_open(dbFilePath.c_str(), &db);
+    if (res != SQLITE_OK)
+        throw DatabaseException("", "SQLite: Failed to create new database");
+
+    auto sqlFilePath = fs::path(config->getOption(CFG_SERVER_STORAGE_SQLITE_INIT_SQL_FILE));
+    log_debug("Loading initialisation SQL from: {}", sqlFilePath.c_str());
+    auto sql = GrbFile(std::move(sqlFilePath)).readTextFile();
+    auto&& myHash = stringHash(sql);
+
+    if (myHash == hashie) {
+        sql += fmt::format("\n" SQLITE3_SET_VERSION ";", DBVERSION);
+
+        char* err = nullptr;
+        int ret = sqlite3_exec(
+            db,
+            sql.c_str(),
+            nullptr,
+            nullptr,
+            &err);
+        std::string error;
+        if (err) {
+            error = err;
+            sqlite3_free(err);
+        }
+        if (ret != SQLITE_OK) {
+            throw DatabaseException("", sl->handleError(sql, error, db, ret));
+        }
+        contamination = true;
+    } else {
+        log_warning("Wrong hash for create script {}: {} != {}", DBVERSION, myHash, hashie);
+    }
+}
+
+/* SLSelectTask */
+SLSelectTask::SLSelectTask(const std::string& query)
+    : query(query.c_str())
+{
+}
+
+void SLSelectTask::run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError)
+{
+    log_debug("Running: {}", query);
+    pres = std::make_shared<Sqlite3Result>();
+
+    char* err = nullptr;
+    int ret = sqlite3_get_table(
+        db,
+        query,
+        &pres->table,
+        &pres->nrow,
+        &pres->ncolumn,
+        &err);
+    std::string error;
+    if (err) {
+        log_debug(err);
+        error = err;
+        sqlite3_free(err);
+    }
+    if (ret != SQLITE_OK) {
+        throw DatabaseException("", sl->handleError(query, error, db, ret));
+    }
+
+    pres->row = pres->table;
+    pres->cur_row = 0;
+}
+
+/* SLExecTask */
+
+SLExecTask::SLExecTask(const std::string& query, bool getLastInsertId)
+    : query(query.c_str())
+    , getLastInsertIdFlag(getLastInsertId)
+{
+}
+
+SLExecTask::SLExecTask(const std::string& query, const std::string& eKey)
+    : query(query.c_str())
+    , getLastInsertIdFlag(false)
+    , eKey(eKey)
+{
+}
+
+void SLExecTask::run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError)
+{
+    log_debug("Running: {}", query);
+    char* err;
+    int ret = sqlite3_exec(
+        db,
+        query,
+        nullptr,
+        nullptr,
+        &err);
+    std::string error;
+    if (err) {
+        error = err;
+        sqlite3_free(err);
+    }
+    if (ret != SQLITE_OK) {
+        if (throwOnError)
+            throw DatabaseException("", sl->handleError(query, error, db, ret));
+        log_debug("Error in sqlite3_exec: {}", sl->handleError(query, error, db, ret));
+    }
+    if (getLastInsertIdFlag)
+        lastInsertId = sqlite3_last_insert_rowid(db);
+    contamination = true;
+}
+
+/* SLBackupTask */
+SLBackupTask::SLBackupTask(std::shared_ptr<Config> config, bool restore)
+    : config(std::move(config))
+    , restore(restore)
+    , dbFile(this->config->getOption(CFG_SERVER_STORAGE_SQLITE_DATABASE_FILE))
+    , dbBackupFile(fmt::format(SQLITE3_BACKUP_FORMAT, this->config->getOption(CFG_SERVER_STORAGE_SQLITE_DATABASE_FILE)))
+{
+}
+
+void SLBackupTask::run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError)
+{
+    log_debug("Running: backup");
+
+    if (!restore) {
+        try {
+            fs::copy(
+                dbFile.getPath(),
+                dbBackupFile.getPath(),
+                fs::copy_options::overwrite_existing);
+            log_debug("sqlite3 backup successful");
+            dbBackupFile.setPermissions();
+            decontamination = true;
+        } catch (const std::runtime_error& e) {
+            log_error("error while making sqlite3 backup: {}", e.what());
+        }
+    } else {
+        log_info("trying to restore sqlite3 database from backup...");
+        sqlite3_close(db);
+        try {
+            fs::copy(
+                dbBackupFile.getPath(),
+                dbFile.getPath(),
+                fs::copy_options::overwrite_existing);
+            dbFile.setPermissions();
+        } catch (const std::runtime_error& e) {
+            throw DatabaseException(fmt::format("Error while restoring sqlite3 backup: {}", e.what()), fmt::format("Error while restoring sqlite3 backup: {}", e.what()));
+        }
+        int res = sqlite3_open(dbFile.getPath().c_str(), &db);
+        if (res != SQLITE_OK) {
+            throw DatabaseException("", "error while restoring sqlite3 backup: could not reopen sqlite3 database after restore");
+        }
+        log_info("sqlite3 database successfully restored from backup.");
+    }
+}

--- a/src/database/sqlite3/sl_task.h
+++ b/src/database/sqlite3/sl_task.h
@@ -1,0 +1,158 @@
+/*GRB*
+    Gerbera - https://gerbera.io/
+
+    sl_task.h - this file is part of Gerbera.
+
+    Copyright (C) 2022 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file sl_task.h
+///\brief Definitions of the SLTask classes.
+
+#ifndef __SQLITE3_TASK_H__
+#define __SQLITE3_TASK_H__
+
+#include <condition_variable>
+#include <mutex>
+
+#include <sqlite3.h>
+
+#include "util/grb_fs.h"
+
+class Config;
+class Sqlite3Database;
+class Sqlite3Result;
+
+#define SQLITE3_BACKUP_FORMAT "{}.backup"
+#define SQLITE3_SET_VERSION "INSERT INTO \"mt_internal_setting\" VALUES('db_version', '{}')"
+
+/// \brief A virtual class that represents a task to be done by the sqlite3 thread.
+class SLTask {
+public:
+    virtual ~SLTask() = default;
+
+    /// \brief run the sqlite3 task
+    /// \param sl The instance of Sqlite3Database to do the queries with.
+    virtual void run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError = true) = 0;
+
+    /// \brief returns true if the task is not completed
+    /// \return true if the task is not completed yet, false if the task is finished and the results are ready.
+    bool is_running() const;
+
+    /// \brief notify the creator of the task using the supplied pthread_mutex and pthread_cond, that the task is finished
+    void sendSignal();
+
+    void sendSignal(std::string error);
+
+    void waitForTask();
+
+    bool didContamination() const { return contamination; }
+    bool didDecontamination() const { return decontamination; }
+
+    std::string getError() const { return error; }
+
+    virtual std::string_view taskType() const = 0;
+
+    virtual bool checkKey(const std::string& key) const { return true; }
+
+protected:
+    /// \brief true as long as the task is not finished
+    ///
+    /// The value is set by the constructor to true and then to false be sendSignal()
+    bool running { true };
+
+    /// \brief true if this task has changed the db (in comparison to the backup)
+    bool contamination {};
+
+    /// \brief true if this task has backuped the db
+    bool decontamination {};
+
+    std::condition_variable cond;
+    mutable std::mutex mutex;
+
+    std::string error;
+};
+
+/// \brief A task for the sqlite3 thread to inititally create the database.
+class SLInitTask : public SLTask {
+public:
+    /// \brief Constructor for the sqlite3 init task
+    explicit SLInitTask(std::shared_ptr<Config> config, unsigned int hashie);
+    void run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError = true) override;
+
+    std::string_view taskType() const override { return "InitTask"; }
+
+protected:
+    std::shared_ptr<Config> config;
+    unsigned int hashie;
+};
+
+/// \brief A task for the sqlite3 thread to do a SQL select.
+class SLSelectTask : public SLTask {
+public:
+    /// \brief Constructor for the sqlite3 select task
+    /// \param query The SQL query string
+    explicit SLSelectTask(const std::string& query);
+    void run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError = true) override;
+    [[nodiscard]] std::shared_ptr<Sqlite3Result> getResult() const { return pres; }
+
+    std::string_view taskType() const override { return "SelectTask"; }
+
+protected:
+    /// \brief The SQL query string
+    const char* query;
+    /// \brief The Sqlite3Result
+    std::shared_ptr<Sqlite3Result> pres;
+};
+
+/// \brief A task for the sqlite3 thread to do a SQL exec.
+class SLExecTask : public SLTask {
+public:
+    /// \brief Constructor for the sqlite3 exec task
+    /// \param query The SQL query string
+    SLExecTask(const std::string& query, bool getLastInsertId);
+    SLExecTask(const std::string& query, const std::string& eKey);
+    void run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError = true) override;
+    int getLastInsertId() const { return lastInsertId; }
+    bool checkKey(const std::string& key) const override { return key != eKey; }
+
+    std::string_view taskType() const override { return "ExecTask"; }
+
+protected:
+    /// \brief The SQL query string
+    const char* query;
+
+    int lastInsertId {};
+    bool getLastInsertIdFlag;
+    std::string eKey;
+};
+
+/// \brief A task for the sqlite3 thread to do a SQL exec.
+class SLBackupTask : public SLTask {
+public:
+    /// \brief Constructor for the sqlite3 backup task
+    SLBackupTask(std::shared_ptr<Config> config, bool restore);
+    void run(sqlite3*& db, Sqlite3Database* sl, bool throwOnError = true) override;
+
+    std::string_view taskType() const override { return "BackupTask"; }
+
+protected:
+    std::shared_ptr<Config> config;
+    bool restore;
+    GrbFile dbFile;
+    GrbFile dbBackupFile;
+};
+
+#endif // __SQLITE3_TASK_H__

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -28,7 +28,7 @@
 */
 
 /// \file sqlite3_database.h
-///\brief Definitions of the Sqlite3Database, Sqlite3Result, Sqlite3Row and SLTask classes.
+///\brief Definitions of the Sqlite3Database, Sqlite3Result and Sqlite3Row classes.
 
 #ifndef __SQLITE3_STORAGE_H__
 #define __SQLITE3_STORAGE_H__
@@ -37,130 +37,20 @@
 #include <sqlite3.h>
 
 #include "database/sql_database.h"
-#include "util/grb_fs.h"
 #include "util/thread_runner.h"
 #include "util/timer.h"
 
 class Sqlite3Database;
 class Sqlite3Result;
-
-/// \brief A virtual class that represents a task to be done by the sqlite3 thread.
-class SLTask {
-public:
-    virtual ~SLTask() = default;
-
-    /// \brief run the sqlite3 task
-    /// \param sl The instance of Sqlite3Database to do the queries with.
-    virtual void run(sqlite3*& db, Sqlite3Database* sl) = 0;
-
-    /// \brief returns true if the task is not completed
-    /// \return true if the task is not completed yet, false if the task is finished and the results are ready.
-    bool is_running() const;
-
-    /// \brief notify the creator of the task using the supplied pthread_mutex and pthread_cond, that the task is finished
-    void sendSignal();
-
-    void sendSignal(std::string error);
-
-    void waitForTask();
-
-    bool didContamination() const { return contamination; }
-    bool didDecontamination() const { return decontamination; }
-
-    std::string getError() const { return error; }
-
-    virtual std::string_view taskType() const = 0;
-
-protected:
-    /// \brief true as long as the task is not finished
-    ///
-    /// The value is set by the constructor to true and then to false be sendSignal()
-    bool running { true };
-
-    /// \brief true if this task has changed the db (in comparison to the backup)
-    bool contamination {};
-
-    /// \brief true if this task has backuped the db
-    bool decontamination {};
-
-    std::condition_variable cond;
-    mutable std::mutex mutex;
-
-    std::string error;
-};
-
-/// \brief A task for the sqlite3 thread to inititally create the database.
-class SLInitTask : public SLTask {
-public:
-    /// \brief Constructor for the sqlite3 init task
-    explicit SLInitTask(std::shared_ptr<Config> config, unsigned int hashie);
-    void run(sqlite3*& db, Sqlite3Database* sl) override;
-
-    std::string_view taskType() const override { return "InitTask"; }
-
-protected:
-    std::shared_ptr<Config> config;
-    unsigned int hashie;
-};
-
-/// \brief A task for the sqlite3 thread to do a SQL select.
-class SLSelectTask : public SLTask {
-public:
-    /// \brief Constructor for the sqlite3 select task
-    /// \param query The SQL query string
-    explicit SLSelectTask(const std::string& query);
-    void run(sqlite3*& db, Sqlite3Database* sl) override;
-    [[nodiscard]] std::shared_ptr<Sqlite3Result> getResult() const { return pres; }
-
-    std::string_view taskType() const override { return "SelectTask"; }
-
-protected:
-    /// \brief The SQL query string
-    const char* query;
-    /// \brief The Sqlite3Result
-    std::shared_ptr<Sqlite3Result> pres;
-};
-
-/// \brief A task for the sqlite3 thread to do a SQL exec.
-class SLExecTask : public SLTask {
-public:
-    /// \brief Constructor for the sqlite3 exec task
-    /// \param query The SQL query string
-    SLExecTask(const std::string& query, bool getLastInsertId);
-    void run(sqlite3*& db, Sqlite3Database* sl) override;
-    int getLastInsertId() const { return lastInsertId; }
-
-    std::string_view taskType() const override { return "ExecTask"; }
-
-protected:
-    /// \brief The SQL query string
-    const char* query;
-
-    int lastInsertId {};
-    bool getLastInsertIdFlag;
-};
-
-/// \brief A task for the sqlite3 thread to do a SQL exec.
-class SLBackupTask : public SLTask {
-public:
-    /// \brief Constructor for the sqlite3 backup task
-    SLBackupTask(std::shared_ptr<Config> config, bool restore);
-    void run(sqlite3*& db, Sqlite3Database* sl) override;
-
-    std::string_view taskType() const override { return "BackupTask"; }
-
-protected:
-    std::shared_ptr<Config> config;
-    bool restore;
-    GrbFile dbFile;
-    GrbFile dbBackupFile;
-};
+class SLTask;
 
 /// \brief The Database class for using SQLite3
 class Sqlite3Database : public Timer::Subscriber, public SQLDatabase, public std::enable_shared_from_this<SQLDatabase> {
 public:
-    void timerNotify(const std::shared_ptr<Timer::Parameter>& param) override;
     Sqlite3Database(const std::shared_ptr<Config>& config, const std::shared_ptr<Mime>& mime, std::shared_ptr<Timer> timer);
+
+    std::string handleError(const std::string& query, const std::string& error, sqlite3* db, int errorCode);
+    void timerNotify(const std::shared_ptr<Timer::Parameter>& param) override;
 
 protected:
     void _exec(const std::string& query) override;
@@ -174,13 +64,13 @@ private:
     std::string quote(const std::string& value) const override;
 
     std::shared_ptr<SQLResult> select(const std::string& query) override;
+    void del(std::string_view tableName, const std::string& clause, const std::vector<int>& ids) override;
+    void exec(std::string_view tableName, const std::string& query, int objId) override;
     int exec(const std::string& query, bool getLastInsertId = false) override;
 
     void storeInternalSetting(const std::string& key, const std::string& value) override;
 
     std::string startupError;
-
-    std::string getError(const std::string& query, const std::string& error, sqlite3* db, int errorCode);
 
     std::unique_ptr<StdThreadRunner> threadRunner;
     void threadProc();
@@ -195,6 +85,8 @@ private:
     /// \brief the tasks to be done by the sqlite3 thread
     std::queue<std::shared_ptr<SLTask>> taskQueue;
     bool taskQueueOpen {};
+    std::vector<std::string> deletedEntries {};
+    std::chrono::seconds lastDelete;
 
     void threadCleanup() override { }
     bool threadCleanupRequired() const override { return false; }
@@ -203,10 +95,6 @@ private:
     bool dbInitDone {};
     bool hasBackupTimer {};
     int sqliteStatus {};
-
-    friend class SLSelectTask;
-    friend class SLExecTask;
-    friend class SLInitTask;
 };
 
 /// \brief The Database class for using SQLite3 with transactions
@@ -242,7 +130,6 @@ private:
 
     friend class SLSelectTask;
     friend class Sqlite3Row;
-    friend class Sqlite3Database;
 };
 
 /// \brief Represents a row of a result of a sqlite3 select

--- a/test/database/test_sql_generators.cc
+++ b/test/database/test_sql_generators.cc
@@ -51,6 +51,19 @@ public:
         return fmt::format("\"{}\"", str);
     }
 
+    void del(std::string_view tableName, const std::string& clause, const std::vector<int>& values) override
+    {
+        auto query = clause.empty() ?
+            fmt::format("DELETE FROM {}", identifier(tableName)) :
+            fmt::format("DELETE FROM {} WHERE {}", identifier(tableName), clause);
+        lastStatement = query;
+    }
+
+    void exec(std::string_view tableName, const std::string& query, int objId) override
+    {
+        lastStatement = query;
+    }
+
     int exec(const std::string& query, bool) override
     {
         lastStatement = query;


### PR DESCRIPTION
This handles the problem of deleted entries being referenced
 Obviously the task queue already contains the commands so we only can avoid exceptions.

Fixes #2674 
fixes #2680 
Fixes #2605 
Fixes #2699 