### PR TITLE
buildfix: support fmtlib 10

### DIFF
--- a/src/config/setup/config_setup_array.cc
+++ b/src/config/setup/config_setup_array.cc
@@ -137,11 +137,11 @@ std::vector<std::string> ConfigArraySetup::getXmlContent(const pugi::xml_node& o
     std::vector<std::string> result;
     if (initArray) {
         if (!initArray(optValue, result, ConfigDefinition::mapConfigOption(nodeOption))) {
-            throw_std_runtime_error("Invalid {} array value '{}'", xpath, optValue);
+            throw_std_runtime_error("Invalid {} array value '{}'", xpath, optValue.name());
         }
     } else {
         if (!createOptionFromNode(optValue, result)) {
-            throw_std_runtime_error("Invalid {} array value '{}'", xpath, optValue);
+            throw_std_runtime_error("Invalid {} array value '{}'", xpath, optValue.name());
         }
     }
     if (result.empty()) {
@@ -150,7 +150,7 @@ std::vector<std::string> ConfigArraySetup::getXmlContent(const pugi::xml_node& o
         result = defaultEntries;
     }
     if (notEmpty && result.empty()) {
-        throw_std_runtime_error("Invalid array {} empty '{}'", xpath, optValue);
+        throw_std_runtime_error("Invalid array {} empty '{}'", xpath, optValue.name());
     }
     return result;
 }

--- a/src/config/setup/config_setup_autoscan.cc
+++ b/src/config/setup/config_setup_autoscan.cc
@@ -245,7 +245,7 @@ std::shared_ptr<ConfigOption> ConfigAutoscanSetup::newOption(const pugi::xml_nod
 {
     auto result = std::vector<AutoscanDirectory>();
     if (!createOptionFromNode(optValue, result)) {
-        throw_std_runtime_error("Init {} autoscan failed '{}'", xpath, optValue);
+        throw_std_runtime_error("Init {} autoscan failed '{}'", xpath, optValue.name());
     }
     optionValue = std::make_shared<AutoscanListOption>(result);
     return optionValue;

--- a/src/config/setup/config_setup_client.cc
+++ b/src/config/setup/config_setup_client.cc
@@ -183,7 +183,7 @@ std::shared_ptr<ConfigOption> ConfigClientSetup::newOption(const pugi::xml_node&
     auto result = std::make_shared<ClientConfigList>();
 
     if (!createOptionFromNode(isEnabled ? optValue : pugi::xml_node(nullptr), result)) {
-        throw_std_runtime_error("Init {} client config failed '{}'", xpath, optValue);
+        throw_std_runtime_error("Init {} client config failed '{}'", xpath, optValue.name());
     }
     optionValue = std::make_shared<ClientConfigListOption>(result);
     return optionValue;

--- a/src/config/setup/config_setup_dictionary.cc
+++ b/src/config/setup/config_setup_dictionary.cc
@@ -163,11 +163,11 @@ std::map<std::string, std::string> ConfigDictionarySetup::getXmlContent(const pu
     std::map<std::string, std::string> result;
     if (initDict) {
         if (!initDict(optValue, result)) {
-            throw_std_runtime_error("Init {} dictionary failed '{}'", xpath, optValue);
+            throw_std_runtime_error("Init {} dictionary failed '{}'", xpath, optValue.name());
         }
     } else {
         if (!createOptionFromNode(optValue, result) && required) {
-            throw_std_runtime_error("Init {} dictionary failed '{}'", xpath, optValue);
+            throw_std_runtime_error("Init {} dictionary failed '{}'", xpath, optValue.name());
         }
     }
     if (result.empty()) {
@@ -176,7 +176,7 @@ std::map<std::string, std::string> ConfigDictionarySetup::getXmlContent(const pu
         result = defaultEntries;
     }
     if (notEmpty && result.empty()) {
-        throw_std_runtime_error("Invalid dictionary {} empty '{}'", xpath, optValue);
+        throw_std_runtime_error("Invalid dictionary {} empty '{}'", xpath, optValue.name());
     }
     return result;
 }

--- a/src/config/setup/config_setup_dynamic.cc
+++ b/src/config/setup/config_setup_dynamic.cc
@@ -192,7 +192,7 @@ std::shared_ptr<ConfigOption> ConfigDynamicContentSetup::newOption(const pugi::x
     auto result = std::make_shared<DynamicContentList>();
 
     if (!createOptionFromNode(optValue, result)) {
-        throw_std_runtime_error("Init {} DynamicContentList failed '{}'", xpath, optValue);
+        throw_std_runtime_error("Init {} DynamicContentList failed '{}'", xpath, optValue.name());
     }
     optionValue = std::make_shared<DynamicContentListOption>(result);
     return optionValue;

--- a/src/config/setup/config_setup_transcoding.cc
+++ b/src/config/setup/config_setup_transcoding.cc
@@ -501,7 +501,7 @@ std::shared_ptr<ConfigOption> ConfigTranscodingSetup::newOption(const pugi::xml_
     auto result = std::make_shared<TranscodingProfileList>();
 
     if (!createOptionFromNode(isEnabled ? optValue : pugi::xml_node(nullptr), result)) {
-        throw_std_runtime_error("Init {} transcoding failed '{}'", xpath, optValue);
+        throw_std_runtime_error("Init {} transcoding failed '{}'", xpath, optValue.name());
     }
     optionValue = std::make_shared<TranscodingProfileListOption>(result);
     return optionValue;

--- a/src/config/setup/config_setup_tweak.cc
+++ b/src/config/setup/config_setup_tweak.cc
@@ -257,7 +257,7 @@ std::shared_ptr<ConfigOption> ConfigDirectorySetup::newOption(const pugi::xml_no
     auto result = std::make_shared<DirectoryConfigList>();
 
     if (!createOptionFromNode(optValue, result)) {
-        throw_std_runtime_error("Init {} DirectoryConfigList failed '{}'", xpath, optValue);
+        throw_std_runtime_error("Init {} DirectoryConfigList failed '{}'", xpath, optValue.name());
     }
     optionValue = std::make_shared<DirectoryTweakOption>(result);
     return optionValue;

--- a/src/config/setup/config_setup_vector.cc
+++ b/src/config/setup/config_setup_vector.cc
@@ -181,7 +181,7 @@ std::vector<std::vector<std::pair<std::string, std::string>>> ConfigVectorSetup:
 {
     std::vector<std::vector<std::pair<std::string, std::string>>> result;
     if (!createOptionFromNode(optValue, result) && required) {
-        throw_std_runtime_error("Init {} vector failed '{}'", xpath, optValue);
+        throw_std_runtime_error("Init {} vector failed '{}'", xpath, optValue.name());
     }
     if (result.empty()) {
         log_debug("{} assigning {} default values", xpath, defaultEntries.size());
@@ -189,7 +189,7 @@ std::vector<std::vector<std::pair<std::string, std::string>>> ConfigVectorSetup:
         result = defaultEntries;
     }
     if (notEmpty && result.empty()) {
-        throw_std_runtime_error("Invalid vector {} empty '{}'", xpath, optValue);
+        throw_std_runtime_error("Invalid vector {} empty '{}'", xpath, optValue.name());
     }
     return result;
 }


### PR DESCRIPTION
With fmtlib10, fmt::format does not accept pugi::xml_node as it is. Use name() member function, as this usage appear on other places of gerbera source code.

Closes #2839 .