### PR TITLE
Drop Build Support for Ubuntu 23.10

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -24,7 +24,6 @@ jobs:
           - "ubuntu:20.04"
           - "ubuntu:22.04"
           - "ubuntu:23.04"
-          - "ubuntu:23.10"
           - "ubuntu:24.04"
           - "ubuntu:24.10"
           - "debian:oldstable"


### PR DESCRIPTION
System packages are no longer available