### PR TITLE
Fix troff warning

### DIFF
--- a/doc/gerbera.1
+++ b/doc/gerbera.1
@@ -96,8 +96,8 @@ name and location of your choice. The file name must be absolute.
 .TP
 \*(T<\fB\-m\fR\*(T>, \*(T<\fB\-\-home\fR\*(T>
 Specify an alternative home directory. By default Gerbera will try to
-retrieve the users home directory from the environment (HOME), then it will look for a
-.config/gerbera directory in users home. If .config/gerbera was found we will try to find
+retrieve the users home directory from the environment (HOME), then it will look for
+the .config/gerbera directory in users home. If .config/gerbera was found we will try to find
 the default configuration file (config.xml).
 
 This option is useful in two cases: when the home directory cannot be


### PR DESCRIPTION
In gerbera.1 config/gerbera is an "undefined macro".

Warning message from the current 1.12.1 release in debian:
```shell
troff:<standard input>:90: warning: macro 'config/gerbera' not defined [usr/share/man/man1/gerbera.1.gz:1]
``` 
This change fixes the warning.