### PR TITLE
Client: remove references to shared_ptrs

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -39,15 +39,15 @@
 #include "util/grb_net.h"
 #include "util/upnp_quirks.h"
 
-ActionRequest::ActionRequest(std::shared_ptr<UpnpXMLBuilder>& xmlBuilder, std::shared_ptr<ClientManager>& clients, UpnpActionRequest* upnpRequest)
+ActionRequest::ActionRequest(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clients, UpnpActionRequest* upnpRequest)
     : upnp_request(upnpRequest)
     , actionName(UpnpActionRequest_get_ActionName_cstr(upnpRequest))
     , UDN(UpnpActionRequest_get_DevUDN_cstr(upnpRequest))
     , serviceID(UpnpActionRequest_get_ServiceID_cstr(upnpRequest))
 {
-    auto ctrlPtIPAddr = std::make_shared<GrbNet>(UpnpActionRequest_get_CtrlPtIPAddr(upnpRequest));
+    auto grbNet = GrbNet(UpnpActionRequest_get_CtrlPtIPAddr(upnpRequest));
     std::string userAgent = UpnpActionRequest_get_Os_cstr(upnpRequest);
-    quirks = std::make_unique<Quirks>(xmlBuilder, clients, ctrlPtIPAddr, userAgent);
+    quirks = std::make_unique<Quirks>(xmlBuilder, clients, grbNet, userAgent);
 }
 
 std::string ActionRequest::getActionName() const

--- a/src/action_request.h
+++ b/src/action_request.h
@@ -86,7 +86,7 @@ protected:
 public:
     /// \brief The Constructor takes the values from the upnp_request and fills in internal variables.
     /// \param *upnp_request Pointer to the Upnp_Action_Request structure.
-    explicit ActionRequest(std::shared_ptr<UpnpXMLBuilder>& xmlBuilder, std::shared_ptr<ClientManager>& clients, UpnpActionRequest* upnpRequest);
+    explicit ActionRequest(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clients, UpnpActionRequest* upnpRequest);
     ~ActionRequest() = default;
 
     /// \brief Returns the name of the action.

--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -2183,8 +2183,8 @@ std::vector<ClientCacheEntry> SQLDatabase::getClients()
     result.reserve(res->getNumRows());
     std::unique_ptr<SQLRow> row;
     while ((row = res->nextRow())) {
-        auto net = std::make_shared<GrbNet>(row->col(0), row->col_int(2, AF_INET));
-        net->setPort(row->col_int(1, 0));
+        auto net = GrbNet(row->col(0), row->col_int(2, AF_INET));
+        net.setPort(row->col_int(1, 0));
         result.emplace_back(net,
             row->col(3),
             std::chrono::seconds(row->col_int(4, 0)),
@@ -2209,9 +2209,9 @@ void SQLDatabase::saveClients(const std::vector<ClientCacheEntry>& cache)
     };
     for (auto& client : cache) {
         auto values = std::vector {
-            quote(client.addr->getNameInfo(false)),
-            quote(client.addr->getPort()),
-            quote(client.addr->getAdressFamily()),
+            quote(client.addr.getNameInfo(false)),
+            quote(client.addr.getPort()),
+            quote(client.addr.getAdressFamily()),
             quote(client.userAgent),
             quote(client.last.count()),
             quote(client.age.count()),

--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -267,8 +267,8 @@ std::size_t FileRequestHandler::parseResourceInfo(std::map<std::string, std::str
 
 std::unique_ptr<Quirks> FileRequestHandler::getQuirks(const UpnpFileInfo* info) const
 {
-    auto ctrlPtIPAddr = std::make_shared<GrbNet>(UpnpFileInfo_get_CtrlPtIPAddr(info));
+    auto ctrlPtIPAddr = GrbNet(UpnpFileInfo_get_CtrlPtIPAddr(info));
     // HINT: most clients do not report exactly the same User-Agent for UPnP services and file request.
     std::string userAgent = UpnpFileInfo_get_Os_cstr(info);
-    return std::make_unique<Quirks>(xmlBuilder, context->getClients(), ctrlPtIPAddr, std::move(userAgent));
+    return std::make_unique<Quirks>(*xmlBuilder, *(context->getClients()), ctrlPtIPAddr, std::move(userAgent));
 }

--- a/src/server.cc
+++ b/src/server.cc
@@ -413,7 +413,7 @@ int Server::handleUpnpRootDeviceEvent(Upnp_EventType eventType, const void* even
     case UPNP_CONTROL_ACTION_REQUEST:
         log_debug("UPNP_CONTROL_ACTION_REQUEST");
         try {
-            auto request = ActionRequest(xmlBuilder, clientManager, static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
+            auto request = ActionRequest(*xmlBuilder, *clientManager, static_cast<UpnpActionRequest*>(const_cast<void*>(event)));
             routeActionRequest(request);
             request.update();
         } catch (const UpnpException& upnpE) {
@@ -459,7 +459,7 @@ int Server::handleUpnpClientEvent(Upnp_EventType eventType, const void* event)
     case UPNP_DISCOVERY_SEARCH_RESULT: {
         auto dEvent = static_cast<const UpnpDiscovery*>(event);
         const char* userAgent = UpnpDiscovery_get_Os_cstr(dEvent);
-        auto destAddr = std::make_shared<GrbNet>(UpnpDiscovery_get_DestAddr(dEvent));
+        auto destAddr = GrbNet(UpnpDiscovery_get_DestAddr(dEvent));
         const char* location = UpnpDiscovery_get_Location_cstr(dEvent);
 
         clientManager->addClientByDiscovery(destAddr, userAgent, location);

--- a/src/util/grb_net.cc
+++ b/src/util/grb_net.cc
@@ -134,12 +134,12 @@ bool GrbNet::equals(const std::string& match) const
     return false;
 }
 
-bool GrbNet::equals(const std::shared_ptr<GrbNet>& other) const
+bool GrbNet::equals(const GrbNet& other) const
 {
-    return sockAddrCmpAddr(reinterpret_cast<const struct sockaddr*>(&other->sockAddr), reinterpret_cast<const struct sockaddr*>(&sockAddr)) == 0;
+    return sockAddrCmpAddr(reinterpret_cast<const struct sockaddr*>(&other.sockAddr), reinterpret_cast<const struct sockaddr*>(&sockAddr)) == 0;
 }
 
-std::string GrbNet::getHostName()
+std::string GrbNet::getHostName() const
 {
     if (!hostName.empty())
         return hostName;

--- a/src/util/grb_net.h
+++ b/src/util/grb_net.h
@@ -31,7 +31,7 @@ Gerbera - https://gerbera.io/
 class GrbNet {
 private:
     struct sockaddr_storage sockAddr = {};
-    std::string hostName;
+    mutable std::string hostName;
 
 public:
     explicit GrbNet(const std::string& addr, int af = AF_INET);
@@ -41,10 +41,10 @@ public:
     in_port_t getPort() const;
     int getAdressFamily() const;
     struct sockaddr_storage readAddr() { return sockAddr; };
-    std::string getHostName();
+    std::string getHostName() const;
     void setHostName(const std::string& hn) { hostName = hn; };
     bool equals(const std::string& match) const;
-    bool equals(const std::shared_ptr<GrbNet>& other) const;
+    bool equals(const GrbNet& other) const;
     std::string getNameInfo(bool withPort = true) const;
 
     /// \brief Finds the Interface with the specified IP address.

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -190,7 +190,7 @@ void ClientManager::refresh(const std::shared_ptr<Config>& config)
     }
 }
 
-void ClientManager::addClientByDiscovery(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const std::string& descLocation)
+void ClientManager::addClientByDiscovery(const GrbNet& addr, const std::string& userAgent, const std::string& descLocation)
 {
 #if 0 // only needed if UserAgent is not good enough
     const ClientInfo* info = nullptr;
@@ -203,7 +203,7 @@ void ClientManager::addClientByDiscovery(const std::shared_ptr<GrbNet>& addr, co
 #endif
 }
 
-const ClientInfo* ClientManager::getInfo(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent) const
+const ClientInfo* ClientManager::getInfo(const GrbNet& addr, const std::string& userAgent) const
 {
     // 1. by IP address
     auto info = getInfoByAddr(addr);
@@ -230,20 +230,20 @@ const ClientInfo* ClientManager::getInfo(const std::shared_ptr<GrbNet>& addr, co
         updateCache(addr, userAgent, info);
     }
 
-    log_debug("client info: {} '{}' -> '{}' as {} with {}", addr->getNameInfo(), userAgent, info->name, ClientConfig::mapClientType(info->type), ClientConfig::mapFlags(info->flags));
+    log_debug("client info: {} '{}' -> '{}' as {} with {}", addr.getNameInfo(), userAgent, info->name, ClientConfig::mapClientType(info->type), ClientConfig::mapFlags(info->flags));
     return info;
 }
 
-const ClientInfo* ClientManager::getInfoByAddr(const std::shared_ptr<GrbNet>& addr) const
+const ClientInfo* ClientManager::getInfoByAddr(const GrbNet& addr) const
 {
     auto it = std::find_if(clientInfo.begin(), clientInfo.end(), [=](auto&& c) {
         if (c.matchType != ClientMatchType::IP)
             return false;
-        return addr->equals(c.match);
+        return addr.equals(c.match);
     });
 
     if (it != clientInfo.end()) {
-        log_debug("found client by IP (ip='{}')", addr->getHostName());
+        log_debug("found client by IP (ip='{}')", addr.getHostName());
         return &(*it);
     }
 
@@ -263,22 +263,22 @@ const ClientInfo* ClientManager::getInfoByType(const std::string& match, ClientM
     return nullptr;
 }
 
-const ClientInfo* ClientManager::getInfoByCache(const std::shared_ptr<GrbNet>& addr) const
+const ClientInfo* ClientManager::getInfoByCache(const GrbNet& addr) const
 {
     AutoLock lock(mutex);
 
     auto it = std::find_if(cache.begin(), cache.end(), [=](auto&& entry) //
-        { return entry.addr->equals(addr); });
+        { return entry.addr.equals(addr); });
 
     if (it != cache.end()) {
-        log_debug("found client by cache (hostname='{}')", it->addr->getHostName());
+        log_debug("found client by cache (hostname='{}')", it->addr.getHostName());
         return it->pInfo;
     }
 
     return nullptr;
 }
 
-void ClientManager::updateCache(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const ClientInfo* pInfo) const
+void ClientManager::updateCache(const GrbNet& addr, const std::string& userAgent, const ClientInfo* pInfo) const
 {
     AutoLock lock(mutex);
 
@@ -289,7 +289,7 @@ void ClientManager::updateCache(const std::shared_ptr<GrbNet>& addr, const std::
         cache.end());
 
     auto it = std::find_if(cache.begin(), cache.end(), [=](auto&& entry) //
-        { return entry.addr->equals(addr); });
+        { return entry.addr.equals(addr); });
 
     if (it != cache.end()) {
         it->last = now;

--- a/src/util/upnp_clients.h
+++ b/src/util/upnp_clients.h
@@ -32,9 +32,11 @@
 #include <mutex>
 #include <pugixml.hpp>
 #include <sys/socket.h>
+#include <utility>
 #include <vector>
 
 #include "common.h"
+#include "grb_net.h"
 #include "util/grb_time.h"
 #include "util/upnp_quirks.h"
 
@@ -83,7 +85,7 @@ struct ClientInfo {
 };
 
 struct ClientCacheEntry {
-    ClientCacheEntry(std::shared_ptr<GrbNet> addr, std::string userAgent, std::chrono::seconds last, std::chrono::seconds age, const struct ClientInfo* pInfo)
+    ClientCacheEntry(GrbNet addr, std::string userAgent, std::chrono::seconds last, std::chrono::seconds age, const struct ClientInfo* pInfo)
         : addr(std::move(addr))
         , userAgent(std::move(userAgent))
         , last(last)
@@ -92,7 +94,7 @@ struct ClientCacheEntry {
     {
     }
 
-    std::shared_ptr<GrbNet> addr {};
+    GrbNet addr;
     std::string userAgent;
     std::chrono::seconds last;
     std::chrono::seconds age;
@@ -145,17 +147,17 @@ public:
     void refresh(const std::shared_ptr<Config>& config);
 
     // always return something, 'Unknown' if we do not know better
-    const ClientInfo* getInfo(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent) const;
+    const ClientInfo* getInfo(const GrbNet& addr, const std::string& userAgent) const;
 
-    void addClientByDiscovery(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const std::string& descLocation);
+    void addClientByDiscovery(const GrbNet& addr, const std::string& userAgent, const std::string& descLocation);
     const std::vector<ClientCacheEntry>& getClientList() const { return cache; }
 
 private:
-    const ClientInfo* getInfoByAddr(const std::shared_ptr<GrbNet>& addr) const;
+    const ClientInfo* getInfoByAddr(const GrbNet& addr) const;
     const ClientInfo* getInfoByType(const std::string& match, ClientMatchType type) const;
 
-    const ClientInfo* getInfoByCache(const std::shared_ptr<GrbNet>& addr) const;
-    void updateCache(const std::shared_ptr<GrbNet>& addr, const std::string& userAgent, const ClientInfo* pInfo) const;
+    const ClientInfo* getInfoByCache(const GrbNet& addr) const;
+    void updateCache(const GrbNet& addr, const std::string& userAgent, const ClientInfo* pInfo) const;
 
     static std::unique_ptr<pugi::xml_document> downloadDescription(const std::string& location);
 

--- a/src/util/upnp_quirks.cc
+++ b/src/util/upnp_quirks.cc
@@ -40,11 +40,11 @@
 #include "util/upnp_clients.h"
 #include "util/upnp_headers.h"
 
-Quirks::Quirks(std::shared_ptr<UpnpXMLBuilder> xmlBuilder, const std::shared_ptr<ClientManager>& clientManager, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent)
-    : xmlBuilder(std::move(xmlBuilder))
+Quirks::Quirks(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clientManager, const GrbNet& addr, const std::string& userAgent)
+    : xmlBuilder(xmlBuilder)
 {
-    if (addr || !userAgent.empty())
-        pClientInfo = clientManager->getInfo(addr, userAgent);
+    if (!userAgent.empty())
+        pClientInfo = clientManager.getInfo(addr, userAgent);
 }
 
 long Quirks::checkFlags(long flags) const
@@ -74,7 +74,7 @@ void Quirks::addCaptionInfo(const std::shared_ptr<CdsItem>& item, Headers& heade
         return;
     }
 
-    auto subAdded = xmlBuilder->renderSubtitleURL(item, pClientInfo->mimeMappings);
+    auto subAdded = xmlBuilder.renderSubtitleURL(item, pClientInfo->mimeMappings);
     if (subAdded) {
         log_debug("Call for Samsung CaptionInfo.sec: {}", subAdded.value());
         headers.addHeader("CaptionInfo.sec", subAdded.value());
@@ -91,7 +91,7 @@ void Quirks::getSamsungFeatureList(ActionRequest& request) const
 
     log_debug("Call for Samsung extension: X_GetFeatureList");
 
-    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder.createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     pugi::xml_document respRoot;
     auto features = respRoot.append_child("Features");
     features.append_attribute("xmlns") = "urn:schemas-upnp-org:av:avs";
@@ -168,7 +168,7 @@ void Quirks::getSamsungObjectIDfromIndex(ActionRequest& request) const
     } else {
         log_warning("X_GetObjectIDfromIndex called without correct content");
     }
-    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder.createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     response->document_element().append_child("ObjectID").append_child(pugi::node_pcdata).set_value("0");
     request.setResponse(std::move(response));
 }
@@ -192,7 +192,7 @@ void Quirks::getSamsungIndexfromRID(ActionRequest& request) const
     } else {
         log_warning("X_GetIndexfromRID called without correct content");
     }
-    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder.createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     response->document_element().append_child("Index").append_child(pugi::node_pcdata).set_value("0");
     request.setResponse(std::move(response));
 }
@@ -242,7 +242,7 @@ void Quirks::saveSamsungBookMarkedPosition(const std::shared_ptr<Database>& data
             log_warning("X_SetBookmark called without correct content");
         }
     }
-    auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
+    auto response = xmlBuilder.createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
     request.setResponse(std::move(response));
 }
 

--- a/src/util/upnp_quirks.h
+++ b/src/util/upnp_quirks.h
@@ -57,7 +57,7 @@ struct ClientInfo;
 
 class Quirks {
 public:
-    Quirks(std::shared_ptr<UpnpXMLBuilder> xmlBuilder, const std::shared_ptr<ClientManager>& clientManager, const std::shared_ptr<GrbNet>& addr, const std::string& userAgent);
+    Quirks(const UpnpXMLBuilder& xmlBuilder, const ClientManager& clientManager, const GrbNet& addr, const std::string& userAgent);
 
     // Look for subtitle file and returns its URL in CaptionInfo.sec response header.
     // To be more compliant with original Samsung server we should check for getCaptionInfo.sec: 1 request header.
@@ -170,7 +170,7 @@ public:
     std::map<std::string, std::string> getMimeMappings() const;
 
 private:
-    std::shared_ptr<UpnpXMLBuilder> xmlBuilder;
+    const UpnpXMLBuilder& xmlBuilder;
     const ClientInfo* pClientInfo;
 
     bool hasFlag(long flag) const;

--- a/src/web/clients.cc
+++ b/src/web/clients.cc
@@ -53,9 +53,9 @@ void Web::Clients::process()
     auto&& clientArr = content->getContext()->getClients()->getClientList();
     for (auto&& obj : clientArr) {
         auto item = clients.append_child("client");
-        auto ip = obj.addr->getNameInfo();
+        auto ip = obj.addr.getNameInfo();
         item.append_attribute("ip") = ip.c_str();
-        auto hostName = obj.addr->getHostName();
+        auto hostName = obj.addr.getHostName();
         item.append_attribute("host") = hostName.c_str();
         item.append_attribute("time") = secondsToString(obj.age).c_str();
         item.append_attribute("last") = secondsToString(obj.last).c_str();


### PR DESCRIPTION
My theory being that the shared_ptrs are expiring leaving invalid references

Needs a decent amount of testing, not confirmed it actually helps with the issue.

Knocked up whilst looking at https://github.com/gerbera/gerbera/issues/2679