### PR TITLE
Changed OpenWRT Installation note

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -172,7 +172,7 @@ OpenWrt (OpenWrt)
 ~~~~~~~~~~~~~~~~~
 .. index:: OpenWrt
 
-Gerbera is available in `OpenWrt <https://github.com/openwrt/packages/tree/master/multimedia/gerbera>`__ for your embedded device/router!
+Gerbera is available in `OpenWrt 22.03 <https://github.com/openwrt/packages/tree/openwrt-22.03/multimedia/gerbera>`__ for your embedded device/router!
 
 
 Buildroot


### PR DESCRIPTION
The link provided was linking to a 404 page. It seems that Gerbera is no longer in versions of OpenWRT since 22.03, which is also noted.