### PR TITLE
Autoscan: Handle renamed directory

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 ## Gerbera - UPnP AV Mediaserver.
 
+ - Add #include to fix building with gcc 14
  - Add audio to year container
  - Add cleanup of missing entries to grb import mode
  - Add option for external URL to be used in web page.
@@ -9,12 +10,16 @@
  - Add support for UPnP commands GetFeatureList and GetSortExtensionCapabilities
  - Allow overriding home in config
  - buildfix: support fmtlib 10
+ - Bump @babel/traverse from 7.23.0 to 7.23.2 in /gerbera-web
+ - Bump chromedriver from 117.0.3 to 119.0.1 in /gerbera-web
  - Bump engine.io and socket.io in /gerbera-web
  - Bump socket.io-parser from 4.2.2 to 4.2.3 in /gerbera-web
  - Bump ua-parser-js from 0.7.32 to 0.7.33 in /gerbera-web
  - Bump webpack from 5.75.0 to 5.76.0 in /gerbera-web
  - Bump word-wrap from 1.2.3 to 1.2.4 in /gerbera-web
+ - Clean up physical entries in subdirectories
  - Clean up unreferenced items
+ - Clients: Support hiding resource types
  - Config WebUI: Catch up with all config changes
  - Config: Add follow-symlinks for autoscan
  - Config: Add support for time specifications
@@ -24,8 +29,10 @@
  - DB: Don't fail on uncritical operations.
  - debian: bookworm is now stable
  - Display message on home screen when database is empty
+ - Doc: Compile libupnp --disable-blocking-tcp-connections
  - Docker: Add JPEG libs
  - Docker: git badge update
+ - Document dependency installation on Debian 12
  - Fix conan
  - Fix handling transcoding requests
  - Fix spelling errors reported by lintian
@@ -37,7 +44,9 @@
  - Quirks: Check for clientInfo
  - README: fix CI badge
  - Rework javascript mechanism
+ - Samsung: Handle browse for content class correctly
  - Set defaults for autoscan settings
+ - Transcode: Wildcards for mime type filter
  - Transcoding: Improve docs and examples
  - Update Library Versions and Documentation
  - Update README.Docker.md -Add docker volume section

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -30,11 +30,13 @@ them to the new `<box-layout ../>`. Run gerbera with `--create-config` to get th
 - Configurable handling of HOME directory
 - Transcoding: parsing issue of requests
 - Stability for sqlite database access
+- Browsing on Samsung devices
 
 ### Code Improvements
 
 - Update Javascript libraries
 - Update versions of pupnp (1.14.18), libexiv2 (v0.27.7), fmt (10.1.1), spdlog (1.12.0) and taglib (1.13.1)
+- Compatibility with gcc14
 
 ## v1.12.1
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -40,7 +40,7 @@ else
     GOOGLETEST="1.14.0"
     LASTFM="0.4.0"
     MATROSKA="1.7.1"
-    PUGIXML="1.13"
+    PUGIXML="1.14"
     PUPNP="1.14.18"
     SPDLOG="1.12.0"
     WAVPACK="5.6.0"

--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -199,7 +199,7 @@ void AutoscanInotify::threadProc()
                 if (!ec) {
                     isDir = isDir || dirEnt.is_directory(ec);
                 }
-                if(ec && !(mask & (IN_DELETE_SELF | IN_DELETE | IN_MOVED_FROM | IN_MOVE_SELF | IN_UNMOUNT))) {
+                if (ec && !(mask & (IN_DELETE_SELF | IN_DELETE | IN_MOVED_FROM | IN_MOVE_SELF | IN_UNMOUNT))) {
                     log_error("Failed to read {}: {}", path.c_str(), ec.message());
                 }
                 std::shared_ptr<AutoscanDirectory> adir;
@@ -524,6 +524,7 @@ int AutoscanInotify::monitorUnmonitorRecursive(const fs::directory_entry& startP
             log_error("AutoscanInotify::monitorUnmonitorRecursive {}: Failed to read {}, {}", startPath.path().c_str(), dirEnt.path().c_str(), ec.message());
         }
     }
+    return result;
 }
 
 int AutoscanInotify::monitorDirectory(const fs::path& path, const std::shared_ptr<AutoscanDirectory>& adir, bool startPoint, const std::vector<std::string>* pathArray)

--- a/src/content/autoscan_inotify.cc
+++ b/src/content/autoscan_inotify.cc
@@ -172,28 +172,43 @@ void AutoscanInotify::threadProc()
             /* --- */
 
             if (event) {
+                // lock.lock();
                 int wd = event->wd;
-                int mask = event->mask;
-                std::string name = event->name;
-                log_debug("inotify event: {} 0x{:x} {}", wd, mask, name);
+                uint32_t mask = event->mask;
+                std::string name = event->len > 0 ? event->name : "";
+                log_debug("inotify event: {} mask=0x{:x} name={}", wd, mask, name);
 
                 std::shared_ptr<Wd> wdObj;
                 try {
                     wdObj = watches.at(wd);
                 } catch (const std::out_of_range&) {
                     inotify->removeWatch(wd);
+                    // lock.unlock();
                     continue;
                 }
 
                 fs::path path = wdObj->getPath();
                 // file is not gone
-                if (!(mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT)))
+                if (mask & IN_MOVE_SELF)
+                    path = path.parent_path() / name;
+                else if (!(mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT)) && !name.empty())
                     path /= name;
 
+                auto dirEnt = fs::directory_entry(path, ec);
+                bool isDir = mask & IN_ISDIR;
+                if (!ec) {
+                    isDir = isDir || dirEnt.is_directory(ec);
+                }
+                if(ec && !(mask & (IN_DELETE_SELF | IN_DELETE | IN_MOVED_FROM | IN_MOVE_SELF | IN_UNMOUNT))) {
+                    log_error("Failed to read {}: {}", path.c_str(), ec.message());
+                }
                 std::shared_ptr<AutoscanDirectory> adir;
                 auto watchAs = getAppropriateAutoscan(wdObj, path);
                 if (watchAs)
                     adir = watchAs->getAutoscanDirectory();
+                if (!watchAs || !adir) {
+                    log_debug("autoscan not found in watches? ({}, watchAs:{}, adir:{}, {})", wd, watchAs == nullptr, adir == nullptr, path.c_str());
+                }
 
                 // file is renamed
                 if (mask & IN_MOVE_SELF) {
@@ -204,24 +219,27 @@ void AutoscanInotify::threadProc()
                 if (mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT)) {
                     recheckNonexistingMonitors(wd, wdObj);
                 }
+                AutoScanSetting asSetting;
+                asSetting.adir = adir;
+                asSetting.followSymlinks = adir->getFollowSymlinks();
+                asSetting.recursive = adir->getRecursive();
+                asSetting.hidden = adir->getHidden();
+                asSetting.rescanResource = true;
+                asSetting.async = true;
+                asSetting.mergeOptions(config, path);
 
                 // file is directory
-                if (mask & IN_ISDIR) {
+                if (isDir) {
                     if (mask & (IN_CREATE | IN_MOVED_TO)) {
                         recheckNonexistingMonitors(wd, wdObj);
                     }
 
                     if (adir && adir->getRecursive() && (mask & IN_CREATE)) {
-                        if (adir->getHidden() || name.at(0) != '.') {
+                        if (!content->isHiddenFile(dirEnt, isDir, asSetting)) {
                             log_debug("Detected new dir, adding to inotify: {}", path.c_str());
-                            auto dirEnt = fs::directory_entry(path, ec);
-                            if (!ec) {
-                                monitorUnmonitorRecursive(dirEnt, false, adir, false, adir->getFollowSymlinks());
-                            } else {
-                                log_error("Failed to read {}: {}", path.c_str(), ec.message());
-                            }
+                            monitorUnmonitorRecursive(dirEnt, false, adir, false, asSetting.followSymlinks);
                         } else {
-                            log_debug("Detected new dir, irgnoring because it's hidden: {}", path.c_str());
+                            log_debug("Detected new dir, ignoring because it's hidden: {}", path.c_str());
                         }
                     }
                 }
@@ -234,8 +252,10 @@ void AutoscanInotify::threadProc()
 
                         // deleted
                         if (mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_UNMOUNT)) {
-                            if (mask & IN_MOVE_SELF)
+                            if (!(mask & IN_MOVE_SELF)) {
+                                log_debug("removing watch {}", path.c_str());
                                 inotify->removeWatch(wd);
+                            }
                             auto watch = getStartPoint(wdObj);
                             if (watch && adir->persistent()) {
                                 monitorNonexisting(path, watch->getAutoscanDirectory());
@@ -250,23 +270,15 @@ void AutoscanInotify::threadProc()
                     // new file
                     if (mask & (IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE)) {
                         log_debug("Adding {}", path.c_str());
-                        auto dirEnt = fs::directory_entry(path, ec);
-                        if (!ec) {
-                            AutoScanSetting asSetting;
-                            asSetting.adir = adir;
-                            asSetting.followSymlinks = adir->getFollowSymlinks();
-                            asSetting.recursive = adir->getRecursive();
-                            asSetting.hidden = adir->getHidden();
-                            asSetting.rescanResource = true;
-                            asSetting.async = true;
-                            asSetting.mergeOptions(config, path);
-                            // path, recursive, async, hidden, rescanResource, low priority, cancellable
-                            content->addFile(dirEnt, adir->getLocation(), asSetting, true, false);
-                            if (mask & IN_ISDIR) {
-                                monitorUnmonitorRecursive(dirEnt, false, adir, false, asSetting.followSymlinks);
+                        // dirEnt, path, rootPath, settings, lowPriority, cancellable
+                        content->addFile(dirEnt, adir->getLocation(), asSetting, true, false);
+                        if (isDir) {
+                            int wdPath = monitorUnmonitorRecursive(dirEnt, false, adir, false, asSetting.followSymlinks);
+                            if ((mask & IN_MOVED_TO) && wdPath > -1) {
+                                auto wdObjPath = watches.at(wdPath);
+                                log_debug("Resetting {} to {}", wdObjPath->getPath().c_str(), path.c_str());
+                                wdObjPath->setPath(path);
                             }
-                        } else {
-                            log_error("Failed to read {}: {}", path.c_str(), ec.message());
                         }
                     }
                 }
@@ -275,6 +287,7 @@ void AutoscanInotify::threadProc()
                     removeDescendants(wd);
                     watches.erase(wd);
                 }
+                // lock.unlock();
             }
         } catch (const std::runtime_error& e) {
             log_error("Inotify thread caught exception: {}", e.what());
@@ -463,32 +476,43 @@ void AutoscanInotify::removeNonexistingMonitor(int wd, const std::shared_ptr<Wd>
     }
 }
 
-void AutoscanInotify::monitorUnmonitorRecursive(const fs::directory_entry& startPath, bool unmonitor, const std::shared_ptr<AutoscanDirectory>& adir, bool startPoint, bool followSymlinks)
+int AutoscanInotify::monitorUnmonitorRecursive(const fs::directory_entry& startPath, bool unmonitor, const std::shared_ptr<AutoscanDirectory>& adir, bool startPoint, bool followSymlinks)
 {
+    int result = -1;
     if (unmonitor)
         unmonitorDirectory(startPath.path(), adir);
     else {
-        bool ok = (monitorDirectory(startPath.path(), adir, startPoint) > 0);
+        result = monitorDirectory(startPath.path(), adir, startPoint);
+        bool ok = (result > 0);
         if (!ok)
-            return;
+            return -1;
     }
 
     std::error_code ec;
     if (!startPath.exists(ec) || !startPath.is_directory(ec)) {
         log_warning("Could not open {}: {}", startPath.path().c_str(), ec.message());
-        return;
+        return -1;
     }
     auto dIter = fs::directory_iterator(startPath, ec);
     if (ec) {
         log_error("monitorUnmonitorRecursive: Failed to iterate {}, {}", startPath.path().c_str(), ec.message());
-        return;
+        return -1;
     }
     for (auto&& dirEnt : dIter) {
         if (shutdownFlag)
             break;
 
-        if (!followSymlinks && dirEnt.is_symlink(ec)) {
-            log_debug("link {} skipped", dirEnt.path().c_str());
+        AutoScanSetting asSetting;
+        asSetting.adir = adir;
+        asSetting.followSymlinks = adir->getFollowSymlinks();
+        asSetting.recursive = adir->getRecursive();
+        asSetting.hidden = adir->getHidden();
+        asSetting.rescanResource = true;
+        asSetting.async = true;
+        asSetting.mergeOptions(config, dirEnt.path());
+
+        if (content->isHiddenFile(dirEnt, dirEnt.is_directory(ec), asSetting)) {
+            log_debug("Hidden file {} skipped", dirEnt.path().c_str());
             continue;
         }
 
@@ -537,7 +561,7 @@ int AutoscanInotify::monitorDirectory(const fs::path& path, const std::shared_pt
             if (pathArray) {
                 watch->setNonexistingPathArray(*pathArray);
             }
-            wdObj->addWatch(move(watch));
+            wdObj->addWatch(std::move(watch));
 
             if (!startPoint) {
                 int startPointWd = inotify->addWatch(adir->getLocation(), events);

--- a/src/content/autoscan_inotify.h
+++ b/src/content/autoscan_inotify.h
@@ -151,6 +151,7 @@ private:
         {
         }
         fs::path getPath() const { return path; }
+        void setPath(const fs::path& newPath) { path = newPath; }
         int getWd() const { return wd; }
         int getParentWd() const { return parentWd; }
         void setParentWd(int parentWd) { this->parentWd = parentWd; }
@@ -167,7 +168,7 @@ private:
 
     std::unordered_map<int, std::shared_ptr<Wd>> watches;
 
-    void monitorUnmonitorRecursive(const fs::directory_entry& startPath, bool unmonitor, const std::shared_ptr<AutoscanDirectory>& adir, bool startPoint, bool followSymlinks);
+    int monitorUnmonitorRecursive(const fs::directory_entry& startPath, bool unmonitor, const std::shared_ptr<AutoscanDirectory>& adir, bool startPoint, bool followSymlinks);
     int monitorDirectory(const fs::path& path, const std::shared_ptr<AutoscanDirectory>& adir, bool startPoint, const std::vector<std::string>* pathArray = nullptr);
     void unmonitorDirectory(const fs::path& path, const std::shared_ptr<AutoscanDirectory>& adir);
 

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -849,6 +849,11 @@ void ContentManager::_rescanDirectory(const std::shared_ptr<AutoscanDirectory>& 
     }
 }
 
+bool ContentManager::isHiddenFile(const fs::directory_entry& dirEntry, bool isDirectory, const AutoScanSetting& settings)
+{
+    return getImportService(settings.adir)->isHiddenFile(dirEntry.path(), isDirectory, dirEntry, settings);
+}
+
 std::shared_ptr<AutoscanDirectory> ContentManager::findAutoscanDirectory(fs::path path) const
 {
     std::shared_ptr<AutoscanDirectory> autoscanDir;

--- a/src/content/content_manager.h
+++ b/src/content/content_manager.h
@@ -190,6 +190,7 @@ public:
     std::vector<std::shared_ptr<AutoscanDirectory>> getAutoscanDirectories() const;
 
     std::shared_ptr<AutoscanDirectory> findAutoscanDirectory(fs::path dir) const;
+    bool isHiddenFile(const fs::directory_entry& dirEntry, bool isDirectory, const AutoScanSetting& settings);
 
     /// \brief Removes an AutoscanDirectrory (found by scanID) from the watch list.
     void removeAutoscanDirectory(const std::shared_ptr<AutoscanDirectory>& adir);

--- a/src/content/import_service.cc
+++ b/src/content/import_service.cc
@@ -313,7 +313,7 @@ void ImportService::removeHidden(AutoScanSetting& settings)
     }
 }
 
-bool ImportService::isHiddenFile(const fs::path& entryPath, bool isDirectory, const fs::directory_entry& dirEntry, AutoScanSetting& settings)
+bool ImportService::isHiddenFile(const fs::path& entryPath, bool isDirectory, const fs::directory_entry& dirEntry, const AutoScanSetting& settings)
 {
     auto&& name = entryPath.filename().string();
     if ((name[0] == '.' && !settings.hidden)

--- a/src/content/import_service.h
+++ b/src/content/import_service.h
@@ -181,7 +181,6 @@ private:
     void fillLayout(const std::shared_ptr<GenericTask>& task);
     void updateFanArt();
     void assignFanArt(const std::shared_ptr<CdsContainer>& container, const std::shared_ptr<CdsObject>& refObj, int count);
-    bool isHiddenFile(const fs::path& entryPath, bool isDirectory, const fs::directory_entry& dirEntry, AutoScanSetting& settings);
     void removeHidden(AutoScanSetting& settings);
 
 public:
@@ -197,6 +196,8 @@ public:
     std::shared_ptr<CdsObject> createSingleItem(const fs::directory_entry& dirEntry);
     std::shared_ptr<CdsContainer> createSingleContainer(int parentContainerId, const fs::directory_entry& dirEntry, const std::string& upnpClass);
     void fillSingleLayout(const std::shared_ptr<ContentState>& state, std::shared_ptr<CdsObject> object, const std::shared_ptr<CdsContainer>& parent, const std::shared_ptr<GenericTask>& task);
+
+    bool isHiddenFile(const fs::path& entryPath, bool isDirectory, const fs::directory_entry& dirEntry, const AutoScanSetting& settings);
 
     void updateItemData(const std::shared_ptr<CdsItem>& item, const std::string& mimetype);
     std::pair<int, bool> addContainerTree(int parentContainerId, const std::vector<std::shared_ptr<CdsObject>>& chain, std::vector<int>& createdIds);

--- a/src/util/mt_inotify.cc
+++ b/src/util/mt_inotify.cc
@@ -95,7 +95,7 @@ bool Inotify::supported()
     return true;
 }
 
-int Inotify::addWatch(const fs::path& path, int events) const
+int Inotify::addWatch(const fs::path& path, uint32_t events) const
 {
     int wd = inotify_add_watch(inotify_fd, path.c_str(), events);
     if (wd < 0 && errno != ENOENT) {

--- a/src/util/mt_inotify.h
+++ b/src/util/mt_inotify.h
@@ -53,7 +53,7 @@ public:
     /// \param path file or directory to monitor.
     /// \param events inotify event mask
     /// \return watch descriptor or a negative value on error
-    int addWatch(const fs::path& path, uint32_t  events) const;
+    int addWatch(const fs::path& path, uint32_t events) const;
 
     /// \brief Removes a previously added file or directory from the watch list
     /// \param wd watch descriptor that was returned by the add_watch function

--- a/src/util/mt_inotify.h
+++ b/src/util/mt_inotify.h
@@ -53,7 +53,7 @@ public:
     /// \param path file or directory to monitor.
     /// \param events inotify event mask
     /// \return watch descriptor or a negative value on error
-    int addWatch(const fs::path& path, int events) const;
+    int addWatch(const fs::path& path, uint32_t  events) const;
 
     /// \brief Removes a previously added file or directory from the watch list
     /// \param wd watch descriptor that was returned by the add_watch function


### PR DESCRIPTION
Renaming a directory left the new one unmonitored until restart because it kept its inode and therefor no new monitoring was started but the old one was deleted