### PR TITLE
cope with su-exec breaking change

### DIFF
--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -95,7 +95,7 @@ fi
 if [[ "$3" =~ "^gerbera " || "$1" == "gerbera" ]]; then
   if [ "$(id -u)" -eq '0' ]; then
     echo "Root DEF"
-    if ! (command su-exec 2>&1) > /dev/null
+    if ! (command su-exec $IMAGE_USER /bin/true 2>&1) > /dev/null
     then
         sudo touch /var/run/gerbera/run.sh
         sudo chown $IMAGE_USER:$IMAGE_GROUP /var/run/gerbera/run.sh


### PR DESCRIPTION
Should fix #3756 

Works fine with this compose file (fails if `user:` is missing). 
```
services:
  gerbera:
    image: gerbera-mig
    container_name: gerbera
    network_mode: host
    user: gerbera
    volumes:
      - ./gerbera-config-3:/var/run/gerbera
      - /data/multimedia/sea750:/mnt/content:ro

volumes:
  gerbera-config:
    external: false
```

Now all files, including the database, are properly stored in `./gerbera-config-3`.

Other notes:
- image user ID (1042 default) needs to have read access to files on host -- I `chown`ed them, but there might be a better option
- for some reason, log says `gerbera  | 2026-01-18 10:07:09   info: Loading configuration from: /run/gerbera/config.xml`. I was expecting `/var/run/...`