### PR TITLE
MetadataHandler: Refactor static methods

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,8 +229,9 @@ add_library(libgerbera STATIC
         src/metadata/metacontent_handler.h
         src/metadata/metadata_enums.cc
         src/metadata/metadata_enums.h
-        src/metadata/metadata_handler.cc
         src/metadata/metadata_handler.h
+        src/metadata/metadata_service.cc
+        src/metadata/metadata_service.h
         src/metadata/resolution.cc
         src/metadata/resolution.h
         src/metadata/taglib_handler.cc

--- a/src/content/content_manager.cc
+++ b/src/content/content_manager.cc
@@ -45,7 +45,7 @@
 #include "config/result/autoscan.h"
 #include "database/database.h"
 #include "import_service.h"
-#include "metadata/metadata_handler.h"
+#include "metadata/metadata_service.h"
 #include "update_manager.h"
 #include "upnp/clients.h"
 #include "util/mime.h"
@@ -426,7 +426,7 @@ std::shared_ptr<CdsObject> ContentManager::createSingleItem(
         }
     } else if (obj->isItem() && processExisting) {
         auto item = std::static_pointer_cast<CdsItem>(obj);
-        MetadataHandler::extractMetaData(context, shared_from_this(), item, dirEnt);
+        getImportService(adir)->getMetadataService()->extractMetaData(item, dirEnt);
         getImportService(adir)->updateItemData(item, item->getMimeType());
     }
     if (processExisting || isNew) {

--- a/src/content/import_service.h
+++ b/src/content/import_service.h
@@ -45,6 +45,7 @@ class GenericTask;
 class ImportService;
 class Layout;
 enum class LayoutType;
+class MetadataService;
 class Mime;
 class ScriptingRuntime;
 class UpnpMap;
@@ -147,6 +148,7 @@ private:
     std::shared_ptr<Mime> mime;
     std::shared_ptr<Database> database;
     std::shared_ptr<ContentManager> content;
+    std::shared_ptr<MetadataService> metadataService;
 
     std::map<std::string, std::string> mimetypeContenttypeMap;
     std::map<std::string, std::string> mimetypeUpnpclassMap;
@@ -214,6 +216,7 @@ public:
     std::shared_ptr<CdsContainer> getContainer(const fs::path& location) const;
     std::shared_ptr<CdsObject> getObject(const fs::path& location) const;
     std::shared_ptr<Layout> getLayout() const { return layout; }
+    std::shared_ptr<MetadataService> getMetadataService() const { return metadataService; }
 
     /// \brief parse a file containing metadata for object
     void parseMetafile(const std::shared_ptr<CdsObject>& obj, const fs::path& path) const;

--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -42,6 +42,7 @@
 
 class CdsResource;
 class MetadataHandler;
+class MetadataService;
 
 class FileRequestHandler : public RequestHandler {
 
@@ -57,7 +58,9 @@ protected:
 private:
     std::unique_ptr<Quirks> getQuirks(const UpnpFileInfo* info) const;
     static std::size_t parseResourceInfo(const std::map<std::string, std::string>& params);
-    std::unique_ptr<MetadataHandler> getResourceMetadataHandler(std::shared_ptr<CdsObject>& obj, std::shared_ptr<CdsResource>& resource) const;
+    std::shared_ptr<MetadataHandler> getResourceMetadataHandler(std::shared_ptr<CdsObject>& obj, std::shared_ptr<CdsResource>& resource) const;
+
+    std::shared_ptr<MetadataService> metadataService;
 };
 
 #endif // __FILE_REQUEST_HANDLER_H__

--- a/src/metadata/exiv2_handler.h
+++ b/src/metadata/exiv2_handler.h
@@ -44,6 +44,10 @@ public:
     explicit Exiv2Handler(const std::shared_ptr<Context>& context);
     void fillMetadata(const std::shared_ptr<CdsObject>& item) override;
     std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsResource>& resource) override;
+
+private:
+    std::vector<std::string> auxTags;
+    std::map<std::string, std::string> metaTags;
 };
 
 #endif // __METADATA_EXIV2_H__

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -42,7 +42,6 @@
 class CdsItem;
 class CdsObject;
 class CdsResource;
-class ContentManager;
 class IOHandler;
 enum class ContentHandler;
 enum class MetadataFields;
@@ -56,8 +55,8 @@ protected:
 
 public:
     explicit MetadataHandler(const std::shared_ptr<Context>& context)
-    : config(context->getConfig())
-    , mime(context->getMime())
+        : config(context->getConfig())
+        , mime(context->getMime())
     {
     }
 

--- a/src/metadata/metadata_handler.h
+++ b/src/metadata/metadata_handler.h
@@ -34,8 +34,6 @@
 #ifndef __METADATA_HANDLER_H__
 #define __METADATA_HANDLER_H__
 
-#include <set>
-
 #include "common.h"
 #include "context.h"
 #include "util/grb_fs.h"
@@ -57,11 +55,13 @@ protected:
     std::shared_ptr<Mime> mime;
 
 public:
-    explicit MetadataHandler(const std::shared_ptr<Context>& context);
-    virtual ~MetadataHandler() = default;
+    explicit MetadataHandler(const std::shared_ptr<Context>& context)
+    : config(context->getConfig())
+    , mime(context->getMime())
+    {
+    }
 
-    static void extractMetaData(const std::shared_ptr<Context>& context, const std::shared_ptr<ContentManager>& content, const std::shared_ptr<CdsItem>& item, const fs::directory_entry& dirEnt);
-    static std::unique_ptr<MetadataHandler> createHandler(const std::shared_ptr<Context>& context, const std::shared_ptr<ContentManager>& content, ContentHandler handlerType);
+    virtual ~MetadataHandler() = default;
 
     /// \brief read metadata from file and add to object
     /// \param obj Object to handle
@@ -72,7 +72,7 @@ public:
     /// \param resource the resource
     /// \return iohandler to stream to client
     virtual std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsResource>& resource) = 0;
-    virtual std::string getMimeType() const;
+    virtual std::string getMimeType() const { return MIMETYPE_DEFAULT; }
 };
 
 #endif // __METADATA_HANDLER_H__

--- a/src/metadata/metadata_service.h
+++ b/src/metadata/metadata_service.h
@@ -1,0 +1,72 @@
+/*GRB*
+
+Gerbera - https://gerbera.io/
+
+    metadata_service.h - this file is part of Gerbera.
+
+    Copyright (C) 2024 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/// \file metadata_service.h
+/// \brief Definition of the MetadataService class.
+#ifndef __METADATA_SERVICE_H__
+#define __METADATA_SERVICE_H__
+
+#include <map>
+
+#include "common.h"
+#include "util/grb_fs.h"
+
+// forward declaration
+class CdsItem;
+class Config;
+class ContentManager;
+class Context;
+enum class ContentHandler;
+class MetadataHandler;
+
+enum class MetadataType {
+    TagLib,
+    Exiv2,
+    LibExif,
+    Matroska,
+    WavPack,
+    Ffmpeg,
+    Thumbnailer,
+    VideoThumbnailer,
+    ImageThumbnailer,
+    FanArt,
+    ContainerArt,
+    Subtitle,
+    Metafile,
+    ResourceFile,
+};
+
+class MetadataService {
+private:
+    std::shared_ptr<Context> context;
+    std::shared_ptr<Config> config;
+    std::shared_ptr<ContentManager> content;
+    std::map<std::string, std::string> mappings;
+    std::map<MetadataType, std::shared_ptr<MetadataHandler>> handlers;
+
+public:
+    explicit MetadataService(const std::shared_ptr<Context>& context, const std::shared_ptr<ContentManager>& content);
+
+    void extractMetaData(const std::shared_ptr<CdsItem>& item, const fs::directory_entry& dirEnt);
+    std::shared_ptr<MetadataHandler> getHandler(ContentHandler handlerType);
+};
+
+#endif // __METADATA_HANDLER_H__


### PR DESCRIPTION
Use fixed instances instead of recreating for each scanned item.

(Should significantly improve import speed.)