### PR TITLE
Fix build against fmt 10.2.2

### DIFF
--- a/src/database/sql_format.h
+++ b/src/database/sql_format.h
@@ -26,6 +26,9 @@
 #define __SQL_FORMAT_H__
 
 #include <fmt/format.h>
+#if FMT_VERSION >= 100202
+#include <fmt/ranges.h>
+#endif
 
 struct SQLIdentifier {
     SQLIdentifier(std::string name, char quote_begin, char quote_end)

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -39,6 +39,9 @@
 #include <map>
 #include <spdlog/spdlog.h>
 #include <type_traits>
+#if FMT_VERSION >= 100202
+#include <fmt/ranges.h>
+#endif
 
 #define log_debug SPDLOG_TRACE
 #define log_dbg SPDLOG_TRACE


### PR DESCRIPTION
git/src/config/client_config.cc:234:35:
error: 'join' is not a member of 'fmt'
|   234 |     return fmt::format("{}", fmt::join(myFlags, " | "));

https://github.com/fmtlib/fmt/commit/50565f9853926501bd1c9bda07c6a98f4d940691