### PR TITLE
Add #include <algorithm> to fix building with gcc 14

### DIFF
--- a/src/cds/cds_objects.h
+++ b/src/cds/cds_objects.h
@@ -34,6 +34,7 @@
 #ifndef __CDS_OBJECTS_H__
 #define __CDS_OBJECTS_H__
 
+#include <algorithm>
 #include <map>
 #include <memory>
 #include <vector>

--- a/src/iohandler/io_handler_buffer_helper.cc
+++ b/src/iohandler/io_handler_buffer_helper.cc
@@ -36,6 +36,8 @@
 
 #include "config/config_manager.h"
 
+#include <algorithm>
+
 IOHandlerBufferHelper::IOHandlerBufferHelper(std::shared_ptr<Config> config, std::size_t bufSize, std::size_t initialFillSize)
     : config(std::move(config))
     , bufSize(bufSize)

--- a/src/iohandler/mem_io_handler.cc
+++ b/src/iohandler/mem_io_handler.cc
@@ -34,6 +34,8 @@
 
 #include "mem_io_handler.h" // API
 
+#include <algorithm>
+
 MemIOHandler::MemIOHandler(const void* buffer, int length)
     : buffer(new char[length])
     , length(length)

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -33,6 +33,7 @@
 #ifndef __TOOLS_H__
 #define __TOOLS_H__
 
+#include <algorithm>
 #include <map>
 #include <optional>
 #include <vector>

--- a/src/util/upnp_clients.cc
+++ b/src/util/upnp_clients.cc
@@ -33,6 +33,8 @@
 
 #include <upnp.h>
 
+#include <algorithm>
+
 std::shared_ptr<ClientStatusDetail> ClientStatusDetail::clone() const
 {
     return std::make_shared<ClientStatusDetail>(group, itemId, playCount, lastPlayed.count(), lastPlayedPosition.count(), bookMarkPos.count());


### PR DESCRIPTION
With gcc 14 some C++ Standard Library headers have been changed to no longer include other headers that were used internally by the library. In gerbera's case it is the `<algorithm>` header.

[Downstream gentoo bug](https://bugs.gentoo.org/917136)

[GCC 14 porting guide](https://gcc.gnu.org/gcc-14/porting_to.html#header-dep-changes)
