### PR TITLE
CI: Upload debs to pkg.gerbera.io

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -35,7 +35,11 @@ jobs:
           docker run \
             --platform=${{ matrix.arch }} \
             -e TZ=Etc/UTC \
-            -e ART_API_KEY=${{ secrets.ART_API_KEY }} \
+            -e DEB_UPLOAD_ACCESS_KEY_ID=${{ secrets.DEB_UPLOAD_ACCESS_KEY_ID }} \
+            -e DEB_UPLOAD_ENDPOINT=${{ secrets.DEB_UPLOAD_ENDPOINT }} \
+            -e DEB_UPLOAD_SECRET_ACCESS_KEY=${{ secrets.DEB_UPLOAD_SECRET_ACCESS_KEY }} \
+            -e PKG_SIGNING_KEY=${{ secrets.PKG_SIGNING_KEY }} \
+            -e PKG_SIGNING_KEY_ID=${{ secrets.PKG_SIGNING_KEY_ID }} \
             -e GH_ACTIONS=y \
             -v "$(pwd):/build" \
             -w /build \


### PR DESCRIPTION
Upload to s3 compatible storage with endpoint at pkg.gerbera.io

Will need to update docs once everything is confirmed to work OK.

Tested locally and its fine.

Script changes are to move the dep installs into the conditional, to avoid rebuilding everytime I was trying an upload.