### PR TITLE
Fix SQL for changing persistent object flag in database

### DIFF
--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -2877,7 +2877,7 @@ void SQLDatabase::_autoscanChangePersistentFlag(int objectID, bool persistent)
         log_warning("cannot change autoscan to persistent {} with illegal ID", persistent);
         return;
     }
-    exec(fmt::format("UPDATE {0}{2}{1} SET {0}flags{1} = ({0}flags{1} {3}{4}) WHERE {0}obj_id{1} = {5}", table_quote_begin, table_quote_end, CDS_OBJECT_TABLE, (persistent ? " | " : " & ~"), OBJECT_FLAG_PERSISTENT_CONTAINER, objectID));
+    exec(fmt::format("UPDATE {0}{2}{1} SET {0}flags{1} = ({0}flags{1} {3}{4}) WHERE {0}id{1} = {5}", table_quote_begin, table_quote_end, CDS_OBJECT_TABLE, (persistent ? " | " : " & ~"), OBJECT_FLAG_PERSISTENT_CONTAINER, objectID));
 }
 
 void SQLDatabase::checkOverlappingAutoscans(const std::shared_ptr<AutoscanDirectory>& adir)


### PR DESCRIPTION
The current SQL uses an invalid column:
> error (1054): "Unknown column 'obj_id' in 'where clause'";
> query: UPDATE mt_cds_object SET flags = (flags | 8) WHERE obj_id = 4

Since mt_cds_object only has a id column we use that.

Resolves: https://github.com/gerbera/gerbera/issues/3426