### PR TITLE
Drop Build Support for Ubuntu 23.04

### DIFF
--- a/.github/workflows/publish-deb.yml
+++ b/.github/workflows/publish-deb.yml
@@ -23,7 +23,6 @@ jobs:
           - "ubuntu:18.04"
           - "ubuntu:20.04"
           - "ubuntu:22.04"
-          - "ubuntu:23.04"
           - "ubuntu:24.04"
           - "ubuntu:24.10"
           - "debian:oldstable"


### PR DESCRIPTION
Installation sources are gone now