### PR TITLE
Fixing Searchable flag in import script

### DIFF
--- a/scripts/js/audio.js
+++ b/scripts/js/audio.js
@@ -254,7 +254,7 @@ function importAudio(obj, cont, rootPath, autoscanId, containerType) {
       result.push(addCdsObject(obj, container, rootPath));
     }
 
-    chain.genre.searchable = false
+    chain.genre.searchable = false;
   }
 
   if (boxSetup[BK_audioAllYears].enabled) {
@@ -436,6 +436,7 @@ function importAudioStructured(obj, cont, rootPath, autoscanId, containerType) {
   // Artist
   const artCnt = audio.artists.length;
   var i;
+
   // A track may be interpreted by more than one artist 
   for (i = 0; i < artCnt; i++) {
     obj.title = audio.title + ' (' + audio.album + ', ' + audio.date + ')';


### PR DESCRIPTION
We shall ensure that the first time we add the album or artist containers into the DB (independently of it's tree) they are searchable.

Fixes import issues in #3635, however does not fix all other issues mentioned there