### PR TITLE
CI: Drop excluded ubuntu versions as CMake PPA now supports those com…

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -14,13 +14,6 @@ jobs:
       matrix:
         os-ver: ["ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "ubuntu:23.10", "debian:stable", "debian:testing", "debian:unstable"]
         arch: ["linux/amd64", "linux/arm/v7", "linux/arm64/v8"]
-        exclude:
-          - os-ver: "ubuntu:18.04" # No Cmake backport for these versions
-            arch: linux/arm/v7
-          - os-ver: "ubuntu:18.04"
-            arch: linux/arm64/v8
-          - os-ver: "ubuntu:20.04" # CMake PPA broken: https://gitlab.kitware.com/cmake/cmake/-/issues/22683
-            arch: linux/arm/v7
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
…binations

Apparently fixed for a year now... https://gitlab.kitware.com/cmake/cmake/-/issues/22683#note_1264849