### PR TITLE
Expand firewall advice in docs (#2993)

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -78,6 +78,18 @@ Gerbera is available in Fedora 29 or later.
 
     sudo dnf install gerbera
 
+If you are running the Server edition of Fedora you will probably need to configure your firewall to
+open the ports Gerbera uses. In the default firewall configuration the following commands should do the 
+trick (change ``49152`` to the port Gerbera is actually using, see the
+:ref:`Port <troubleshoot_port>` section of the Troubleshooting page).
+If you are running the Workstation edition of Fedora, Gerbera should work with the default 
+firewall configuration and these commands won't be needed.
+
+.. code-block:: sh
+
+    sudo firewall-cmd --permanent --add-service=ssdp
+    sudo firewall-cmd --permanent --add-port=49152/tcp
+
 FreeBSD
 ~~~~~~~~~~~~~~~~~
 .. index:: FreeBSD

--- a/doc/troubleshooting.rst
+++ b/doc/troubleshooting.rst
@@ -44,18 +44,37 @@ Network Interface
 
 Interface to bind to, for example eth0, this can be specified instead of the IP address.
 
+.. _troubleshoot_port:
+
 Port
 ----
 
+In addition to UDP port ``1900`` (required by UPnP/SSDP), Gerbera uses a port in the range of ``49152``
+or above for serving media and for UPnP requests. 
 If multiple instances of Gerbera or other UPnP media servers are running at the same time the port may be blocked.
 
 ::
 
     --port or -p
 
-Specify the server port that will be used for the web user interface, for serving media and for UPnP requests,
-minimum allowed value is ``49152``. If this option is omitted a default port will be chosen, however, in
-this case it is possible that the port will change upon server restart.
+Specify the server port that will be used for the web user interface, for serving media and for UPnP requests.
+The minimum allowed value is ``49152``. This can also be specified in the config file.
+If this option is omitted a default port will be chosen, but in
+this case it is possible that the port will change upon server restart. 
+
+Gerbera's startup messages will tell you which server port it's actually using.
+
+Firewall
+--------
+
+If gerbera appears to be running but other devices on the network can't see it, ensure that your 
+firewall is not blocking UDP port ``1900`` or the server port that Gerbera is using
+(e.g. ``49152``, see the :ref:`Port <troubleshoot_port>` section above). 
+
+If you have opened only a single server port in your firewall for Gerbera to use, consider adding that port 
+to the command line or config file to prevent it from changing upon server restart.
+If multiple instances of Gerbera or other UPnP media servers are running at the same time you may need 
+to open multiple ports.
 
 Debugging
 ~~~~~~~~~


### PR DESCRIPTION
Add a new Firewall section to the Troubleshooting page.

Expand the Port section of the Troubleshooting page to complement the new Firewall section.

Add info about Fedora Server edition on the Installing Gerbera page. The existing Fedora section was ok for the Workstation edition. The added info should save a user a bunch of troubleshooting if they install on the Server edition.