### PR TITLE
Fix crashes on freebsd 14.1

### DIFF
--- a/src/content/import_service.cc
+++ b/src/content/import_service.cc
@@ -378,7 +378,7 @@ bool ImportService::isHiddenFile(const fs::path& entryPath, bool isDirectory, co
     if (!noMediaName.empty()) {
         auto noMediaFile = (isDirectory) ? entryPath / noMediaName : entryPath.parent_path() / noMediaName;
         if (contentStateCache.find(noMediaFile) != contentStateCache.end()) {
-            return contentStateCache[entryPath]->getState() != ImportState::Broken; // broken means: file not found
+            return contentStateCache[noMediaFile]->getState() != ImportState::Broken; // broken means: file not found
         }
         auto noMediaEntry = fs::directory_entry(noMediaFile, ec);
         if (!noMediaEntry.exists(ec) || ec) {

--- a/src/content/inotify/autoscan_inotify.cc
+++ b/src/content/inotify/autoscan_inotify.cc
@@ -264,8 +264,9 @@ int AutoscanInotify::watchPathForMoves(const fs::path& path, int wd, unsigned in
 {
     int parentWd = INOTIFY_ROOT;
 
+    fs::path parent = path.parent_path();
     fs::path watchPath;
-    for (auto it = path.begin(); it != std::prev(path.end()); ++it) {
+    for (auto it = parent.begin(); it != parent.end(); ++it) {
         watchPath /= *it;
         log_debug("adding move watch: {}", watchPath.c_str());
         parentWd = addMoveWatch(watchPath, wd, parentWd, retryCount);

--- a/src/util/grb_fs.cc
+++ b/src/util/grb_fs.cc
@@ -293,13 +293,7 @@ bool isTheora(const fs::path& oggFilename)
 
 fs::path getLastPath(const fs::path& path)
 {
-    auto it = std::prev(path.end()); // filename
-    if (it != path.end())
-        it = std::prev(it); // last path
-    if (it != path.end())
-        return *it;
-
-    return {};
+    return path.parent_path().filename();
 }
 
 #ifndef HAVE_FFMPEG


### PR DESCRIPTION
These changes fix application crashes on the freebsd 14.1

1. I removed the use of std::prev with std::filesystem::path objects (see llvm/llvm-project#55521)
2. Fixed typo (at least it looks like typo) in import code that handles `.nomedia` files

After applying these patches I was able to successfully compile and run port of gerbera 2.1.0 on freebsd 14.1 on my NAS, and successfully imported my video folder with recursive flag.