### PR TITLE
BUGFIX: common.js boxSetup check Video/AllDates for Dates

### DIFF
--- a/scripts/js/common.js
+++ b/scripts/js/common.js
@@ -1022,7 +1022,7 @@ function addVideo(obj, cont, rootPath, containerType) {
     }
 
     // Dates
-    if (boxSetup['Video/allYears'].enabled && obj.metaData[M_CREATION_DATE] && obj.metaData[M_CREATION_DATE][0]) {
+    if (boxSetup['Video/allDates'].enabled && obj.metaData[M_CREATION_DATE] && obj.metaData[M_CREATION_DATE][0]) {
         var date = obj.metaData[M_CREATION_DATE][0];
         var dateParts = date.split('T');
         if (dateParts.length > 1) {


### PR DESCRIPTION
Per issue #2998  -- this change updates the Dates section of the Video box setup to check if the parameter boxSetup['Video/allDates'] is checked instead of boxSetup['Video/allYears']