### PR TITLE
Update to pupnp 1.14.27

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@
 - Load Config file modules
 - Show changed items in UI
 - Update npupnp to 6.2.3
-- Update to pupnp 1.14.26
+- Update to pupnp 1.14.27
 
 ### v3.1.1
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ sudo make install
 
 | Library             | Min Version  | Recommended  | Latest tested        | Required?     | Note                             | Default  |
 |---------------------|--------------|--------------|----------------------|---------------|----------------------------------|----------|
-| [libupnp]           | 1.14.6       | 1.14.20      | 1.14.26              | XOR libnpupnp | UPnP protocol support            |          |
+| [libupnp]           | 1.14.6       | 1.14.20      | 1.14.27              | XOR libnpupnp | UPnP protocol support            |          |
 | [libnpupnp]         | 4.2.1        | 5.1.2        | 6.2.3                | XOR libupnp   | Alternate UPnP protocol support  | Disabled |
 | libuuid             |              |              |                      | Depends on OS | Not required on \*BSD            |          |
 | [pugixml]           |              | 1.10         | 1.15                 | Required      | XML file and data support        |          |

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -9,7 +9,7 @@
 
 ### Code Improvements
 
-- Update maximum versions of npupnp (6.2.3), cmake (4.2.2), pupnp (1.14.26)
+- Update maximum versions of npupnp (6.2.3), cmake (4.2.2), pupnp (1.14.27)
 
 ## v3.1.1
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -79,7 +79,7 @@ else
     MATROSKA="1.7.1"
     NPUPNP="6.2.3"
     PUGIXML="1.15"
-    PUPNP="1.14.26"
+    PUPNP="1.14.27"
     SPDLOG="1.17.0"
     WAVPACK="5.9.0"
     TAGLIB="2.1.1"


### PR DESCRIPTION
Since this includes an upstream fix for the OmniOS build, should I remove the patch for 1.14.26?