### PR TITLE
Libexif: add custom logger

### DIFF
--- a/doc/config-server.rst
+++ b/doc/config-server.rst
@@ -27,7 +27,7 @@ This section defines the server configuration parameters.
 
       Activate debugging messages only for certain subsystems. The following subsystems are available:
       ``thread``, ``sqlite3``, ``cds``, ``server``, ``content``, ``update``, ``mysql``, ``sqldatabase``, ``proc``, ``autoscan``, ``script``, ``web``, ``layout``,
-      ``exif``, ``transcoding``, ``taglib``, ``ffmpeg``, ``wavpack``, ``requests``, ``connmgr``, ``mrregistrar``, ``xml``, ``clients``, ``iohandler``, ``online``,
+      ``exif``, ``exiv2``, ``transcoding``, ``taglib``, ``ffmpeg``, ``wavpack``, ``requests``, ``connmgr``, ``mrregistrar``, ``xml``, ``clients``, ``iohandler``, ``online``,
       ``metadata``, ``matroska``.
       Multiple subsystems can be combined with a ``|``. Names are not case sensitive. This is for developers and testers mostly and has to be activted in cmake 
       options at compile time (``-DWITH_DEBUG_OPTIONS=YES``).

--- a/src/metadata/exiv2_handler.cc
+++ b/src/metadata/exiv2_handler.cc
@@ -32,7 +32,7 @@
 /// \file exiv2_handler.cc
 
 #ifdef HAVE_EXIV2
-#define LOG_FAC log_facility_t::exif
+#define LOG_FAC log_facility_t::exiv2
 #include "exiv2_handler.h" // API
 
 #include <exiv2/exiv2.hpp>

--- a/src/metadata/libexif_handler.h
+++ b/src/metadata/libexif_handler.h
@@ -49,12 +49,15 @@ class StringConverter;
 /// libexif library
 class LibExifHandler : public MediaMetadataHandler {
 private:
+    ExifLog* log = nullptr;
+
     void process_ifd(const ExifContent* content, const std::shared_ptr<CdsItem>& item, const std::unique_ptr<StringConverter>& sc,
         std::string& imageX, std::string& imageY,
         const std::vector<std::string>& auxtags, const std::map<std::string, std::string>& metatags);
 
 public:
     explicit LibExifHandler(const std::shared_ptr<Context>& context);
+    ~LibExifHandler();
     void fillMetadata(const std::shared_ptr<CdsObject>& obj) override;
     std::unique_ptr<IOHandler> serveContent(const std::shared_ptr<CdsObject>& obj, const std::shared_ptr<CdsResource>& resource) override;
 };

--- a/src/util/logger.cc
+++ b/src/util/logger.cc
@@ -105,6 +105,7 @@ std::map<log_facility_t, std::string_view> GrbLogger::facilities = {
     { log_facility_t::web, "Web" },
     { log_facility_t::layout, "Layout" },
     { log_facility_t::exif, "Exif" },
+    { log_facility_t::exiv2, "Exiv2" },
     { log_facility_t::transcoding, "Transcoding" },
     { log_facility_t::taglib, "Taglib" },
     { log_facility_t::ffmpeg, "FFMpeg" },

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -62,6 +62,7 @@ enum class log_facility_t {
     web,
     layout,
     exif,
+    exiv2,
     transcoding,
     taglib,
     ffmpeg,


### PR DESCRIPTION
Integrate LibExif messages in gerbera log instead of hiding them from the user.