### PR TITLE
XML: Allow escaping ticks for some clients

### DIFF
--- a/doc/supported-devices.rst
+++ b/doc/supported-devices.rst
@@ -24,6 +24,7 @@ The automatic detection supports the following devices and software:
 - SamsungBDJ5500 (Samsung Blu-ray Player J5500), setting device flags to ``SAMSUNG|SAMSUNG_FEATURES``
 - EC-IRadio (e.g. Dual CR 510), setting device flags to ``IRADIO``
 - PanasonicTV, setting device flags to ``PANASONIC``
+- BoseSoundtouch, setting device flags to ``STRICTXML``
 
 Device Flags
 ~~~~~~~~~~~~
@@ -38,6 +39,7 @@ The device flags have the following meaning
 -  ``IRADIO``: 0x08, don't send ``<?xml ...?>`` declaration in response
 -  ``PV_SUBTITLES``: 0x40, add attributes ``pv:subtitleFileType`` and ``pv:subtitleFileUri`` to video files if subtitles exist
 -  ``PANASONIC``: 0x80, avoid adding part of the filename in item uri. Filename in item uri is used by other players, e.g. VLC to detect the language of a subtitle file.
+-  ``STRICTXML``: 0x100, encode most of special chars also, like ``'`` as ``&amp;apos;``
 
 Manual Overrides
 ~~~~~~~~~~~~~~~~

--- a/src/config/client_config.cc
+++ b/src/config/client_config.cc
@@ -139,6 +139,7 @@ static constexpr auto clientTypes = std::array {
     std::pair("SamsungBDJ5500", ClientType::SamsungBDJ5500),
     std::pair("EC-IRadio", ClientType::IRadio),
     std::pair("PanasonicTV", ClientType::PanasonicTV),
+    std::pair("BoseSoundtouch", ClientType::BoseSoundtouch),
     std::pair("StandardUPnP", ClientType::StandardUPnP),
 };
 
@@ -174,6 +175,7 @@ static constexpr auto quirkFlags = std::array {
     std::pair("IRADIO", QUIRK_FLAG_IRADIO),
     std::pair("PV_SUBTITLES", QUIRK_FLAG_PV_SUBTITLES),
     std::pair("PANASONIC", QUIRK_FLAG_PANASONIC),
+    std::pair("STRICTXML", QUIRK_FLAG_STRICTXML),
 };
 
 int ClientConfig::remapFlag(const std::string& flag)

--- a/src/upnp_cds.cc
+++ b/src/upnp_cds.cc
@@ -134,16 +134,17 @@ void ContentDirectoryService::doBrowse(ActionRequest& request)
     didlLiteRoot.append_attribute(UPNP_XML_UPNP_NAMESPACE_ATTR) = UPNP_XML_UPNP_NAMESPACE;
     didlLiteRoot.append_attribute(UPNP_XML_SEC_NAMESPACE_ATTR) = UPNP_XML_SEC_NAMESPACE;
 
+    auto stringLimitClient = stringLimit;
     if (quirks->getStringLimit() > -1) {
-        stringLimit = quirks->getStringLimit();
+        stringLimitClient = quirks->getStringLimit();
     }
 
     for (auto&& obj : arr) {
         markPlayedItem(obj, obj->getTitle());
-        xmlBuilder->renderObject(obj, stringLimit, didlLiteRoot, quirks);
+        xmlBuilder->renderObject(obj, stringLimitClient, didlLiteRoot, quirks);
     }
 
-    std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", 0);
+    std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", quirks && quirks->needsStrictXml() ? pugi::format_no_escapes : 0);
     log_debug("didl {}", didlLiteXml);
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
@@ -210,13 +211,14 @@ void ContentDirectoryService::doSearch(ActionRequest& request)
         throw UpnpException(UPNP_E_NO_SUCH_ID, "no such object");
     }
 
+    auto stringLimitClient = stringLimit;
     if (quirks->getStringLimit() > -1) {
-        stringLimit = quirks->getStringLimit();
+        stringLimitClient = quirks->getStringLimit();
     }
 
     for (auto&& cdsObject : results) {
         if (!cdsObject->isItem()) {
-            xmlBuilder->renderObject(cdsObject, stringLimit, didlLiteRoot);
+            xmlBuilder->renderObject(cdsObject, stringLimitClient, didlLiteRoot);
             continue;
         }
 
@@ -234,10 +236,10 @@ void ContentDirectoryService::doSearch(ActionRequest& request)
         }
 
         markPlayedItem(cdsObject, title);
-        xmlBuilder->renderObject(cdsObject, stringLimit, didlLiteRoot);
+        xmlBuilder->renderObject(cdsObject, stringLimitClient, didlLiteRoot);
     }
 
-    std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", 0);
+    std::string didlLiteXml = UpnpXMLBuilder::printXml(didlLite, "", quirks && quirks->needsStrictXml() ? pugi::format_no_escapes : 0);
     log_debug("didl {}", didlLiteXml);
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);

--- a/src/upnp_xml.h
+++ b/src/upnp_xml.h
@@ -130,7 +130,13 @@ protected:
 
     std::string renderExtension(const std::string& contentType, const fs::path& location, const std::string& language) const;
     void addField(pugi::xml_node& entry, const std::string& key, const std::string& val) const;
-    void addPropertyList(pugi::xml_node& result, const std::vector<std::pair<std::string, std::string>>& meta, const std::map<std::string, std::string>& auxData, config_option_t itemProps, config_option_t nsProp) const;
+    void addPropertyList(bool strictXml,
+        std::size_t stringLimit,
+        pugi::xml_node& result,
+        const std::vector<std::pair<std::string, std::string>>& meta,
+        const std::map<std::string, std::string>& auxData,
+        config_option_t itemProps,
+        config_option_t nsProp) const;
     std::string findDlnaProfile(const CdsResource& res, const std::string& contentType) const;
     std::string dlnaProfileString(const CdsResource& res, const std::string& contentType, bool formatted = true) const;
 

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -171,6 +171,16 @@ void ClientManager::refresh(const std::shared_ptr<Config>& config)
             ClientMatchType::UserAgent,
             "Panasonic MIL DLNA CP",
         },
+
+        // User-Agent(actionReq): Allegro-Software-WebClient/5.40b1 DLNADOC/1.50
+        {
+            "Bose Soundtouch",
+            DEFAULT_CLIENT_GROUP,
+            ClientType::BoseSoundtouch,
+            QUIRK_FLAG_STRICTXML,
+            ClientMatchType::UserAgent,
+            "Allegro-Software-WebClient",
+        },
     };
 
     auto clientConfigList = config->getClientConfigListOption(CFG_CLIENTS_LIST);
@@ -220,7 +230,7 @@ const ClientInfo* ClientManager::getInfo(const std::shared_ptr<GrbNet>& addr, co
         updateCache(addr, userAgent, info);
     }
 
-    log_debug("client info: {} '{}' -> '{}' as {}", addr->getNameInfo(), userAgent, info->name, ClientConfig::mapClientType(info->type));
+    log_debug("client info: {} '{}' -> '{}' as {} with {}", addr->getNameInfo(), userAgent, info->name, ClientConfig::mapClientType(info->type), ClientConfig::mapFlags(info->flags));
     return info;
 }
 

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -54,6 +54,7 @@ enum class ClientType {
     SamsungBDJ5500,
     IRadio,
     PanasonicTV,
+    BoseSoundtouch,
     StandardUPnP
 };
 

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -261,6 +261,11 @@ int Quirks::getStringLimit() const
     return pClientInfo ? pClientInfo->stringLimit : -1;
 }
 
+bool Quirks::needsStrictXml() const
+{
+    return pClientInfo && (pClientInfo->flags & QUIRK_FLAG_STRICTXML) == QUIRK_FLAG_STRICTXML;
+}
+
 bool Quirks::getMultiValue() const
 {
     return pClientInfo ? pClientInfo->multiValue : true;

--- a/src/util/upnp_quirks.h
+++ b/src/util/upnp_quirks.h
@@ -42,6 +42,7 @@ using QuirkFlags = std::uint32_t;
 #define QUIRK_FLAG_SAMSUNG_HIDE_DYNAMIC 0x00000020
 #define QUIRK_FLAG_PV_SUBTITLES 0x00000040
 #define QUIRK_FLAG_PANASONIC 0x00000080
+#define QUIRK_FLAG_STRICTXML 0x00000100
 
 // forward declaration
 class ActionRequest;
@@ -139,6 +140,13 @@ public:
      *
      */
     int getStringLimit() const;
+
+    /** \brief UPnP client needs everything escaped, esp. '
+     *
+     * \return bool
+     *
+     */
+    bool needsStrictXml() const;
 
     /** \brief Get multi value upnp properties
      *


### PR DESCRIPTION
closes  #2616

But causes clients like FooBar to fail on browse because of double espace `&amp;apos;`