### PR TITLE
Fix config2.xsd

### DIFF
--- a/config/config2.xsd
+++ b/config/config2.xsd
@@ -1180,10 +1180,7 @@
     <xs:element name="profile">
         <xs:complexType>
             <xs:all>
-                <xs:choice minOccurs="1" maxOccurs="1">
-                        <xs:element name="mimetype" type="xs:string"/>
-                        <xs:element ref="mimetype"/>
-                </xs:choice>
+                <xs:element ref="mimetype"/>
                 <xs:element ref="dlna-profile" minOccurs="0"/>
                 <xs:element ref="accept-url" minOccurs="0"/>
                 <xs:element ref="first-resource" minOccurs="0"/>
@@ -1192,7 +1189,7 @@
                 <xs:element ref="agent"/>
                 <xs:element ref="buffer"/>
                 <xs:element ref="sample-frequency" minOccurs="0"/>
-                <xs:element name="audio-channels"/>
+                <xs:element name="audio-channels" minOccurs="0"/>
                 <xs:element ref="resolution" minOccurs="0"/>
                 <xs:element ref="thumbnail" minOccurs="0"/>
             </xs:all>
@@ -1211,11 +1208,11 @@
 
     <xs:element name="dlna-profile" type="xs:string"/>
     <xs:element name="mimetype">
-        <xs:complexType>
+        <xs:complexType mixed="true">
             <xs:sequence>
                 <xs:element ref="mime-property" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
-            <xs:attribute name="value" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="mime-property">

--- a/config/config2.xsd
+++ b/config/config2.xsd
@@ -1192,6 +1192,7 @@
                 <xs:element ref="agent"/>
                 <xs:element ref="buffer"/>
                 <xs:element ref="sample-frequency" minOccurs="0"/>
+                <xs:element name="audio-channels"/>
                 <xs:element ref="resolution" minOccurs="0"/>
                 <xs:element ref="thumbnail" minOccurs="0"/>
             </xs:all>


### PR DESCRIPTION
I got an error:

```
$ xmllint --noout --schema config/config2.xsd test/config/fixtures/mock-config-all.xml config/config2.xsd:1183: element choice: Schemas parser error :
 Element '{http://www.w3.org/2001/XMLSchema}all': The content is not valid.
 Expected is (annotation?, (annotation?, element*).
WXS schema config/config2.xsd failed to compile
```

Maybe github actions should automatically validate the xsd files so that such errors are found.