### PR TITLE
remove unique_ptr from xml_document

### DIFF
--- a/src/config/config_manager.cc
+++ b/src/config/config_manager.cc
@@ -67,7 +67,6 @@ ConfigManager::ConfigManager(
     : definition(std::move(definition))
     , filename(std::move(filename))
     , dataDir(std::move(dataDir))
-    , xmlDoc(std::make_unique<pugi::xml_document>())
 {
     options = std::vector<std::shared_ptr<ConfigOption>>(to_underlying(ConfigVal::MAX));
     GrbLogger::Logger.setDebugLogging(debug);
@@ -138,14 +137,14 @@ void ConfigManager::load(const fs::path& userHome)
     auto self = getSelf();
 
     log_info("Loading configuration from: {}", filename.string());
-    pugi::xml_parse_result result = xmlDoc->load_file(filename.c_str());
+    pugi::xml_parse_result result = xmlDoc.load_file(filename.c_str());
     if (result.status != pugi::xml_parse_status::status_ok) {
         throw ConfigParseException(result.description());
     }
 
     log_info("Parsing configuration...");
 
-    auto root = xmlDoc->document_element();
+    auto root = xmlDoc.document_element();
 
     getAllNodes(root, false);
 
@@ -379,11 +378,11 @@ void ConfigManager::load(const fs::path& userHome)
     log_info("Configuration load succeeded.");
 
     std::ostringstream buf;
-    xmlDoc->print(buf, "  ");
+    xmlDoc.print(buf, "  ");
     log_debug("Config file dump after loading: {}", buf.str());
 
     // now the XML is no longer needed we can destroy it
-    xmlDoc = nullptr;
+    xmlDoc.reset();
 }
 
 /// @brief Validate that correlated options have correct values

--- a/src/config/config_manager.h
+++ b/src/config/config_manager.h
@@ -39,11 +39,7 @@
 
 #include <map>
 #include <memory>
-
-namespace pugi {
-class xml_document;
-class xml_node;
-} // namespace pugi
+#include <pugixml.hpp>
 
 // forward declaration
 class AutoscanDirectory;
@@ -167,7 +163,7 @@ protected:
     fs::path dataDir;
     fs::path magicFile;
     std::map<std::string, std::string> origValues;
-    std::unique_ptr<pugi::xml_document> xmlDoc;
+    pugi::xml_document xmlDoc;
     std::vector<std::shared_ptr<ConfigOption>> options;
     std::map<std::string, bool> knownNodes;
 

--- a/src/content/scripting/metafile_parser_script.cc
+++ b/src/content/scripting/metafile_parser_script.cc
@@ -64,9 +64,9 @@ void MetafileParserScript::processObject(const std::shared_ptr<CdsObject>& obj, 
 
     log_debug("Checking metafile {} for {}...", path.string(), obj->getLocation().string());
     GrbFile file(path);
-    pugi::xml_parse_result result = xmlDoc->load_file(path.c_str());
+    pugi::xml_parse_result result = xmlDoc.load_file(path.c_str());
     if (result.status == pugi::xml_parse_status::status_ok) {
-        root = xmlDoc->document_element();
+        root = xmlDoc.document_element();
     }
     currentHandle = file.open("r");
     processed = obj;
@@ -95,7 +95,7 @@ void MetafileParserScript::processObject(const std::shared_ptr<CdsObject>& obj, 
 
     delete[] currentLine;
     currentLine = nullptr;
-    xmlDoc->reset();
+    xmlDoc.reset();
     root = nullNode;
 
     currentObjectID = INVALID_OBJECT_ID;

--- a/src/content/scripting/parser_script.cc
+++ b/src/content/scripting/parser_script.cc
@@ -199,7 +199,7 @@ pugi::xml_node& ParserScript::readXml(int direction)
         return root;
     }
     if (direction < -1 && root.root()) {
-        root = xmlDoc->document_element();
+        root = xmlDoc.document_element();
         return root;
     }
     if (direction < 0 && root.parent()) {

--- a/src/content/scripting/parser_script.h
+++ b/src/content/scripting/parser_script.h
@@ -73,7 +73,7 @@ protected:
     int currentObjectID { INVALID_OBJECT_ID };
     char* currentLine {};
     std::shared_ptr<GenericTask> currentTask;
-    std::unique_ptr<pugi::xml_document> xmlDoc { std::make_unique<pugi::xml_document>() };
+    pugi::xml_document xmlDoc;
     pugi::xml_node root;
 };
 

--- a/src/content/scripting/playlist_parser_script.cc
+++ b/src/content/scripting/playlist_parser_script.cc
@@ -177,11 +177,11 @@ void PlaylistParserScript::processPlaylistObject(
     if (item->getMimeType() != MIME_TYPE_ASX_PLAYLIST) {
         currentHandle = file.open("r");
     } else {
-        pugi::xml_parse_result result = xmlDoc->load_file(item->getLocation().c_str());
+        pugi::xml_parse_result result = xmlDoc.load_file(item->getLocation().c_str());
         if (result.status != pugi::xml_parse_status::status_ok) {
             throw ConfigParseException(result.description());
         }
-        root = xmlDoc->document_element();
+        root = xmlDoc.document_element();
     }
 
     currentTask = std::move(task);
@@ -210,7 +210,7 @@ void PlaylistParserScript::processPlaylistObject(
 
     delete[] currentLine;
     currentLine = nullptr;
-    xmlDoc->reset();
+    xmlDoc.reset();
     root = nullNode;
 
     currentObjectID = INVALID_OBJECT_ID;


### PR DESCRIPTION
The main advantage of unique_ptr is forward decleration of types and dynamic allocation of non trivial types. Not the case with pugi's xml types.

In cases where it's never NULL, remove both. No need.