### PR TITLE
Test: Fix CMake commands

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@
 - Improve handling multivalue tags in virtual paths
 - Increase size of pupnp threadpool
 - Resource directory configuration and cleanup collection
+- Test: Fix CMake commands
 - Update Build Environment
 - Update js vendor files
 - UPnP: Add support for filters

--- a/cmake/GenCompileInfo.cmake
+++ b/cmake/GenCompileInfo.cmake
@@ -1,10 +1,31 @@
+#*GRB*
 #
+#  Gerbera - https://gerbera.io/
+#
+#  GenCompileInfo.cmake - this file is part of Gerbera.
+#
+#  Copyright (C) 2016-2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
 # Generate the list of compile options
 # used to compile Gerbera
 #
 # Identify the Git branch and revision
 # if the directory has .git/ folder
-#
+
 function(generate_compile_info)
     set(COMPILE_INFO_LIST
             "WITH_NPUPNP=${WITH_NPUPNP}"

--- a/cmake/generateDoc.cmake
+++ b/cmake/generateDoc.cmake
@@ -1,9 +1,29 @@
-# generateDoc.cmake
-# -helper macro to add a "doc" target with CMake build system.
+#*GRB*
+#
+#  Gerbera - https://gerbera.io/
+#
+#  generateDoc.cmake - this file is part of Gerbera.
+#
+#  Copyright (C) 2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
+# helper macro to add a "doc" target with CMake build system.
 # and configure doxy.config.in to doxy.config
 #
 # target "doc" allows building the documentation with doxygen/dot on Linux and Mac
-#
 
 find_package(Doxygen REQUIRED dot)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,3 +1,25 @@
+#*GRB*
+#
+#  Gerbera - https://gerbera.io/
+#
+#  CMakeLists.txt - this file is part of Gerbera.
+#
+#  Copyright (C) 2016-2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
 find_package(GTest REQUIRED)
 
 # CMake can't fix gmock support. https://gitlab.kitware.com/cmake/cmake/-/issues/17365

--- a/test/config/CMakeLists.txt
+++ b/test/config/CMakeLists.txt
@@ -1,3 +1,25 @@
+#*GRB*
+#
+#  Gerbera - https://gerbera.io/
+#
+#  CMakeLists.txt - this file is part of Gerbera.
+#
+#  Copyright (C) 2016-2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
 add_executable(testconfig
     main.cc
     test_configgenerator.cc
@@ -16,13 +38,19 @@ else()
     )
 endif()
 
-add_custom_command(TARGET testconfig POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
-    DEPENDS fixtures/*
-    COMMENT "Copying Config Fixtures"
-)
 target_compile_definitions(testconfig PRIVATE CMAKE_BINARY_DIR="${CMAKE_BINARY_DIR}")
-add_dependencies(testconfig gerbera)
+add_dependencies(testconfig libgerbera gerbera)
 
 include(GoogleTest)
-gtest_discover_tests(testconfig DISCOVERY_TIMEOUT 60)
+
+gtest_discover_tests(testconfig DISCOVERY_TIMEOUT 60 TEST_LIST GRB_CONFIG_TESTS)
+
+add_test(NAME configFixtures
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
+    # DEPENDS fixtures/*
+)
+set_tests_properties(configFixtures PROPERTIES FIXTURES_SETUP GrbConfig)
+
+set_property(DIRECTORY APPEND PROPERTY
+    TEST_INCLUDE_FILES ${CMAKE_CURRENT_LIST_DIR}/CTestManip.cmake
+)

--- a/test/config/CTestManip.cmake
+++ b/test/config/CTestManip.cmake
@@ -2,9 +2,9 @@
 #
 #  Gerbera - https://gerbera.io/
 #
-#  CMakeLists.txt - this file is part of Gerbera.
+#  CTestManip.cmake - this file is part of Gerbera.
 #
-#  Copyright (C) 2016-2024 Gerbera Contributors
+#  Copyright (C) 2024 Gerbera Contributors
 #
 #  Gerbera is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License version 2
@@ -20,24 +20,5 @@
 #
 #  $Id$
 
-add_executable(testcontent
-    main.cc
-    test_autoscan_list.cc
-    test_resolution.cc
-)
-
-if (NOT TARGET GTest::gmock)
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::GTest
-    )
-else()
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::gmock
-    )
-endif()
-add_dependencies(testcontent libgerbera gerbera)
-
-include(GoogleTest)
-gtest_discover_tests(testcontent DISCOVERY_TIMEOUT 60)
+set_tests_properties(${GRB_CONFIG_TESTS} PROPERTIES FIXTURES_REQUIRED GrbConfig)
+MESSAGE("Copying Config Fixtures")

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -1,3 +1,25 @@
+#*GRB*
+#
+#  Gerbera - https://gerbera.io/
+#
+#  CMakeLists.txt - this file is part of Gerbera.
+#
+#  Copyright (C) 2016-2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
 include(GoogleTest)
 generate_compile_info()
 
@@ -22,15 +44,20 @@ else()
     )
 endif()
 
-add_custom_command(TARGET testcore POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
-        DEPENDS fixtures/*
-        COMMENT "Copying Core Fixtures"
-)
 target_compile_definitions(testcore PRIVATE CMAKE_BINARY_DIR="$<TARGET_FILE_DIR:gerbera>")
 target_compile_definitions(testcore PRIVATE COMPILE_INFO="${COMPILE_INFO}")
 target_compile_definitions(testcore PRIVATE GIT_BRANCH="${GIT_BRANCH}")
 target_compile_definitions(testcore PRIVATE GIT_COMMIT_HASH="${GIT_COMMIT_HASH}")
+add_dependencies(testcore libgerbera gerbera)
 
-include(GoogleTest)
-gtest_discover_tests(testcore DISCOVERY_TIMEOUT 60)
+gtest_discover_tests(testcore DISCOVERY_TIMEOUT 60 TEST_LIST GRB_CORE_TESTS)
+
+add_test(NAME coreFixtures
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
+    # DEPENDS fixtures/*
+)
+set_tests_properties(coreFixtures PROPERTIES FIXTURES_SETUP GrbCore)
+
+set_property(DIRECTORY APPEND PROPERTY
+    TEST_INCLUDE_FILES ${CMAKE_CURRENT_LIST_DIR}/CTestManip.cmake
+)

--- a/test/core/CTestManip.cmake
+++ b/test/core/CTestManip.cmake
@@ -2,9 +2,9 @@
 #
 #  Gerbera - https://gerbera.io/
 #
-#  CMakeLists.txt - this file is part of Gerbera.
+#  CTestManip.cmake - this file is part of Gerbera.
 #
-#  Copyright (C) 2016-2024 Gerbera Contributors
+#  Copyright (C) 2024 Gerbera Contributors
 #
 #  Gerbera is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License version 2
@@ -20,24 +20,5 @@
 #
 #  $Id$
 
-add_executable(testcontent
-    main.cc
-    test_autoscan_list.cc
-    test_resolution.cc
-)
-
-if (NOT TARGET GTest::gmock)
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::GTest
-    )
-else()
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::gmock
-    )
-endif()
-add_dependencies(testcontent libgerbera gerbera)
-
-include(GoogleTest)
-gtest_discover_tests(testcontent DISCOVERY_TIMEOUT 60)
+set_tests_properties(${GRB_CORE_TESTS} PROPERTIES FIXTURES_REQUIRED GrbCore)
+MESSAGE("Copying Core Fixtures")

--- a/test/database/CMakeLists.txt
+++ b/test/database/CMakeLists.txt
@@ -1,17 +1,31 @@
+#*GRB*
+#
+#  Gerbera - https://gerbera.io/
+#
+#  CMakeLists.txt - this file is part of Gerbera.
+#
+#  Copyright (C) 2016-2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
 add_executable(testdb
     main.cc
     test_database.cc
     test_sql_generators.cc
     mysql_config_fake.h
     sqlite_config_fake.h)
-
-add_custom_command(TARGET testdb POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/sqlite3/sqlite3.sql ${CMAKE_CURRENT_BINARY_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/sqlite3/sqlite3-upgrade.xml ${CMAKE_CURRENT_BINARY_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/mysql/mysql.sql ${CMAKE_CURRENT_BINARY_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/mysql/mysql-upgrade.xml ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Copying Database Scripts"
-)
 
 if (NOT TARGET GTest::gmock)
     target_link_libraries(testdb PRIVATE
@@ -24,6 +38,29 @@ else()
         GTest::gmock
     )
 endif()
+add_dependencies(testdb libgerbera gerbera)
 
 include(GoogleTest)
-gtest_discover_tests(testdb DISCOVERY_TIMEOUT 60)
+gtest_discover_tests(testdb DISCOVERY_TIMEOUT 60 TEST_LIST GRB_DB_TESTS)
+
+add_test(NAME dbFixturesSqLite
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/sqlite3/sqlite3.sql ${CMAKE_CURRENT_BINARY_DIR}
+    # DEPENDS fixtures/*
+)
+add_test(NAME dbFixturesSqliteUpgrade
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/sqlite3/sqlite3-upgrade.xml ${CMAKE_CURRENT_BINARY_DIR}
+    # DEPENDS fixtures/*
+)
+add_test(NAME dbFixturesMySql
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/mysql/mysql.sql ${CMAKE_CURRENT_BINARY_DIR}
+    # DEPENDS fixtures/*
+)
+add_test(NAME dbFixtureMySqlUpgrade
+    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/src/database/mysql/mysql-upgrade.xml ${CMAKE_CURRENT_BINARY_DIR}
+    # DEPENDS fixtures/*
+)
+set_tests_properties(dbFixturesSqLite dbFixturesSqliteUpgrade dbFixturesMySql dbFixtureMySqlUpgrade PROPERTIES FIXTURES_SETUP GrbDb)
+
+set_property(DIRECTORY APPEND PROPERTY
+    TEST_INCLUDE_FILES ${CMAKE_CURRENT_LIST_DIR}/CTestManip.cmake
+)

--- a/test/database/CTestManip.cmake
+++ b/test/database/CTestManip.cmake
@@ -2,9 +2,9 @@
 #
 #  Gerbera - https://gerbera.io/
 #
-#  CMakeLists.txt - this file is part of Gerbera.
+#  CTestManip.cmake - this file is part of Gerbera.
 #
-#  Copyright (C) 2016-2024 Gerbera Contributors
+#  Copyright (C) 2024 Gerbera Contributors
 #
 #  Gerbera is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License version 2
@@ -20,24 +20,5 @@
 #
 #  $Id$
 
-add_executable(testcontent
-    main.cc
-    test_autoscan_list.cc
-    test_resolution.cc
-)
-
-if (NOT TARGET GTest::gmock)
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::GTest
-    )
-else()
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::gmock
-    )
-endif()
-add_dependencies(testcontent libgerbera gerbera)
-
-include(GoogleTest)
-gtest_discover_tests(testcontent DISCOVERY_TIMEOUT 60)
+set_tests_properties(${GRB_DB_TESTS} PROPERTIES FIXTURES_REQUIRED GrbDb)
+MESSAGE("Copying Database Scripts")

--- a/test/scripting/CMakeLists.txt
+++ b/test/scripting/CMakeLists.txt
@@ -1,3 +1,25 @@
+#*GRB*
+#
+#  Gerbera - https://gerbera.io/
+#
+#  CMakeLists.txt - this file is part of Gerbera.
+#
+#  Copyright (C) 2016-2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
 add_executable(testscripting
     main.cc
     mock/duk_helper.h
@@ -30,13 +52,18 @@ else()
     )
 endif()
 
-add_custom_command(TARGET testscripting POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
-    DEPENDS fixtures/*
-    COMMENT "Copying Scripting Fixtures"
-)
 target_compile_definitions(testscripting PRIVATE SCRIPTS_DIR="${CMAKE_SOURCE_DIR}/scripts")
+add_dependencies(testscripting libgerbera gerbera)
 
 include(GoogleTest)
-gtest_discover_tests(testscripting DISCOVERY_TIMEOUT 60)
+gtest_discover_tests(testscripting DISCOVERY_TIMEOUT 60 TEST_LIST GRB_SCRIPTING_TESTS)
 
+add_test(NAME scriptingFixtures
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/fixtures ${CMAKE_CURRENT_BINARY_DIR}/fixtures
+    # DEPENDS fixtures/*
+)
+set_tests_properties(scriptingFixtures PROPERTIES FIXTURES_SETUP GrbScripting)
+
+set_property(DIRECTORY APPEND PROPERTY
+    TEST_INCLUDE_FILES ${CMAKE_CURRENT_LIST_DIR}/CTestManip.cmake
+)

--- a/test/scripting/CTestManip.cmake
+++ b/test/scripting/CTestManip.cmake
@@ -2,9 +2,9 @@
 #
 #  Gerbera - https://gerbera.io/
 #
-#  CMakeLists.txt - this file is part of Gerbera.
+#  CTestManip.cmake - this file is part of Gerbera.
 #
-#  Copyright (C) 2016-2024 Gerbera Contributors
+#  Copyright (C) 2024 Gerbera Contributors
 #
 #  Gerbera is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License version 2
@@ -20,24 +20,5 @@
 #
 #  $Id$
 
-add_executable(testcontent
-    main.cc
-    test_autoscan_list.cc
-    test_resolution.cc
-)
-
-if (NOT TARGET GTest::gmock)
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::GTest
-    )
-else()
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::gmock
-    )
-endif()
-add_dependencies(testcontent libgerbera gerbera)
-
-include(GoogleTest)
-gtest_discover_tests(testcontent DISCOVERY_TIMEOUT 60)
+set_tests_properties(${GRB_SCRIPTING_TESTS} PROPERTIES FIXTURES_REQUIRED GrbScripting)
+MESSAGE("Copying Scripting Fixtures")

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -1,3 +1,25 @@
+#*GRB*
+#
+#  Gerbera - https://gerbera.io/
+#
+#  CMakeLists.txt - this file is part of Gerbera.
+#
+#  Copyright (C) 2016-2024 Gerbera Contributors
+#
+#  Gerbera is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License version 2
+#  as published by the Free Software Foundation.
+#
+#  Gerbera is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Gerbera.  If not, see <http://www.gnu.org/licenses/>.
+#
+#  $Id$
+
 add_executable(testutil
     main.cc
     test_tools.cc
@@ -18,11 +40,17 @@ else()
     )
 endif()
 
-add_custom_command(TARGET testutil POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/testdata ${CMAKE_CURRENT_BINARY_DIR}/testdata
-        DEPENDS testdata/*
-        COMMENT "Copying Util Test Data"
-        )
+add_dependencies(testutil libgerbera gerbera)
 
 include(GoogleTest)
-gtest_discover_tests(testutil DISCOVERY_TIMEOUT 60)
+gtest_discover_tests(testutil DISCOVERY_TIMEOUT 60 TEST_LIST GRB_UTIL_TESTS)
+
+add_test(NAME utilFixtures
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/testdata ${CMAKE_CURRENT_BINARY_DIR}/testdata
+    # DEPENDS testdata/*
+)
+set_tests_properties(utilFixtures PROPERTIES FIXTURES_SETUP GrbUtil)
+
+set_property(DIRECTORY APPEND PROPERTY
+    TEST_INCLUDE_FILES ${CMAKE_CURRENT_LIST_DIR}/CTestManip.cmake
+)

--- a/test/util/CTestManip.cmake
+++ b/test/util/CTestManip.cmake
@@ -2,9 +2,9 @@
 #
 #  Gerbera - https://gerbera.io/
 #
-#  CMakeLists.txt - this file is part of Gerbera.
+#  CTestManip.cmake - this file is part of Gerbera.
 #
-#  Copyright (C) 2016-2024 Gerbera Contributors
+#  Copyright (C) 2024 Gerbera Contributors
 #
 #  Gerbera is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License version 2
@@ -20,24 +20,5 @@
 #
 #  $Id$
 
-add_executable(testcontent
-    main.cc
-    test_autoscan_list.cc
-    test_resolution.cc
-)
-
-if (NOT TARGET GTest::gmock)
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::GTest
-    )
-else()
-    target_link_libraries(testcontent PRIVATE
-        libgerbera
-        GTest::gmock
-    )
-endif()
-add_dependencies(testcontent libgerbera gerbera)
-
-include(GoogleTest)
-gtest_discover_tests(testcontent DISCOVERY_TIMEOUT 60)
+set_tests_properties(${GRB_UTIL_TESTS} PROPERTIES FIXTURES_REQUIRED GrbUtil)
+MESSAGE("Copying Util Test Data")


### PR DESCRIPTION
DEPENDS is not supported in custom command:
https://cmake.org/cmake/help/latest/policy/CMP0175.html#policy:CMP0175

Fixtures are copies with each test now: Makes fixing fixtures a lot faster.

Message is not printed with the test but in the beginning.