### PR TITLE
Fix to issue #3063 - Some Virtual Albums are Missing Cover Art

### DIFF
--- a/src/content/import_service.cc
+++ b/src/content/import_service.cc
@@ -825,6 +825,10 @@ void ImportService::assignFanArt(
     }
 
     auto fanart = container->getResource(ResourcePurpose::Thumbnail);
+    // Ignore if the fanart's FanArtObject is not set
+    if (fanart && stoiString(fanart->getAttribute(ResourceAttribute::FANART_OBJ_ID)) <= CDS_ID_ROOT)
+        fanart = nullptr;
+
     if (fanart && fanart->getHandlerType() != ContentHandler::CONTAINERART) {
         // remove stale references
         auto fanartObjId = stoiString(fanart->getAttribute(ResourceAttribute::FANART_OBJ_ID));
@@ -848,7 +852,11 @@ void ImportService::assignFanArt(
         metadataService->getHandler(ContentHandler::CONTAINERART)->fillMetadata(container);
         auto containerart = container->getResource(ResourcePurpose::Thumbnail);
         if (containerart) {
-            fanart = containerart;
+            // Ignore if the fanart's FanArtObject is not set
+            if (stoiString(containerart->getAttribute(ResourceAttribute::FANART_OBJ_ID)) > CDS_ID_ROOT)
+                fanart = containerart;
+            else
+                containerart = nullptr;
         } else if (fanart) {
             container->addResource(fanart); // restore if no image matches
         }
@@ -936,7 +944,7 @@ std::pair<int, bool> ImportService::addContainerTree(
     const std::shared_ptr<CdsObject>& refItem,
     std::vector<int>& createdIds)
 {
-    log_debug("start '{}' {}", rootPath.string(), parentContainerId);
+    log_debug("start '{}' {} - refItem {}", rootPath.string(), parentContainerId, refItem ? refItem->getID() : -1);
     std::string tree; // accumulate path to container here
     int result = parentContainerId;
     bool isNew = false;


### PR DESCRIPTION
Here is a fix to the problem where fanart is missing for multiple albums with the same artist.

I am new to the Gerbera code so maybe there is some complexity that I do not understand. But I'd like to say that the "assignFanArt()" code seems overly complex. There are so many cases to deal with, and I think this mainly stems from the fact that the fanart resource (and other metadata) for each audio file is duplicated in the database for each parent container. I would have thought that "assignFanArt()" should be a simple process - setting the container to point to the fanart resource of the first track's file. But it sometimes points to the virtual track, and sometimes to tracks other than the first one. It's pretty confusing!

Perhaps this needs to be tidied up - I might give it a go when I get a chance.