### PR TITLE
clang-tidy: add implicit headers

### DIFF
--- a/src/cds/cds_container.h
+++ b/src/cds/cds_container.h
@@ -33,6 +33,12 @@ Gerbera - https://gerbera.io/
 #include "cds_objects.h"
 #include "upnp/upnp_common.h"
 
+#include <memory>
+#include <string>
+
+enum class AutoscanType;
+enum class MetadataFields;
+
 /// @brief A container in the content directory.
 class CdsContainer final : public CdsObject {
 protected:

--- a/src/cds/cds_item.h
+++ b/src/cds/cds_item.h
@@ -32,6 +32,9 @@ Gerbera - https://gerbera.io/
 
 #include "cds_objects.h"
 
+#include <memory>
+#include <string>
+
 class ClientStatusDetail;
 
 /// @brief An Item in the content directory.

--- a/src/cds/cds_objects.h
+++ b/src/cds/cds_objects.h
@@ -40,9 +40,18 @@
 #include "util/grb_fs.h"
 
 #include <algorithm>
+#include <chrono>
 #include <map>
 #include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
+
+enum class ContentHandler;
+enum class ObjectType;
+enum class ResourceAttribute;
+enum class ResourcePurpose;
 
 /// @brief Generic object in the Content Directory.
 class CdsObject {

--- a/src/cds/cds_resource.h
+++ b/src/cds/cds_resource.h
@@ -39,6 +39,8 @@
 
 #include <map>
 #include <memory>
+#include <string>
+#include <string_view>
 
 #define RESOURCE_OPTION_FOURCC "4cc"
 

--- a/src/config/config_definition.h
+++ b/src/config/config_definition.h
@@ -33,6 +33,10 @@
 
 #include <fmt/format.h>
 
+#include <memory>
+#include <string>
+#include <vector>
+
 #define CONFIG_XML_VERSION 2
 
 // default values

--- a/src/config/config_int_types.h
+++ b/src/config/config_int_types.h
@@ -26,7 +26,7 @@
 #ifndef __CONFIG_INT_TYPES_H__
 #define __CONFIG_INT_TYPES_H__
 
-#include <cinttypes>
+#include <cstdint>
 
 using IntOptionType = std::int32_t;
 using UIntOptionType = std::uint32_t;

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -37,9 +37,10 @@
 
 #include "config.h"
 
+#include "config_int_types.h"
+
 #include <map>
 #include <memory>
-#include <netinet/in.h>
 
 namespace pugi {
 class xml_document;

--- a/src/config/config_options.h
+++ b/src/config/config_options.h
@@ -38,6 +38,7 @@
 #include <fmt/format.h>
 #include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "config_int_types.h"

--- a/src/config/config_setup.h
+++ b/src/config/config_setup.h
@@ -32,6 +32,9 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 namespace pugi {

--- a/src/config/grb_runtime.h
+++ b/src/config/grb_runtime.h
@@ -31,7 +31,10 @@ Gerbera - https://gerbera.io/
 #include <fmt/core.h>
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
+
+#include <sys/types.h>
 
 class Config;
 class ConfigDefinition;

--- a/src/config/result/autoscan.h
+++ b/src/config/result/autoscan.h
@@ -40,8 +40,13 @@
 #include "upnp/upnp_common.h"
 #include "util/timer.h"
 
-#include <mutex>
+#include <chrono>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
 #include <string_view>
+#include <utility>
 
 // forward declarations
 class CdsContainer;

--- a/src/config/result/box_layout.h
+++ b/src/config/result/box_layout.h
@@ -32,10 +32,12 @@
 #include "edit_helper.h"
 #include "upnp/upnp_common.h"
 
+#include <cstddef>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
+#include <string_view>
+#include <utility>
 #include <vector>
 
 // forward declarations

--- a/src/config/result/client_config.h
+++ b/src/config/result/client_config.h
@@ -29,9 +29,12 @@
 
 #include "edit_helper.h"
 #include "upnp/clients.h"
+#include "upnp/quirks.h"
 
 #include <map>
-#include <mutex>
+#include <memory>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/src/config/result/directory_tweak.h
+++ b/src/config/result/directory_tweak.h
@@ -31,8 +31,6 @@
 #include "util/grb_fs.h"
 
 #include <map>
-#include <mutex>
-#include <vector>
 
 // forward declaration
 class AutoscanDirectory;

--- a/src/config/result/dynamic_content.h
+++ b/src/config/result/dynamic_content.h
@@ -30,10 +30,6 @@
 #include "edit_helper.h"
 #include "util/grb_fs.h"
 
-#include <map>
-#include <mutex>
-#include <vector>
-
 // forward declarations
 class Config;
 class DynamicContent;

--- a/src/config/result/transcoding.h
+++ b/src/config/result/transcoding.h
@@ -35,7 +35,7 @@
 #ifndef __TRANSCODING_H__
 #define __TRANSCODING_H__
 
-#include "cds/cds_resource.h"
+#include "cds/cds_enums.h"
 #include "common.h"
 #include "metadata/metadata_enums.h"
 #include "upnp/quirks.h"

--- a/src/config/setup/config_setup_array.h
+++ b/src/config/setup/config_setup_array.h
@@ -30,6 +30,10 @@
 #include "config/config_setup.h"
 #include "config/config_val.h"
 
+class ArrayOption;
+class Config;
+class ConfigOption;
+
 using ArrayInitFunction = std::function<bool(const pugi::xml_node& value, std::vector<std::string>& result, const char* node_name)>;
 using ArrayItemCheckFunction = std::function<bool(const std::string& value)>;
 

--- a/src/config/setup/config_setup_autoscan.h
+++ b/src/config/setup/config_setup_autoscan.h
@@ -31,6 +31,8 @@
 
 class AutoscanDirectory;
 class AutoscanList;
+class Config;
+class ConfigOption;
 enum class AutoscanScanMode;
 
 class ConfigAutoscanSetup : public ConfigSetup {

--- a/src/config/setup/config_setup_bool.h
+++ b/src/config/setup/config_setup_bool.h
@@ -29,6 +29,9 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
+
 class ConfigBoolSetup : public ConfigSetup {
     using ConfigSetup::ConfigSetup;
 

--- a/src/config/setup/config_setup_boxlayout.cc
+++ b/src/config/setup/config_setup_boxlayout.cc
@@ -43,6 +43,18 @@
 #include <algorithm>
 #include <numeric>
 
+ConfigBoxLayoutSetup::ConfigBoxLayoutSetup(
+    ConfigVal option,
+    const char* xpath,
+    const char* help,
+    std::vector<BoxLayout> defaultEntries)
+    : ConfigSetup(option, xpath, help)
+    , defaultEntries(std::move(defaultEntries))
+{
+}
+
+ConfigBoxLayoutSetup::~ConfigBoxLayoutSetup() = default;
+
 /// @brief Creates an array of BoxLayout objects from a XML nodeset.
 /// @param element starting element of the nodeset.
 bool ConfigBoxLayoutSetup::createOptionFromNode(

--- a/src/config/setup/config_setup_boxlayout.h
+++ b/src/config/setup/config_setup_boxlayout.h
@@ -32,6 +32,8 @@
 class BoxChain;
 class BoxLayout;
 class BoxLayoutList;
+class Config;
+class ConfigOption;
 
 /// @brief Class for BoxLayout config parser
 class ConfigBoxLayoutSetup : public ConfigSetup {
@@ -52,11 +54,8 @@ public:
         ConfigVal option,
         const char* xpath,
         const char* help,
-        std::vector<BoxLayout> defaultEntries)
-        : ConfigSetup(option, xpath, help)
-        , defaultEntries(std::move(defaultEntries))
-    {
-    }
+        std::vector<BoxLayout> defaultEntries);
+    ~ConfigBoxLayoutSetup() override;
 
     /// @brief Update Option from Web UI or Database
     bool updateItem(

--- a/src/config/setup/config_setup_client.h
+++ b/src/config/setup/config_setup_client.h
@@ -30,7 +30,10 @@
 #include "config/config_setup.h"
 
 class ClientConfig;
+class ClientConfigList;
 class ClientGroupConfig;
+class Config;
+class ConfigOption;
 
 class ConfigClientSetup : public ConfigSetup {
     using ConfigSetup::ConfigSetup;

--- a/src/config/setup/config_setup_dictionary.h
+++ b/src/config/setup/config_setup_dictionary.h
@@ -29,6 +29,10 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
+class DictionaryOption;
+
 using DictionaryInitFunction = std::function<bool(const pugi::xml_node& value, std::map<std::string, std::string>& result)>;
 
 /// @brief Configuration parser to load dictionaries

--- a/src/config/setup/config_setup_dynamic.h
+++ b/src/config/setup/config_setup_dynamic.h
@@ -29,7 +29,10 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
 class DynamicContent;
+class DynamicContentList;
 
 /// @brief Setup of dynamic content reader
 class ConfigDynamicContentSetup : public ConfigSetup {

--- a/src/config/setup/config_setup_enum.h
+++ b/src/config/setup/config_setup_enum.h
@@ -32,6 +32,9 @@
 
 #include <pugixml.hpp>
 
+class Config;
+class ConfigOption;
+
 template <class En>
 class ConfigEnumSetup : public ConfigSetup {
 protected:

--- a/src/config/setup/config_setup_int.h
+++ b/src/config/setup/config_setup_int.h
@@ -29,6 +29,12 @@
 
 #include "config/config_setup.h" // API
 
+#include "config/config_int_types.h"
+#include "config/config_options.h"
+
+class Config;
+class ConfigOption;
+
 template <typename T, class OptionClass>
 class ConfigIntegerSetup : public ConfigSetup {
     static_assert(std::is_integral_v<T>, "Integral required.");

--- a/src/config/setup/config_setup_path.h
+++ b/src/config/setup/config_setup_path.h
@@ -29,6 +29,9 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
+
 enum class ConfigPathArguments {
     none = 0,
     /// @brief isFile file or directory

--- a/src/config/setup/config_setup_string.h
+++ b/src/config/setup/config_setup_string.h
@@ -29,6 +29,9 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
+
 class ConfigStringSetup : public ConfigSetup {
 protected:
     bool notEmpty = false;

--- a/src/config/setup/config_setup_time.h
+++ b/src/config/setup/config_setup_time.h
@@ -29,7 +29,12 @@
 
 #include "config/config_setup.h"
 
+#include "config/config_int_types.h"
+
 #include "util/grb_time.h"
+
+class Config;
+class ConfigOption;
 
 class ConfigTimeSetup : public ConfigSetup {
 protected:

--- a/src/config/setup/config_setup_transcoding.h
+++ b/src/config/setup/config_setup_transcoding.h
@@ -29,6 +29,10 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
+class TranscodingProfileList;
+
 class ConfigTranscodingSetup : public ConfigSetup {
     using ConfigSetup::ConfigSetup;
 

--- a/src/config/setup/config_setup_tweak.h
+++ b/src/config/setup/config_setup_tweak.h
@@ -29,6 +29,9 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
+class DirectoryConfigList;
 class DirectoryTweak;
 
 class ConfigDirectorySetup : public ConfigSetup {

--- a/src/config/setup/config_setup_vector.h
+++ b/src/config/setup/config_setup_vector.h
@@ -29,6 +29,10 @@
 
 #include "config/config_setup.h"
 
+class Config;
+class ConfigOption;
+class VectorOption;
+
 class ConfigVectorSetup : public ConfigSetup {
 protected:
     bool notEmpty = false;

--- a/src/content/content.h
+++ b/src/content/content.h
@@ -38,6 +38,7 @@ class GenericTask;
 class CdsContainer;
 class CdsObject;
 class Context;
+class Executor;
 class ScriptingRuntime;
 enum class TaskOwner;
 

--- a/src/content/content_manager.h
+++ b/src/content/content_manager.h
@@ -39,7 +39,6 @@
 
 #include <map>
 #include <memory>
-#include <unordered_set>
 #include <vector>
 
 // forward declarations
@@ -57,14 +56,17 @@ enum class OnlineServiceType;
 
 class AutoscanList;
 class CdsItem;
+class Config;
 class ConverterManager;
 class CMAddFileTask;
+class Database;
 class GenericTask;
 class ImportService;
 class LastFm;
 class Mime;
 class Server;
 class TaskProcessor;
+class Timer;
 class UpdateManager;
 enum class AutoscanScanMode;
 namespace Web {

--- a/src/content/inotify/scripting_inotify.cc
+++ b/src/content/inotify/scripting_inotify.cc
@@ -36,6 +36,8 @@
 #include "content/scripting/scripting_runtime.h"
 #include "context.h"
 
+#include <algorithm>
+
 template void InotifyManager<PathWatch>::run();
 
 ScriptingInotify::ScriptingInotify(

--- a/src/content/onlineservice/task_processor.cc
+++ b/src/content/onlineservice/task_processor.cc
@@ -40,6 +40,8 @@
 #include "exceptions.h"
 #include "online_service.h"
 
+#include <algorithm>
+
 TaskProcessor::TaskProcessor(std::shared_ptr<Config> config)
     : config(std::move(config))
 {

--- a/src/content/scripting/import_script.h
+++ b/src/content/scripting/import_script.h
@@ -37,6 +37,7 @@
 #include "common.h"
 #include "script.h"
 
+#include <map>
 #include <memory>
 
 // forward declaration

--- a/src/content/scripting/metafile_parser_script.h
+++ b/src/content/scripting/metafile_parser_script.h
@@ -36,6 +36,8 @@
 
 #include "parser_script.h"
 
+class CdsItem;
+
 class MetafileParserScript : public ParserScript {
 public:
     MetafileParserScript(const std::shared_ptr<Content>& content, const std::string& parent);

--- a/src/content/scripting/playlist_parser_script.h
+++ b/src/content/scripting/playlist_parser_script.h
@@ -36,6 +36,9 @@
 
 #include "parser_script.h"
 
+class CdsContainer;
+class CdsItem;
+
 class PlaylistParserScript : public ParserScript {
 public:
     PlaylistParserScript(const std::shared_ptr<Content>& content, const std::string& parent);

--- a/src/content/scripting/script.h
+++ b/src/content/scripting/script.h
@@ -37,9 +37,7 @@
 #include "util/grb_fs.h"
 
 #include <duktape.h>
-#include <map>
 #include <memory>
-#include <mutex>
 #include <vector>
 
 // forward declaration

--- a/src/database/postgres/postgres_database.h
+++ b/src/database/postgres/postgres_database.h
@@ -28,10 +28,13 @@
 #include "util/thread_runner.h"
 #include "util/timer.h"
 
-#include <mutex>
 #include <pqxx/pqxx>
 #include <queue>
 
+class Config;
+class ConverterManager;
+class Database;
+class Mime;
 class PostgresSQLResult;
 class PostgresSQLRow;
 class PGTask;

--- a/src/database/search_handler.h
+++ b/src/database/search_handler.h
@@ -36,7 +36,6 @@
 #include <map>
 #include <memory>
 #include <tuple>
-#include <unordered_map>
 #include <vector>
 
 #define UPNP_SEARCH_ID "@id"

--- a/src/database/sqlite3/sqlite_database.h
+++ b/src/database/sqlite3/sqlite_database.h
@@ -39,9 +39,15 @@
 #include "util/thread_runner.h"
 #include "util/timer.h"
 
+#include <cstddef>
 #include <mutex>
 #include <queue>
 
+class Config;
+class ConverterManager;
+class Database;
+class GrbFile;
+class Mime;
 class Sqlite3Database;
 class Sqlite3Result;
 class SLTask;
@@ -112,7 +118,7 @@ private:
     mutable std::mutex del_mutex;
     using DelAutoLock = std::scoped_lock<std::mutex>;
     mutable std::vector<std::string> deletedEntries;
-    size_t maxDeleteCount { DELETE_CACHE_MAX_SIZE };
+    std::size_t maxDeleteCount { DELETE_CACHE_MAX_SIZE };
     std::chrono::seconds lastDelete;
 
     void threadCleanup() override { }

--- a/src/exceptions.h
+++ b/src/exceptions.h
@@ -34,6 +34,7 @@
 #ifndef __EXCEPTIONS_H__
 #define __EXCEPTIONS_H__
 
+#include <cerrno>
 #include <fmt/core.h>
 #include <stdexcept>
 #include <string>

--- a/src/iohandler/buffered_io_handler.h
+++ b/src/iohandler/buffered_io_handler.h
@@ -39,6 +39,8 @@
 #include <memory>
 #include <upnp.h>
 
+class IOHandler;
+
 /// @brief a IOHandler with buffer support
 /// the buffer is only for read(). write() is not supported
 /// the public functions of this class are *not* thread safe!

--- a/src/iohandler/file_io_handler.h
+++ b/src/iohandler/file_io_handler.h
@@ -38,6 +38,8 @@
 #include "io_handler.h"
 #include "util/grb_fs.h"
 
+#include <sys/types.h>
+
 /// @brief Allows the web server to read from a file.
 class FileIOHandler : public IOHandler {
 protected:

--- a/src/iohandler/io_handler.h
+++ b/src/iohandler/io_handler.h
@@ -39,6 +39,8 @@
 #include <cstdint>
 #include <upnp.h>
 
+#include <sys/types.h>
+
 using grb_read_t = std::int32_t;
 static constexpr grb_read_t CHECK_SOCKET = -666;
 

--- a/src/iohandler/io_handler_buffer_helper.h
+++ b/src/iohandler/io_handler_buffer_helper.h
@@ -38,6 +38,7 @@
 
 #include "util/thread_runner.h"
 
+#include <sys/types.h>
 #include <upnp.h>
 
 class Config;

--- a/src/iohandler/io_handler_chainer.h
+++ b/src/iohandler/io_handler_chainer.h
@@ -44,6 +44,9 @@
 
 #include "util/thread_executor.h"
 
+#include <cstddef>
+#include <memory>
+
 /// @brief gets two IOHandler, starts a thread which reads from one IOHandler
 /// and writes the data to the other IOHandler
 class IOHandlerChainer : public ThreadExecutor {

--- a/src/iohandler/mem_io_handler.h
+++ b/src/iohandler/mem_io_handler.h
@@ -38,6 +38,8 @@
 
 #include <string>
 
+#include <sys/types.h>
+
 /// @brief Allows the web server to read from a memory buffer instead of a file.
 class MemIOHandler : public IOHandler {
 protected:

--- a/src/iohandler/process_io_handler.cc
+++ b/src/iohandler/process_io_handler.cc
@@ -37,6 +37,7 @@
 #include "content/content.h"
 #include "exceptions.h"
 
+#include <algorithm>
 #include <csignal>
 #include <utility>
 

--- a/src/iohandler/process_io_handler.h
+++ b/src/iohandler/process_io_handler.h
@@ -38,6 +38,11 @@
 #include "util/executor.h"
 #include "util/grb_fs.h"
 
+#include <cstddef>
+#include <vector>
+
+#include <sys/types.h>
+
 // forward declaration
 class Content;
 

--- a/src/metadata/metacontent_handler.h
+++ b/src/metadata/metacontent_handler.h
@@ -27,8 +27,6 @@
 #ifndef __METADATA_CONTENT_H__
 #define __METADATA_CONTENT_H__
 
-#include <map>
-
 #include "config/config.h"
 #include "metadata_handler.h"
 

--- a/src/metadata/metadata_enums.h
+++ b/src/metadata/metadata_enums.h
@@ -39,6 +39,8 @@
 #include "util/enum_iterator.h"
 
 #include <map>
+#include <string>
+#include <utility>
 
 #define CONTENT_TYPE_AIFF "aiff"
 #define CONTENT_TYPE_APE "ape"

--- a/src/metadata/metadata_service.h
+++ b/src/metadata/metadata_service.h
@@ -27,6 +27,8 @@ Gerbera - https://gerbera.io/
 #include "util/grb_fs.h"
 
 #include <map>
+#include <memory>
+#include <string>
 
 // forward declaration
 class CdsItem;

--- a/src/request_handler/request_handler.h
+++ b/src/request_handler/request_handler.h
@@ -37,7 +37,6 @@
 #include <map>
 #include <memory>
 #include <upnp.h>
-#include <vector>
 
 // forward declaration
 class CdsObject;

--- a/src/server.h
+++ b/src/server.h
@@ -35,10 +35,12 @@
 #define __SERVER_H__
 
 #include <memory>
-#include <netinet/in.h>
 #include <string>
-#include <upnp.h>
 #include <vector>
+
+#include <netinet/in.h>
+#include <sys/types.h>
+#include <upnp.h>
 
 // forward declarations
 class ActionRequest;

--- a/src/upnp/headers.h
+++ b/src/upnp/headers.h
@@ -27,9 +27,8 @@
 #define GERBERA_HEADERS_H
 
 #include <map>
-#include <memory>
+#include <string>
 #include <upnp.h>
-#include <vector>
 
 /// @brief Utility class for HTTP headers in UPnP requests
 class Headers {

--- a/src/upnp/quirks.h
+++ b/src/upnp/quirks.h
@@ -26,7 +26,7 @@
 #ifndef __UPNP_QUIRKS_H__
 #define __UPNP_QUIRKS_H__
 
-#include <cinttypes>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <vector>

--- a/src/util/logger.h
+++ b/src/util/logger.h
@@ -34,14 +34,16 @@
 #ifndef __LOGGER_H__
 #define __LOGGER_H__
 
-#include <array>
 #include <fmt/format.h>
 #if FMT_VERSION >= 100202
 #include <fmt/ranges.h>
 #endif
-#include <map>
 #include <spdlog/spdlog.h>
 #include <type_traits>
+
+#ifdef GRBDEBUG
+#include <map>
+#endif
 
 #define log_debug SPDLOG_TRACE
 #define log_vdebug(...) (void)0

--- a/src/util/mime.h
+++ b/src/util/mime.h
@@ -27,11 +27,11 @@
 #define __MIME_H__
 
 #include <map>
-#include <mutex>
 
 #include "util/grb_fs.h"
 
 #ifdef HAVE_MAGIC
+#include <mutex>
 // for older versions of filemagic
 extern "C" {
 #include <magic.h>

--- a/src/util/process_executor.h
+++ b/src/util/process_executor.h
@@ -35,7 +35,6 @@
 #define __PROCESS_EXECUTOR_H__
 
 #include <map>
-#include <memory>
 #include <vector>
 
 #include <unistd.h>

--- a/src/util/timer.cc
+++ b/src/util/timer.cc
@@ -36,6 +36,8 @@
 #include "exceptions.h"
 #include "util/logger.h"
 
+#include <algorithm>
+
 void Timer::run()
 {
     log_debug("Starting Timer thread...");

--- a/src/util/timer.h
+++ b/src/util/timer.h
@@ -37,9 +37,10 @@
 #include "grb_time.h"
 #include "thread_runner.h"
 
-#include <algorithm>
 #include <atomic>
 #include <memory>
+
+class Config;
 
 /// @brief Class implementing time driven actions
 class Timer {

--- a/src/util/tools.cc
+++ b/src/util/tools.cc
@@ -38,6 +38,7 @@
 #include "util/logger.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <numeric>
 #include <queue>
 #include <regex>

--- a/src/util/tools.h
+++ b/src/util/tools.h
@@ -34,9 +34,8 @@
 #define __TOOLS_H__
 
 #include <algorithm>
-#include <cinttypes>
+#include <cstdint>
 #include <map>
-#include <optional>
 #include <string>
 #include <vector>
 

--- a/src/web/page_request.h
+++ b/src/web/page_request.h
@@ -30,13 +30,11 @@
 
 #include "util/grb_fs.h"
 
-#include <chrono>
-#include <vector>
-
 // forward declarations
 class AutoscanDirectory;
 class CdsItemExternalURL;
 class CdsItem;
+class CdsObject;
 class Config;
 class ConfigDefinition;
 class ConfigSetup;

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -45,12 +45,17 @@
 class AutoscanDirectory;
 class CdsItemExternalURL;
 class CdsItem;
+class CdsObject;
 class Config;
 class ConfigDefinition;
 class ConfigSetup;
 class ConfigValue;
+class Content;
+class Context;
 class ConverterManager;
 class Database;
+class Quirks;
+class Server;
 class UpnpXMLBuilder;
 enum class ConfigVal;
 


### PR DESCRIPTION
Found with misc-include-cleaner