### PR TITLE
Fix update of playlists

### DIFF
--- a/src/content/inotify/inotify_handler.cc
+++ b/src/content/inotify/inotify_handler.cc
@@ -220,7 +220,7 @@ int InotifyHandler::doExistingFile(const std::shared_ptr<Database>& database, co
             isDir = changedObject->isContainer();
         if ((!AUTOSCAN_IS_WRITTEN(mask) || importMode != ImportMode::Gerbera) && changedObject) {
             log_debug("deleting {}", path.c_str());
-            content->removeObject(adir, changedObject, path, !AUTOSCAN_IS_MOVED(mask));
+            content->removeObject(adir, changedObject, path, !AUTOSCAN_IS_MOVED(mask), false);
             changedObject = nullptr;
         }
     }


### PR DESCRIPTION
Playlist create and updates can fail due to a race of deleting the existing playlist and making a new one. Make the removeObject synchronous to fix the issue.

When a playlist file is updated, AutoscanInotify::threadProc takes the following actions:

InotifyHandler::doExistingFile
- invokes ContentManager:removeObject with the default aysnc = true

InotifyHandlder::doNewFile
- invokes ContentManager:addFile with the asSetting.async argument set to false
- the doImport processs is started
- eventually a SELECT is done for the mt_cds_object entry for the .m3u file
- the async process has not yet deleted this, so the entry is found
- soon after, the mt_cds_object entry for the .m3u file as well as the two V entries that reference the the .m3u file entry are deleted, causing the exception

The next time the playlist file is updated, no entries exist, so only doNewFile is called.
The entry for the playlist is not found, and the appropriate entries are created.

Using InotifyHandler::doExistingFile should run content->removeObject with async set to false will cause the previous instance to be removed before the new one starts to be created.

