### PR TITLE
Fix build against fmt 10.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ sudo make install
 | libiconv            |             |             |               | Required      | Charset conversion         |          |
 | sqlite3             | 3.7.0       | 3.35.5      | 3.36.0        | Required      | Database storage           |          |
 | zlib                |             |             |               | Required      | Data compression           |          |
-| [fmtlib]            | 7.1.3       | 9.1.0       | 10.2.1        | Required      | Fast string formatting     |          |
+| [fmtlib]            | 7.1.3       | 9.1.0       | 10.2.2        | Required      | Fast string formatting     |          |
 | [spdlog]            | 1.8.1       | 1.11.0      | 1.14.1        | Required      | Runtime logging            |          |
 | [duktape]           | 2.1.0       | 2.6.0       | 2.7.0         | Optional      | Scripting Support          | Enabled  |
 | mysql               |             |             |               | Optional      | Alternate database storage | Disabled |

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -58,7 +58,7 @@ else
     EBML="1.4.5"
     EXIV2="v0.28.2"
     FFMPEGTHUMBNAILER="2.2.2"
-    FMT="10.2.1"
+    FMT="10.2.2"
     GOOGLETEST="1.14.0"
     LASTFM="0.4.0"
     MATROSKA="1.7.1"

--- a/src/database/sql_format.h
+++ b/src/database/sql_format.h
@@ -26,6 +26,9 @@
 #define __SQL_FORMAT_H__
 
 #include <fmt/format.h>
+#if FMT_VERSION >= 100202
+#include <fmt/ranges.h>
+#endif
 
 struct SQLIdentifier {
     SQLIdentifier(std::string name, char quote_begin, char quote_end)

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -39,6 +39,9 @@
 #include <map>
 #include <spdlog/spdlog.h>
 #include <type_traits>
+#if FMT_VERSION >= 100202
+#include <fmt/ranges.h>
+#endif
 
 #define log_debug SPDLOG_TRACE
 #define log_dbg SPDLOG_TRACE


### PR DESCRIPTION
git/src/config/client_config.cc:234:35:
error: 'join' is not a member of 'fmt'
|   234 |     return fmt::format("{}", fmt::join(myFlags, " | "));

https://github.com/fmtlib/fmt/commit/50565f9853926501bd1c9bda07c6a98f4d940691