### PR TITLE
remove unique_ptr from ProcListItem vector

### DIFF
--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -69,14 +69,14 @@ bool ProcListItem::abortOnDeath() const
 bool ProcessIOHandler::abort() const
 {
     return std::any_of(procList.begin(), procList.end(),
-        [=](auto&& proc) { auto exec = proc->getExecutor();
-            return exec && !exec->isAlive() && proc->abortOnDeath(); });
+        [=](auto&& proc) { auto exec = proc.getExecutor();
+            return exec && !exec->isAlive() && proc.abortOnDeath(); });
 }
 
 void ProcessIOHandler::killAll() const
 {
     for (auto&& i : procList) {
-        auto exec = i->getExecutor();
+        auto exec = i.getExecutor();
         if (exec)
             exec->kill();
     }
@@ -88,7 +88,7 @@ void ProcessIOHandler::registerAll()
         content->registerExecutor(mainProc);
 
     for (auto&& i : procList) {
-        auto exec = i->getExecutor();
+        auto exec = i.getExecutor();
         if (exec)
             content->registerExecutor(exec);
     }
@@ -100,7 +100,7 @@ void ProcessIOHandler::unregisterAll()
         content->unregisterExecutor(mainProc);
 
     for (auto&& i : procList) {
-        auto exec = i->getExecutor();
+        auto exec = i.getExecutor();
         if (exec)
             content->unregisterExecutor(exec);
     }
@@ -109,7 +109,7 @@ void ProcessIOHandler::unregisterAll()
 ProcessIOHandler::ProcessIOHandler(const std::shared_ptr<Content>& content,
     fs::path filename,
     std::shared_ptr<Executor> mainProc,
-    std::vector<std::unique_ptr<ProcListItem>> procList,
+    std::vector<ProcListItem> procList,
     bool ignoreSeek)
     : content(content)
     , procList(std::move(procList))

--- a/src/iohandler/process_io_handler.h
+++ b/src/iohandler/process_io_handler.h
@@ -47,6 +47,13 @@ class Content;
 class ProcListItem {
 public:
     explicit ProcListItem(std::shared_ptr<Executor> exec, bool abortOnDeath = false);
+
+    ~ProcListItem() = default;
+    ProcListItem(const ProcListItem&) = delete;
+    ProcListItem& operator=(const ProcListItem&) = delete;
+    ProcListItem(ProcListItem&&) = default;
+    ProcListItem& operator=(ProcListItem&&) = default;
+
     std::shared_ptr<Executor> getExecutor() const;
     bool abortOnDeath() const;
 
@@ -67,7 +74,7 @@ public:
     /// @param ignoreSeek don't throw exception when seek is called
     ProcessIOHandler(const std::shared_ptr<Content>& content,
         fs::path filename, std::shared_ptr<Executor> mainProc,
-        std::vector<std::unique_ptr<ProcListItem>> procList = {},
+        std::vector<ProcListItem> procList = {},
         bool ignoreSeek = false);
     ~ProcessIOHandler() override;
 
@@ -104,7 +111,7 @@ protected:
     std::shared_ptr<Content> content;
 
     /// @brief List of associated processes.
-    std::vector<std::unique_ptr<ProcListItem>> procList;
+    std::vector<ProcListItem> procList;
 
     /// @brief Main process used for reading
     std::shared_ptr<Executor> mainProc;

--- a/src/transcoding/transcode_ext_handler.cc
+++ b/src/transcoding/transcode_ext_handler.cc
@@ -83,7 +83,7 @@ std::unique_ptr<IOHandler> TranscodeExternalHandler::serveContent(const std::sha
     }
 #endif
 
-    std::vector<std::unique_ptr<ProcListItem>> procList;
+    std::vector<ProcListItem> procList;
     fs::path inLocation = location;
 
     bool isURL = obj->isExternalItem();
@@ -155,7 +155,7 @@ void TranscodeExternalHandler::checkTranscoder(const std::shared_ptr<Transcoding
 }
 
 #ifdef HAVE_CURL
-fs::path TranscodeExternalHandler::openCurlFifo(const fs::path& location, std::vector<std::unique_ptr<ProcListItem>>& procList)
+fs::path TranscodeExternalHandler::openCurlFifo(const fs::path& location, std::vector<ProcListItem>& procList)
 {
     std::string url = location;
     log_debug("creating reader fifo: {}", location.c_str());
@@ -167,7 +167,7 @@ fs::path TranscodeExternalHandler::openCurlFifo(const fs::path& location, std::v
             config->getIntOption(ConfigVal::EXTERNAL_TRANSCODING_CURL_FILL_SIZE));
         auto pIoh = std::make_unique<ProcessIOHandler>(content, ret, nullptr);
         auto ch = std::make_unique<IOHandlerChainer>(std::move(cIoh), std::move(pIoh), 16384);
-        procList.push_back(std::make_unique<ProcListItem>(std::move(ch)));
+        procList.emplace_back(std::move(ch));
     } catch (const std::runtime_error&) {
         unlink(ret.c_str());
         throw;

--- a/src/transcoding/transcode_ext_handler.h
+++ b/src/transcoding/transcode_ext_handler.h
@@ -53,7 +53,7 @@ private:
     fs::path makeFifo();
     static void checkTranscoder(const std::shared_ptr<TranscodingProfile>& profile);
 #ifdef HAVE_CURL
-    fs::path openCurlFifo(const fs::path& location, std::vector<std::unique_ptr<ProcListItem>>& procList);
+    fs::path openCurlFifo(const fs::path& location, std::vector<ProcListItem>& procList);
 #endif
 };
 


### PR DESCRIPTION
Easier to define move only operations for the class.