### PR TITLE
Fix build on systems that have const in second argument to iconv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,13 @@ target_link_libraries(libgerbera PUBLIC std::filesystem)
 
 find_package(Iconv REQUIRED)
 target_link_libraries(libgerbera PUBLIC Iconv::Iconv)
+include(CheckPrototypeDefinition)
+set(CMAKE_REQUIRED_LIBRARIES Iconv::Iconv)
+check_prototype_definition(iconv "size_t iconv(iconv_t cd, const char **src, size_t *srcl, char **dst, size_t *dstl)" 0 "iconv.h" ICONV_CONST)
+if(ICONV_CONST)
+    target_compile_definitions(libgerbera PRIVATE ICONV_CONST)
+endif()
+unset(CMAKE_REQUIRED_LIBRARIES)
 
 find_package(UUID REQUIRED)
 target_link_libraries(libgerbera PUBLIC UUID::UUID)

--- a/src/util/string_converter.cc
+++ b/src/util/string_converter.cc
@@ -122,8 +122,8 @@ std::string StringConverter::_convert(const std::string& str, bool validate,
     // log_debug(("iconv: BEFORE: input bytes left: {}  output bytes left: {}",
     //        input_bytes, output_bytes));
 #if defined(ICONV_CONST) || defined(SOLARIS)
-    int ret = iconv(cd, inputPtr, &input_bytes,
-        output_ptr, &output_bytes);
+    int ret = iconv(cd, inputPtr, &inputBytes,
+        outputPtr, &outputBytes);
 #else
     int ret = iconv(cd, const_cast<char**>(inputPtr), &inputBytes,
         outputPtr, &outputBytes);


### PR DESCRIPTION
Make sure ICONV_CONST is defined if the system has const in its iconv prototype definition.

Use the right variable names when calling iconv with const.