### PR TITLE
add `req_type=sync`: full recursive reconcile of a single directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,7 @@ add_library(
     src/web/remove.cc
     src/web/session_manager.cc
     src/web/session_manager.h
+    src/web/sync.cc
     src/web/tasks.cc
     src/web/web_autoscan.cc
     src/web/web_request_handler.cc

--- a/src/web/pages.h
+++ b/src/web/pages.h
@@ -176,6 +176,18 @@ protected:
     bool processPageAction(Json::Value& element, const std::string& action) override;
 };
 
+/// @brief Call from WebUi to rescan a directory tracked by autoscan
+class Sync : public PageRequest {
+    using PageRequest::PageRequest;
+
+public:
+    const static std::string_view PAGE;
+    std::string_view getPage() const override { return PAGE; }
+
+protected:
+    bool processPageAction(Json::Value& element, const std::string& action) override;
+};
+
 /// @brief Call from WebUi to Remove item in database view
 class Remove : public PageRequest {
     using PageRequest::PageRequest;

--- a/src/web/sync.cc
+++ b/src/web/sync.cc
@@ -29,7 +29,9 @@
 
 #include "common.h"
 #include "cds/cds_objects.h"
+#include "config/config_val.h"
 #include "config/result/autoscan.h"
+#include "content/autoscan_setting.h"
 #include "content/content.h"
 #include "database/database.h"
 #include "exceptions.h"
@@ -64,9 +66,20 @@ bool Web::Sync::processPageAction(Json::Value& element, const std::string& actio
         content->rescanDirectory(adir, adir->getObjectID(), path, true);
     } else {
         auto container = database->findObjectByPath(path, UNUSED_CLIENT_GROUP, DbFileType::Directory);
-        if (!container || !container->isContainer())
-            throw_std_runtime_error("Path {} is not a container in the database", path.string());
-        content->rescanDirectory(adir, container->getID(), path, true);
+        if (container && container->isContainer()) {
+            content->rescanDirectory(adir, container->getID(), path, true);
+        } else {
+            // tracked path not scanned yet: import just this subtree,
+            // mirroring the addSubDirectory branch of a running rescan
+            AutoScanSetting asSetting;
+            asSetting.adir = adir;
+            asSetting.recursive = adir->getRecursive();
+            asSetting.followSymlinks = adir->getFollowSymlinks();
+            asSetting.hidden = adir->getHidden();
+            asSetting.rescanResource = false;
+            asSetting.mergeOptions(config, path);
+            content->addFile(dirEnt, adir->getLocation(), asSetting, true, false);
+        }
     }
     return true;
 }

--- a/src/web/sync.cc
+++ b/src/web/sync.cc
@@ -1,0 +1,72 @@
+/*GRB*
+
+    Gerbera - https://gerbera.io/
+
+    web/sync.cc - this file is part of Gerbera.
+
+    Copyright (C) 2026 Gerbera Contributors
+
+    Gerbera is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License version 2
+    as published by the Free Software Foundation.
+
+    Gerbera is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    version 2 along with Gerbera; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+    $Id$
+*/
+
+/// @file web/sync.cc
+#define GRB_LOG_FAC GrbLogFacility::web
+
+#include "pages.h" // API
+
+#include "common.h"
+#include "cds/cds_objects.h"
+#include "config/result/autoscan.h"
+#include "content/content.h"
+#include "database/database.h"
+#include "exceptions.h"
+#include "util/tools.h"
+
+const std::string_view Web::Sync::PAGE = "sync";
+
+bool Web::Sync::processPageAction(Json::Value& element, const std::string& action)
+{
+    std::string objID = param("object_id");
+    auto path = fs::path((objID == "0") ? FS_ROOT_DIRECTORY : hexDecodeString(objID));
+    if (path.empty())
+        throw_std_runtime_error("Illegal empty path");
+
+    std::error_code ec;
+    auto dirEnt = fs::directory_entry(path, ec);
+    if (ec || !dirEnt.is_directory(ec))
+        throw_std_runtime_error("Failed to read {}: {}", path.string(), ec ? ec.message() : "not a directory");
+
+    // prefer the autoscan machinery when the path is tracked
+    auto adir = content->getAutoscanDirectory(path);
+    if (!adir) {
+        for (auto&& dir : content->getAutoscanDirectories()) {
+            if (dir && dir->getRecursive() && isSubDir(path, dir->getLocation()))
+                adir = dir;
+        }
+    }
+    if (!adir)
+        throw_std_runtime_error("sync called with untracked path {}", path.string());
+
+    if (adir->getLocation() == path) {
+        content->rescanDirectory(adir, adir->getObjectID(), path, true);
+    } else {
+        auto container = database->findObjectByPath(path, UNUSED_CLIENT_GROUP, DbFileType::Directory);
+        if (!container || !container->isContainer())
+            throw_std_runtime_error("Path {} is not a container in the database", path.string());
+        content->rescanDirectory(adir, container->getID(), path, true);
+    }
+    return true;
+}

--- a/src/web/web_request_handler.cc
+++ b/src/web/web_request_handler.cc
@@ -213,6 +213,8 @@ std::unique_ptr<WebRequestHandler> createWebRequestHandler(
 {
     if (page == Web::Add::PAGE)
         return std::make_unique<Web::Add>(content, server, xmlBuilder, quirks);
+    if (page == Web::Sync::PAGE)
+        return std::make_unique<Web::Sync>(content, server, xmlBuilder, quirks);
     if (page == Web::Remove::PAGE)
         return std::make_unique<Web::Remove>(content, server, xmlBuilder, quirks);
     if (page == Web::AddObject::PAGE)


### PR DESCRIPTION
API only changes adding a `req_type=sync`. This is a draft intended to demonstrate a possible backend component of #3921. (I'm not sure what the web-ui would look like.)

Today, triggering a scan of a manual/timed autoscan always walks the entire scan root — the UI's "Scan Now" only accepts the root, and the only narrower mechanism is inotify, which holds a watch that can keep a disk from spinning down.

This adds a `sync` page that rescans an arbitrary subdirectory of a tracked scan. The rescan task starts its directory walk at the requested path's own container, so only that subtree is read from disk.

Usage (same hex-path convention as req_type=add): `content/interface?req_type=sync&sid=...&object_id=<hex-encoded-path>`

- scan root → rescan from its own object id (a scheduled tick, now)
- subdir of a recursive manual/timed scan → rescan only that subtree
- subdir not yet scanned (e.g. added to disk since the last full scan, or the scan never ran) → import just that subtree with the scan's settings; missing parent containers are created as empty scaffolding
- path outside any autoscan → rejected; untracked imports stay with req_type=add (we'd need to have a scanning policy etc that makes this more complicated)

No autoscan entries, timers, or inotify watches are created or modified.