### PR TITLE
Fix processing for M_DATE and M_CREATION_DATE on FFmpeg handler.

### DIFF
--- a/src/metadata/ffmpeg_handler.cc
+++ b/src/metadata/ffmpeg_handler.cc
@@ -137,14 +137,16 @@ void FfmpegHandler::addFfmpegMetadataFields(const std::shared_ptr<CdsItem>& item
                         tmWork = fmt::localtime(utcTime);
                     } else if (strptime(e->value, "%Y-%m-%d", &tmWork)) {
                         ; // use the value as is
-                    } else if (strptime(e->value, "%Y", &tmWork)) { 
+                    } else if (strptime(e->value, "%Y", &tmWork)) {
                         // convert the value to "XXXX-01-01"
                         tmWork.tm_mon = 0; // Month (0-11)
                         tmWork.tm_mday = 1; // Day of the month (1-31)
-                    } else continue;
+                    } else
+                        continue;
                     auto mDate = fmt::format("{:%Y-%m-%d}", tmWork);
                     item->addMetaData(field, mDate);
-                } else item->addMetaData(field, sc->convert(trimString(value)));
+                } else
+                    item->addMetaData(field, sc->convert(trimString(value)));
             }
             if (field == M_TRACKNUMBER) {
                 item->setTrackNumber(stoiString(value));

--- a/src/metadata/ffmpeg_handler.h
+++ b/src/metadata/ffmpeg_handler.h
@@ -75,6 +75,8 @@ private:
         std::pair(M_PARTNUMBER, "discnumber"),
         std::pair(M_ALBUMARTIST, "album_artist"),
         std::pair(M_COMPOSER, "composer"),
+        std::pair(M_DATE, "date"),
+        std::pair(M_CREATION_DATE, "creation_time"),
     };
 };
 


### PR DESCRIPTION
On ffmpeg_handler.cc there is a issue in meta data processing for M_DATE and M_CREATION_DATE. 

https://github.com/gerbera/gerbera/blob/042e0404549159f97e5211915bc46e3529bf1241/src/metadata/ffmpeg_handler.cc#L135-L138

https://github.com/gerbera/gerbera/blob/042e0404549159f97e5211915bc46e3529bf1241/src/metadata/ffmpeg_handler.cc#L143-L145


`if (emptyProperties[M_DATE])` and `if (emptyProperties[M_CREATION_DATE])` are always **false**.
Because `emptyProperties` are created by `propertyMap`  
https://github.com/gerbera/gerbera/blob/042e0404549159f97e5211915bc46e3529bf1241/src/metadata/ffmpeg_handler.cc#L102-L105
that is https://github.com/gerbera/gerbera/blob/042e0404549159f97e5211915bc46e3529bf1241/src/metadata/ffmpeg_handler.h#L68-L78
, where both M_DATE and M_CREATION_DATE are not included.

I want to add them and refine the M_DATE and M_CREATION_DATE processing.