### PR TITLE
samsung bookmark save/restore

### DIFF
--- a/src/upnp/quirks.h
+++ b/src/upnp/quirks.h
@@ -100,13 +100,13 @@ public:
      *
      * @param item CdsItem which will be played and stores the bookmark information.
      * @param result Answer content.
-     * @param offset number of seconds to jump
+     * @param offsetSecond number of seconds to jump back
      *
      */
     void restoreSamsungBookMarkedPosition(
         const std::shared_ptr<CdsItem>& item,
         pugi::xml_node& result,
-        int offset = 10) const;
+        int offsetSecond) const;
 
     /** @brief Stored bookmark information into the database
      *


### PR DESCRIPTION
On a Samsung Q TV the save bookmark to jump to the very end when restoring. When looking at the code it looks very wrong. Its no symmetrical and converts the wrong way. Also the `offset` applied was in seconds where the `bookMarkPos` is in milliseconds.

Facts
- Old Samsung TVs provide and expect position in seconds
- Newer Samsung TVs (starting with Q) provide and expect position in milliseconds
- internally with `playStatus->setBookMarkPosition` the position is expect in milliseconds

Math:
- save
  - playStatus = (Old in sec  * 1000)
  - playStatus = New in msec
- restore
  - Old in sec =  playStatus / 1000
  - New in msec = playStatus

With this its working on a Samsung Q TV and should work on older Samsung TVs as well.