### PR TITLE
Cleanup FileRequestHandler

### DIFF
--- a/src/file_request_handler.cc
+++ b/src/file_request_handler.cc
@@ -55,9 +55,9 @@
 #include "util/url_utils.h"
 #include "web/session_manager.h"
 
-FileRequestHandler::FileRequestHandler(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder)
+FileRequestHandler::FileRequestHandler(const std::shared_ptr<ContentManager>& content, const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder, std::shared_ptr<MetadataService> metadataService)
     : RequestHandler(content, xmlBuilder)
-    , metadataService(std::make_shared<MetadataService>(content->getContext(), content))
+    , metadataService(std::move(metadataService))
 {
 }
 

--- a/src/file_request_handler.h
+++ b/src/file_request_handler.h
@@ -47,7 +47,7 @@ class MetadataService;
 class FileRequestHandler : public RequestHandler {
 
 public:
-    explicit FileRequestHandler(const std::shared_ptr<ContentManager>& content, std::shared_ptr<UpnpXMLBuilder> xmlBuilder);
+    explicit FileRequestHandler(const std::shared_ptr<ContentManager>& content, const std::shared_ptr<UpnpXMLBuilder>& xmlBuilder, std::shared_ptr<MetadataService> metadataService);
 
     void getInfo(const char* filename, UpnpFileInfo* info) override;
     std::unique_ptr<IOHandler> open(const char* filename, enum UpnpOpenFileMode mode) override;

--- a/src/server.h
+++ b/src/server.h
@@ -45,6 +45,7 @@ class ConnectionManagerService;
 class ContentDirectoryService;
 class ContentManager;
 class Context;
+class MetadataService;
 class MRRegistrarService;
 class RequestHandler;
 class SubscriptionRequest;
@@ -92,11 +93,12 @@ protected:
     std::shared_ptr<ClientManager> clientManager;
     std::shared_ptr<Mime> mime;
     std::shared_ptr<Database> database;
-    std::shared_ptr<Web::SessionManager> session_manager;
+    std::shared_ptr<Web::SessionManager> sessionManager;
     std::shared_ptr<Context> context;
 
     std::shared_ptr<Timer> timer;
     std::shared_ptr<ContentManager> content;
+    std::shared_ptr<MetadataService> metadataService;
 
     std::string ip;
     in_port_t port {};


### PR DESCRIPTION
avoid creating MetadataService each time
avoid copying XmlBuilder twice