### PR TITLE
switch xml_document to std::optional

### DIFF
--- a/src/action_request.cc
+++ b/src/action_request.cc
@@ -72,14 +72,14 @@ const std::shared_ptr<Quirks>& ActionRequest::getQuirks() const
     return quirks;
 }
 
-std::unique_ptr<pugi::xml_document> ActionRequest::getRequest() const
+pugi::xml_document ActionRequest::getRequest() const
 {
-    auto request = std::make_unique<pugi::xml_document>();
+    pugi::xml_document request;
 #if defined(USING_NPUPNP)
-    auto ret = request->load_string(upnp_request->xmlAction.c_str());
+    auto ret = request.load_string(upnp_request->xmlAction.c_str());
 #else
     DOMString cxml = ixmlPrintDocument(UpnpActionRequest_get_ActionRequest(upnp_request));
-    auto ret = request->load_string(cxml);
+    auto ret = request.load_string(cxml);
     ixmlFreeDOMString(cxml);
 #endif
 
@@ -89,7 +89,7 @@ std::unique_ptr<pugi::xml_document> ActionRequest::getRequest() const
     return request;
 }
 
-void ActionRequest::setResponse(std::unique_ptr<pugi::xml_document> response)
+void ActionRequest::setResponse(pugi::xml_document response)
 {
     this->response = std::move(response);
 }
@@ -102,7 +102,7 @@ void ActionRequest::setErrorCode(int errCode)
 void ActionRequest::update()
 {
     if (response) {
-        std::string xml = UpnpXMLBuilder::printXml(*response, "", 0);
+        std::string xml = UpnpXMLBuilder::printXml(response, "", 0);
         log_debug("xml: {}", xml);
 
 #if defined(USING_NPUPNP)

--- a/src/action_request.h
+++ b/src/action_request.h
@@ -79,7 +79,7 @@ protected:
     /// @brief XML holding the response, we fill it in.
     ///
     /// Set by setResponse()
-    std::unique_ptr<pugi::xml_document> response;
+    pugi::xml_document response;
 
 public:
     /// @brief The Constructor takes the values from the upnp_request and fills in internal variables.
@@ -99,14 +99,14 @@ public:
     std::string getServiceID() const;
 
     /// @brief Returns the XML representation of the request, that comes to us.
-    std::unique_ptr<pugi::xml_document> getRequest() const;
+    pugi::xml_document getRequest() const;
 
     /// @brief Returns the client quirks
     const std::shared_ptr<Quirks>& getQuirks() const;
 
     /// @brief Sets the response (XML created outside as the answer to the request)
     /// @param response XML holding the action response.
-    void setResponse(std::unique_ptr<pugi::xml_document> response);
+    void setResponse(pugi::xml_document response);
 
     /// @brief Set the error code for the SDK.
     /// @param errCode UPnP error code.

--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -66,6 +66,7 @@ ConfigManager::ConfigManager(
     : definition(std::move(definition))
     , filename(std::move(filename))
     , dataDir(std::move(dataDir))
+    , xmlDoc(std::in_place)
 {
     options = std::vector<std::shared_ptr<ConfigOption>>(to_underlying(ConfigVal::MAX));
     GrbLogger::Logger.setDebugLogging(debug);
@@ -88,6 +89,8 @@ ConfigManager::ConfigManager(
         throw std::runtime_error(expErrMsg.str());
     }
 }
+
+ConfigManager::~ConfigManager() = default;
 
 std::shared_ptr<Config> ConfigManager::getSelf()
 {
@@ -379,7 +382,7 @@ void ConfigManager::load(const fs::path& userHome)
     log_debug("Config file dump after loading: {}", buf.str());
 
     // now the XML is no longer needed we can destroy it
-    xmlDoc = nullptr;
+    xmlDoc.reset();
 }
 
 /// @brief Validate that correlated options have correct values

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -40,6 +40,7 @@
 #include <map>
 #include <memory>
 #include <netinet/in.h>
+#include <optional>
 #include <pugixml.hpp>
 
 // forward declaration
@@ -65,6 +66,8 @@ public:
         const fs::path& configDir,
         fs::path dataDir,
         bool debug);
+
+    ~ConfigManager() override;
 
     /// @brief Returns the name of the config file that was used to launch the server.
     fs::path getConfigFilename() const override { return filename; }
@@ -162,7 +165,7 @@ protected:
     fs::path dataDir;
     fs::path magicFile;
     std::map<std::string, std::string> origValues;
-    std::unique_ptr<pugi::xml_document> xmlDoc { std::make_unique<pugi::xml_document>() };
+    std::optional<pugi::xml_document> xmlDoc;
     std::vector<std::shared_ptr<ConfigOption>> options;
     std::map<std::string, bool> knownNodes;
 

--- a/src/content/onlineservice/curl_online_service.h
+++ b/src/content/onlineservice/curl_online_service.h
@@ -51,7 +51,7 @@ public:
 
     /// @brief Sets the service XML from which we will extract the objects.
     /// @return \c false if service XML contained an error status.
-    virtual void setServiceContent(std::unique_ptr<pugi::xml_document> service) = 0;
+    virtual void setServiceContent(std::optional<pugi::xml_document> service) = 0;
 
     /// @brief retrieves an object from the service.
     ///
@@ -69,7 +69,7 @@ protected:
     std::shared_ptr<Config> config;
     std::shared_ptr<Database> database;
 
-    std::unique_ptr<pugi::xml_document> service_xml;
+    std::optional<pugi::xml_document> service_xml;
 };
 
 /// @brief This is an interface for all online services, the function
@@ -92,7 +92,7 @@ public:
 protected:
     virtual std::unique_ptr<CurlContentHandler> getContentHandler() const = 0;
 
-    std::unique_ptr<pugi::xml_document> getData();
+    std::optional<pugi::xml_document> getData();
 
     // the handle *must never be used from multiple threads*
     CURL* curl_handle;

--- a/src/content/scripting/metafile_parser_script.cc
+++ b/src/content/scripting/metafile_parser_script.cc
@@ -64,9 +64,9 @@ void MetafileParserScript::processObject(const std::shared_ptr<CdsObject>& obj, 
 
     log_debug("Checking metafile {} for {}...", path.string(), obj->getLocation().string());
     GrbFile file(path);
-    pugi::xml_parse_result result = xmlDoc->load_file(path.c_str());
+    pugi::xml_parse_result result = xmlDoc.load_file(path.c_str());
     if (result.status == pugi::xml_parse_status::status_ok) {
-        root = xmlDoc->document_element();
+        root = xmlDoc.document_element();
     }
     currentHandle = file.open("r");
     processed = obj;
@@ -95,7 +95,7 @@ void MetafileParserScript::processObject(const std::shared_ptr<CdsObject>& obj, 
 
     delete[] currentLine;
     currentLine = nullptr;
-    xmlDoc->reset();
+    xmlDoc.reset();
     root = nullNode;
 
     currentObjectID = INVALID_OBJECT_ID;

--- a/src/content/scripting/parser_script.cc
+++ b/src/content/scripting/parser_script.cc
@@ -199,7 +199,7 @@ pugi::xml_node& ParserScript::readXml(int direction)
         return root;
     }
     if (direction < -1 && root.root()) {
-        root = xmlDoc->document_element();
+        root = xmlDoc.document_element();
         return root;
     }
     if (direction < 0 && root.parent()) {

--- a/src/content/scripting/parser_script.h
+++ b/src/content/scripting/parser_script.h
@@ -73,7 +73,7 @@ protected:
     int currentObjectID { INVALID_OBJECT_ID };
     char* currentLine {};
     std::shared_ptr<GenericTask> currentTask;
-    std::unique_ptr<pugi::xml_document> xmlDoc { std::make_unique<pugi::xml_document>() };
+    pugi::xml_document xmlDoc;
     pugi::xml_node root;
 };
 

--- a/src/content/scripting/playlist_parser_script.cc
+++ b/src/content/scripting/playlist_parser_script.cc
@@ -177,11 +177,11 @@ void PlaylistParserScript::processPlaylistObject(
     if (item->getMimeType() != MIME_TYPE_ASX_PLAYLIST) {
         currentHandle = file.open("r");
     } else {
-        pugi::xml_parse_result result = xmlDoc->load_file(item->getLocation().c_str());
+        pugi::xml_parse_result result = xmlDoc.load_file(item->getLocation().c_str());
         if (result.status != pugi::xml_parse_status::status_ok) {
             throw ConfigParseException(result.description());
         }
-        root = xmlDoc->document_element();
+        root = xmlDoc.document_element();
     }
 
     currentTask = std::move(task);
@@ -210,7 +210,7 @@ void PlaylistParserScript::processPlaylistObject(
 
     delete[] currentLine;
     currentLine = nullptr;
-    xmlDoc->reset();
+    xmlDoc.reset();
     root = nullNode;
 
     currentObjectID = INVALID_OBJECT_ID;

--- a/src/upnp/client_manager.cc
+++ b/src/upnp/client_manager.cc
@@ -253,7 +253,7 @@ void ClientManager::addClientByDiscovery(
     if (!client || (client->pInfo && client->pInfo->matchType == ClientMatchType::None)) {
         auto descXml = downloadDescription(descLocation);
         if (descXml) {
-            pugi::xpath_node rootNode = descXml->document_element();
+            pugi::xpath_node rootNode = descXml.document_element();
             if (rootNode.node() && std::string(rootNode.node().name()) == "root") {
                 pugi::xpath_node deviceNode = rootNode.node().select_node("device");
                 if (deviceNode && deviceNode.node()) {
@@ -399,9 +399,9 @@ const ClientObservation* ClientManager::updateCache(
     return &(*it);
 }
 
-std::unique_ptr<pugi::xml_document> ClientManager::downloadDescription(const std::string& location)
+pugi::xml_document ClientManager::downloadDescription(const std::string& location)
 {
-    auto xml = std::make_unique<pugi::xml_document>();
+    pugi::xml_document xml;
 #if defined(USING_NPUPNP)
     std::string description, ct;
     int errCode = UpnpDownloadUrlItem(location, description, ct);
@@ -409,7 +409,7 @@ std::unique_ptr<pugi::xml_document> ClientManager::downloadDescription(const std
         log_debug("Error obtaining client description from {} -- error = {}", location, errCode);
         return xml;
     }
-    auto ret = xml->load_string(description.c_str());
+    auto ret = xml.load_string(description.c_str());
 #else
     IXML_Document* descDoc = nullptr;
     int errCode = UpnpDownloadXmlDoc(location.c_str(), &descDoc);
@@ -419,7 +419,7 @@ std::unique_ptr<pugi::xml_document> ClientManager::downloadDescription(const std
     }
 
     DOMString cxml = ixmlPrintDocument(descDoc);
-    auto ret = xml->load_string(cxml);
+    auto ret = xml.load_string(cxml);
 
     ixmlFreeDOMString(cxml);
     ixmlDocument_free(descDoc);

--- a/src/upnp/client_manager.h
+++ b/src/upnp/client_manager.h
@@ -31,6 +31,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <pugixml.hpp>
 #include <vector>
 
@@ -85,7 +86,7 @@ private:
         const std::shared_ptr<Headers>& headers,
         const ClientProfile* pInfo) const;
 
-    static std::unique_ptr<pugi::xml_document> downloadDescription(const std::string& location);
+    static pugi::xml_document downloadDescription(const std::string& location);
 
     mutable std::mutex mutex;
     using AutoLock = std::scoped_lock<std::mutex>;

--- a/src/upnp/conn_mgr_service.cc
+++ b/src/upnp/conn_mgr_service.cc
@@ -64,7 +64,7 @@ void ConnectionManagerService::doGetCurrentConnectionIDs(ActionRequest& request)
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     root.append_child("ConnectionID").append_child(pugi::node_pcdata).set_value("0");
 
     request.setResponse(std::move(response));
@@ -88,7 +88,7 @@ void ConnectionManagerService::doGetProtocolInfo(ActionRequest& request) const
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CM_SERVICE_TYPE);
     auto csv = mimeTypesToCsv(database->getMimeTypes());
-    auto root = response->document_element();
+    auto root = response.document_element();
 
     root.append_child("Source").append_child(pugi::node_pcdata).set_value(csv.c_str());
     root.append_child("Sink").append_child(pugi::node_pcdata).set_value("");
@@ -103,13 +103,13 @@ bool ConnectionManagerService::processSubscriptionRequest(const SubscriptionRequ
 {
     auto csv = mimeTypesToCsv(database->getMimeTypes());
     auto propset = xmlBuilder->createEventPropertySet();
-    auto property = propset->document_element().first_child();
+    auto property = propset.document_element().first_child();
 
     property.append_child("CurrentConnectionIDs").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("SinkProtocolInfo").append_child(pugi::node_pcdata).set_value("");
     property.append_child("SourceProtocolInfo").append_child(pugi::node_pcdata).set_value(csv.c_str());
 
-    std::string xml = UpnpXMLBuilder::printXml(*propset, "", 0);
+    std::string xml = UpnpXMLBuilder::printXml(propset, "", 0);
 
     return UPNP_E_SUCCESS == GrbUpnpAcceptSubscription( //
                deviceHandle, config->getOption(ConfigVal::SERVER_UDN), //
@@ -119,10 +119,10 @@ bool ConnectionManagerService::processSubscriptionRequest(const SubscriptionRequ
 bool ConnectionManagerService::sendSubscriptionUpdate(const std::string& sourceProtocolCsv)
 {
     auto propset = xmlBuilder->createEventPropertySet();
-    auto property = propset->document_element().first_child();
+    auto property = propset.document_element().first_child();
     property.append_child("SourceProtocolInfo").append_child(pugi::node_pcdata).set_value(sourceProtocolCsv.c_str());
 
-    std::string xml = UpnpXMLBuilder::printXml(*propset, "", 0);
+    std::string xml = UpnpXMLBuilder::printXml(propset, "", 0);
     return UPNP_E_SUCCESS == GrbUpnpNotify( //
                deviceHandle, //
                config->getOption(ConfigVal::SERVER_UDN), serviceID, xml);

--- a/src/upnp/cont_dir_service.cc
+++ b/src/upnp/cont_dir_service.cc
@@ -83,7 +83,7 @@ void ContentDirectoryService::doBrowse(ActionRequest& request)
     log_debug("start");
 
     auto req = request.getRequest();
-    auto reqRoot = req->document_element();
+    auto reqRoot = req.document_element();
 
 #ifdef GRBDEBUG
     if (GrbLogger::Logger.isDebugging(GRB_LOG_FAC))
@@ -184,7 +184,7 @@ void ContentDirectoryService::doBrowse(ActionRequest& request)
     log_debug("didl {}", didlLiteXml);
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    auto respRoot = response->document_element();
+    auto respRoot = response.document_element();
     respRoot.append_child("Result").append_child(pugi::node_pcdata).set_value(didlLiteXml.c_str());
     respRoot.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(arr.size()).c_str());
     respRoot.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(param.getTotalMatches()).c_str());
@@ -199,7 +199,7 @@ void ContentDirectoryService::doSearch(ActionRequest& request)
     log_debug("start");
 
     auto req = request.getRequest();
-    auto reqRoot = req->document_element();
+    auto reqRoot = req.document_element();
 
 #ifdef GRBDEBUG
     if (GrbLogger::Logger.isDebugging(GRB_LOG_FAC))
@@ -292,7 +292,7 @@ void ContentDirectoryService::doSearch(ActionRequest& request)
     log_debug("didl {}", didlLiteXml);
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    auto respRoot = response->document_element();
+    auto respRoot = response.document_element();
     respRoot.append_child("Result").append_child(pugi::node_pcdata).set_value(didlLiteXml.c_str());
     respRoot.append_child("NumberReturned").append_child(pugi::node_pcdata).set_value(fmt::to_string(results.size()).c_str());
     respRoot.append_child("TotalMatches").append_child(pugi::node_pcdata).set_value(fmt::to_string(searchParam.getTotalMatches()).c_str());
@@ -336,7 +336,7 @@ void ContentDirectoryService::doGetSearchCapabilities(ActionRequest& request) co
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     root.append_child("SearchCaps").append_child(pugi::node_pcdata).set_value(SQLDatabase::getSearchCapabilities().c_str());
     request.setResponse(std::move(response));
 
@@ -348,7 +348,7 @@ void ContentDirectoryService::doGetSortCapabilities(ActionRequest& request) cons
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     root.append_child("SortCaps").append_child(pugi::node_pcdata).set_value(SQLDatabase::getSortCapabilities().c_str());
     request.setResponse(std::move(response));
 
@@ -360,7 +360,7 @@ void ContentDirectoryService::doGetFeatureList(ActionRequest& request) const
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     pugi::xml_document respRoot;
     auto features = respRoot.append_child("Features");
     features.append_attribute("xmlns") = "urn:schemas-upnp-org:av:avs";
@@ -380,7 +380,7 @@ void ContentDirectoryService::doGetSortExtensionCapabilities(ActionRequest& requ
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     root.append_child("SortExtensionCaps").append_child(pugi::node_pcdata).set_value("+,-"); // TIME+, TIME-
     request.setResponse(std::move(response));
 
@@ -392,7 +392,7 @@ void ContentDirectoryService::doGetSystemUpdateID(ActionRequest& request) const
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     root.append_child("Id").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     request.setResponse(std::move(response));
 
@@ -440,13 +440,13 @@ bool ContentDirectoryService::processSubscriptionRequest(const SubscriptionReque
     log_debug("start");
 
     auto propset = xmlBuilder->createEventPropertySet();
-    auto property = propset->document_element().first_child();
+    auto property = propset.document_element().first_child();
     property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
     auto obj = database->loadObject(DEFAULT_CLIENT_GROUP, 0);
     auto cont = std::static_pointer_cast<CdsContainer>(obj);
     property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(fmt::format("0,{}", cont->getUpdateID()).c_str());
 
-    std::string xml = UpnpXMLBuilder::printXml(*propset, "", 0);
+    std::string xml = UpnpXMLBuilder::printXml(propset, "", 0);
 
     return UPNP_E_SUCCESS == GrbUpnpAcceptSubscription( //
                deviceHandle, config->getOption(ConfigVal::SERVER_UDN), //
@@ -460,11 +460,11 @@ bool ContentDirectoryService::sendSubscriptionUpdate(const std::string& containe
     systemUpdateID++;
 
     auto propset = xmlBuilder->createEventPropertySet();
-    auto property = propset->document_element().first_child();
+    auto property = propset.document_element().first_child();
     property.append_child("ContainerUpdateIDs").append_child(pugi::node_pcdata).set_value(containerUpdateIDsCsv.c_str());
     property.append_child("SystemUpdateID").append_child(pugi::node_pcdata).set_value(fmt::to_string(systemUpdateID).c_str());
 
-    std::string xml = UpnpXMLBuilder::printXml(*propset, "", 0);
+    std::string xml = UpnpXMLBuilder::printXml(propset, "", 0);
     return UPNP_E_SUCCESS == GrbUpnpNotify( //
                deviceHandle, config->getOption(ConfigVal::SERVER_UDN), //
                serviceID, xml);

--- a/src/upnp/mr_reg_service.cc
+++ b/src/upnp/mr_reg_service.cc
@@ -60,7 +60,7 @@ void MRRegistrarService::doIsAuthorized(ActionRequest& request) const
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 
     request.setResponse(std::move(response));
@@ -83,7 +83,7 @@ void MRRegistrarService::doIsValidated(ActionRequest& request) const
     log_debug("start");
 
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_MRREG_SERVICE_TYPE);
-    auto root = response->document_element();
+    auto root = response.document_element();
     root.append_child("Result").append_child(pugi::node_pcdata).set_value("1");
 
     request.setResponse(std::move(response));
@@ -95,13 +95,13 @@ void MRRegistrarService::doIsValidated(ActionRequest& request) const
 bool MRRegistrarService::processSubscriptionRequest(const SubscriptionRequest& request)
 {
     auto propset = xmlBuilder->createEventPropertySet();
-    auto property = propset->document_element().first_child();
+    auto property = propset.document_element().first_child();
     property.append_child("ValidationRevokedUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("ValidationSucceededUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("AuthorizationDeniedUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("AuthorizationGrantedUpdateID").append_child(pugi::node_pcdata).set_value("0");
 
-    std::string xml = UpnpXMLBuilder::printXml(*propset, "", 0);
+    std::string xml = UpnpXMLBuilder::printXml(propset, "", 0);
 
     return UPNP_E_SUCCESS == GrbUpnpAcceptSubscription( //
                deviceHandle, config->getOption(ConfigVal::SERVER_UDN), //
@@ -111,14 +111,14 @@ bool MRRegistrarService::processSubscriptionRequest(const SubscriptionRequest& r
 bool MRRegistrarService::sendSubscriptionUpdate(const std::string& sourceProtocolCsv)
 {
     auto propset = xmlBuilder->createEventPropertySet();
-    auto property = propset->document_element().first_child();
+    auto property = propset.document_element().first_child();
     property.append_child("ValidationRevokedUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("ValidationSucceededUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("AuthorizationDeniedUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("AuthorizationGrantedUpdateID").append_child(pugi::node_pcdata).set_value("0");
     property.append_child("SourceProtocolInfo").append_child(pugi::node_pcdata).set_value(sourceProtocolCsv.c_str());
 
-    std::string xml = UpnpXMLBuilder::printXml(*propset, "", 0);
+    std::string xml = UpnpXMLBuilder::printXml(propset, "", 0);
     return UPNP_E_SUCCESS == GrbUpnpNotify( //
                deviceHandle, config->getOption(ConfigVal::SERVER_UDN), //
                serviceID, xml);

--- a/src/upnp/quirks.cc
+++ b/src/upnp/quirks.cc
@@ -140,7 +140,7 @@ void Quirks::getSamsungFeatureList(ActionRequest& request) const
         container.append_attribute("type") = type;
     }
 
-    response->document_element().append_child("FeatureList").append_child(pugi::node_pcdata).set_value(UpnpXMLBuilder::printXml(respRoot, "", 0).c_str());
+    response.document_element().append_child("FeatureList").append_child(pugi::node_pcdata).set_value(UpnpXMLBuilder::printXml(respRoot, "", 0).c_str());
     request.setResponse(std::move(response));
 }
 
@@ -271,7 +271,7 @@ void Quirks::getSamsungObjectIDfromIndex(ActionRequest& request) const
     log_debug("Call for Samsung extension: X_GetObjectIDfromIndex");
 
     auto doc = request.getRequest();
-    auto reqRoot = doc->document_element();
+    auto reqRoot = doc.document_element();
     if (reqRoot) {
         log_debug("request {}", UpnpXMLBuilder::printXml(reqRoot, " "));
 
@@ -283,7 +283,7 @@ void Quirks::getSamsungObjectIDfromIndex(ActionRequest& request) const
         log_warning("X_GetObjectIDfromIndex called without correct content");
     }
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    response->document_element().append_child("ObjectID").append_child(pugi::node_pcdata).set_value("0");
+    response.document_element().append_child("ObjectID").append_child(pugi::node_pcdata).set_value("0");
     request.setResponse(std::move(response));
 }
 
@@ -296,7 +296,7 @@ void Quirks::getSamsungIndexfromRID(ActionRequest& request) const
 
     log_debug("Call for Samsung extension: X_GetIndexfromRID");
     auto doc = request.getRequest();
-    auto reqRoot = doc->document_element();
+    auto reqRoot = doc.document_element();
     if (reqRoot) {
         log_debug("request {}", UpnpXMLBuilder::printXml(reqRoot, " "));
 
@@ -308,7 +308,7 @@ void Quirks::getSamsungIndexfromRID(ActionRequest& request) const
         log_warning("X_GetIndexfromRID called without correct content");
     }
     auto response = xmlBuilder->createResponse(request.getActionName(), UPNP_DESC_CDS_SERVICE_TYPE);
-    response->document_element().append_child("Index").append_child(pugi::node_pcdata).set_value("0");
+    response.document_element().append_child("Index").append_child(pugi::node_pcdata).set_value("0");
     request.setResponse(std::move(response));
 }
 
@@ -338,7 +338,7 @@ void Quirks::saveSamsungBookMarkedPosition(const std::shared_ptr<Database>& data
     } else {
         auto divider = hasFlag(QUIRK_FLAG_SAMSUNG_BOOKMARK_MSEC) ? 1 : 1000;
         auto doc = request.getRequest();
-        auto reqRoot = doc->document_element();
+        auto reqRoot = doc.document_element();
         if (reqRoot) {
             log_debug("request {}", UpnpXMLBuilder::printXml(reqRoot, " "));
 

--- a/src/upnp/xml_builder.cc
+++ b/src/upnp/xml_builder.cc
@@ -137,10 +137,10 @@ UpnpXMLBuilder::UpnpXMLBuilder(
     containerPropertyDefaults = config->getDictionaryOption(ConfigVal::UPNP_CONTAINER_PROPERTY_DEFAULTS);
 }
 
-std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createResponse(const std::string& actionName, const std::string& serviceType) const
+pugi::xml_document UpnpXMLBuilder::createResponse(const std::string& actionName, const std::string& serviceType) const
 {
-    auto response = std::make_unique<pugi::xml_document>();
-    auto root = response->append_child(fmt::format("u:{}Response", actionName).c_str());
+    pugi::xml_document response;
+    auto root = response.append_child(fmt::format("u:{}Response", actionName).c_str());
     root.append_attribute("xmlns:u") = serviceType.c_str();
 
     return response;
@@ -506,11 +506,11 @@ void UpnpXMLBuilder::renderObject(
     log_debug("Rendered DIDL: {}", printXml(result, "  "));
 }
 
-std::unique_ptr<pugi::xml_document> UpnpXMLBuilder::createEventPropertySet() const
+pugi::xml_document UpnpXMLBuilder::createEventPropertySet() const
 {
-    auto doc = std::make_unique<pugi::xml_document>();
+    pugi::xml_document doc;
 
-    auto propset = doc->append_child("e:propertyset");
+    auto propset = doc.append_child("e:propertyset");
     propset.append_attribute("xmlns:e") = "urn:schemas-upnp-org:event-1-0";
 
     propset.append_child("e:property");

--- a/src/upnp/xml_builder.h
+++ b/src/upnp/xml_builder.h
@@ -39,6 +39,7 @@
 #include <deque>
 #include <map>
 #include <memory>
+#include <optional>
 #include <pugixml.hpp>
 #include <vector>
 
@@ -71,7 +72,7 @@ public:
     /// \<u:actionNameResponse xmlns:u="serviceType"/\>
     /// Further response information (various parameters, DIDL-Lite or
     /// whatever can then be adapted to it.
-    std::unique_ptr<pugi::xml_document> createResponse(const std::string& actionName, const std::string& serviceType) const;
+    pugi::xml_document createResponse(const std::string& actionName, const std::string& serviceType) const;
 
     /// @brief Renders the DIDL-Lite representation of an object in the content directory.
     /// @param obj Object to be rendered as XML.
@@ -91,7 +92,7 @@ public:
 
     /// @brief Renders XML for the event property set.
     /// @return pugi::xml_document representing the newly created XML.
-    std::unique_ptr<pugi::xml_document> createEventPropertySet() const;
+    pugi::xml_document createEventPropertySet() const;
 
     /// @brief Renders a resource tag (part of DIDL-Lite XML)
     /// @param obj Object containing this resource

--- a/test/core/test_upnp_xml.cc
+++ b/test/core/test_upnp_xml.cc
@@ -399,7 +399,7 @@ TEST_F(UpnpXmlTest, RenderObjectItemWithResourcesWithQuirks)
 TEST_F(UpnpXmlTest, CreatesEventPropertySet)
 {
     auto result = subject->createEventPropertySet();
-    auto root = result->document_element();
+    auto root = result.document_element();
 
     EXPECT_NE(root, nullptr);
     EXPECT_STREQ(root.name(), "e:propertyset");
@@ -415,7 +415,7 @@ TEST_F(UpnpXmlTest, CreateResponse)
     auto result = subject->createResponse(actionName, serviceType);
     EXPECT_NE(result, nullptr);
 
-    auto root = result->document_element();
+    auto root = result.document_element();
     EXPECT_STREQ(root.name(), "u:actionResponse");
     EXPECT_STREQ(root.attribute("xmlns:u").value(), "urn:schemas-upnp-org:service:ContentDirectory:1");
 }


### PR DESCRIPTION
The main advantage of unique_ptr is forward decleration of types and dynamic allocation of non trivial types. Not the case with pugi's xml types.

In cases where it's never NULL, remove both. No need.