### PR TITLE
Fix SQLDatabase::getRefObjects SQL on MySQL/MariaDB

### DIFF
--- a/src/database/sql_database.cc
+++ b/src/database/sql_database.cc
@@ -2082,7 +2082,7 @@ std::vector<int> SQLDatabase::getRefObjects(
     int objectId,
     CdsEntryType entryType)
 {
-    auto getSql = fmt::format("SELECT {}, {} FROM {} WHERE {} AND {} == {}",
+    auto getSql = fmt::format("SELECT {}, {} FROM {} WHERE {} AND {} = {}",
         browseColumnMapper->mapQuoted(BrowseColumn::Id, true),
         browseColumnMapper->mapQuoted(BrowseColumn::LastUpdated, true),
         browseColumnMapper->getTableName(),


### PR DESCRIPTION
"==" for comparison is not allowed in MariaDB's SQL. Introduced with commit 567e19fcae7b14c1179cf9c1e6e06152fdedd70e
> Add support for cuesheets

Resolves: https://github.com/gerbera/gerbera/issues/3864